### PR TITLE
subsys: bootloader: Add assert to memeq_32.

### DIFF
--- a/subsys/bootloader/include/fw_metadata.h
+++ b/subsys/bootloader/include/fw_metadata.h
@@ -23,16 +23,19 @@
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <toolchain.h>
+#include <assert.h>
 
 #define MAGIC_LEN_WORDS (CONFIG_SB_MAGIC_LEN / sizeof(u32_t))
 
 struct __packed fw_firmware_info {
 	u32_t magic[MAGIC_LEN_WORDS];
 	u32_t firmware_size;      /* Size without validation_info pointer and
-							   * padding. */
-	u32_t firmware_version;   /* Monotonically increasing version counter.*/
-	u32_t firmware_address;   /* The address of the start (vector table) of
-							   * the firmware. */
+				   * padding.
+				   */
+	u32_t firmware_version; /* Monotonically increasing version counter.*/
+	u32_t firmware_address; /* The address of the start (vector table) of
+				 * the firmware.
+				 */
 };
 
 struct __packed fw_validation_info {
@@ -45,12 +48,14 @@ struct __packed fw_validation_info {
 	/* The hash of the firmware.*/
 	u8_t  firmware_hash[CONFIG_SB_HASH_LEN];
 
-	/* Public key to be used for signature verification. This must be checked
-	 * against a trusted hash. */
+	/* Public key to be used for signature verification.
+	 * This must be checked against a trusted hash.
+	 */
 	u8_t  public_key[CONFIG_SB_PUBLIC_KEY_LEN];
 
-	/* Signature over the firmware as represented by the firmware_address and
-	 * firmware_size in the firmware_info. */
+	/* Signature over the firmware as represented by the
+	 * firmware_address and firmware_size in the firmware_info.
+	 */
 	u8_t  signature[CONFIG_SB_SIGNATURE_LEN];
 };
 
@@ -60,7 +65,7 @@ struct __packed fw_validation_info {
  * it needs no version.
  */
 struct fw_validation_pointer {
-	u32_t                          magic[MAGIC_LEN_WORDS];
+	u32_t magic[MAGIC_LEN_WORDS];
 	const struct fw_validation_info *validation_info;
 };
 
@@ -71,10 +76,8 @@ static inline bool memeq_32(const void *expected, const void *actual,
 	u32_t *expected_32 = (u32_t *) expected;
 	u32_t *actual_32   = (u32_t *) actual;
 
-	/* ASSERT(!(len & 3)); */ /* len is a multiple of 4 */
-	if (len % sizeof(u32_t) != 0) {
-		return false;
-	}
+	__ASSERT(!(len & 3), "Length is not multiple of 4");
+
 	for (u32_t i = 0; i < (len / sizeof(u32_t)); i++) {
 		if (expected_32[i] != actual_32[i]) {
 			return false;


### PR DESCRIPTION
Use assert to validate input address.
Also contains some formatting to make the code sub 80 chars width.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>