### PR TITLE
samples: peripheral_uart: handle heavy dataload gracefully

### DIFF
--- a/samples/bluetooth/peripheral_uart/src/main.c
+++ b/samples/bluetooth/peripheral_uart/src/main.c
@@ -105,7 +105,15 @@ static void uart_cb(struct device *uart)
 			if (rx) {
 				rx->len = 0;
 			} else {
+				char dummy;
+
 				printk("Not able to allocate UART receive buffer\n");
+
+				/* Drop one byte to avoid spinning in a
+				 * eternal loop.
+				 */
+				uart_fifo_read(uart, &dummy, 1);
+
 				return;
 			}
 		}


### PR DESCRIPTION
Drop bytes when not able to handle all incomming uart bytes
to avoid spinning in an eternal loop

Signed-off-by: Even Falch-Larsen <even.falch-larsen@nordicsemi.no>