### PR TITLE
subsys: net: lib: nrf_cloud: Add temperature sensor type

### DIFF
--- a/include/nrf_cloud.h
+++ b/include/nrf_cloud.h
@@ -59,6 +59,8 @@ enum nrf_cloud_sensor {
 	NRF_CLOUD_SENSOR_GPS,
 	/** The FLIP movement sensor on the device. */
 	NRF_CLOUD_SENSOR_FLIP,
+	/** The TEMP sensor on the device. */
+	NRF_CLOUD_SENSOR_TEMP,
 };
 
 /** @brief User input sequence values for user association type

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_codec.c
@@ -45,6 +45,7 @@ static void encode_ua_button_sequence(const struct nrf_cloud_data *sequence,
 static const char * const sensor_type_str[] = {
 	[NRF_CLOUD_SENSOR_GPS] = "GPS",
 	[NRF_CLOUD_SENSOR_FLIP] = "FLIP",
+	[NRF_CLOUD_SENSOR_TEMP] = "TEMP",
 };
 
 static const struct ua_encode_info ua_encode_info[] = {


### PR DESCRIPTION
This patch adds temperature sensor type (TEMP) to nrf_cloud lib.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>