### PR TITLE
samples: nrf9160: lte_ble_gateway: LEDs on start

### DIFF
--- a/samples/nrf9160/lte_ble_gateway/src/main.c
+++ b/samples/nrf9160/lte_ble_gateway/src/main.c
@@ -509,7 +509,8 @@ static void modem_configure(void)
 	} else {
 		int err;
 
-		printk("LTE LC config ...\n");
+		printk("Establishing LTE link (this may take some time) ...\n");
+		display_state = LEDS_CONNECTING;
 		err = lte_lc_init_and_connect();
 		__ASSERT(err == 0, "LTE link could not be established.");
 	}


### PR DESCRIPTION
A small fix to make the LEDs show the connecting
status when you turn on the kit.
This to make the connecting experience more similar
to the asset_tracker sample.

Signed-off-by: Martin Lesund <martin.lesund@nordicsemi.no>