### PR TITLE
subsys: bootloader: cmake: Allow using OpenSSL CLI for private key actions

### DIFF
--- a/doc/nrf/ug_bootloader.rst
+++ b/doc/nrf/ug_bootloader.rst
@@ -88,7 +88,7 @@ Complete the following steps to add a secure bootloader chain to your applicatio
 1. Create a private key in PEM format.
    To do so, run the following command, which stores your private key in a file name ``priv.pem`` in the current folder::
 
-       openssl genpkey -algorithm EC -pkeyopt ec_paramgen_curve:P-256 -pkeyopt ec_param_enc:named_curve -out priv.pem
+       openssl ecparam -name prime256v1 -genkey -noout -out priv.pem
 
    OpenSSL is installed with GIT, so it should be available in your GIT bash.
    See `openSSL`_ for more information.
@@ -107,6 +107,11 @@ Complete the following steps to add a secure bootloader chain to your applicatio
 
       There are additional configuration options that you can modify, but it is not recommended to do so.
       The default settings are suitable for most use cases.
+
+   .. note::
+      If you need more flexibility with signing, or you don't want the build system to handle your private key, choose CONFIG_SB_SIGNING_CUSTOM.
+      When choosing CONFIG_SB_SIGNING_CUSTOM, you must also specify CONFIG_SB_SIGNING_COMMAND and CONFIG_SB_SIGNING_PUBLIC_KEY.
+
    #. Click **Configure**.
 
 #. Select **Build** > **Build Solution** to compile your application.

--- a/scripts/bootloader/asn1parse.py
+++ b/scripts/bootloader/asn1parse.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2018 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+
+
+from subprocess import Popen, PIPE, STDOUT, check_output
+import re
+import sys
+import argparse
+import ecdsa
+
+
+def leftpad(s, length):
+    return b'\0' * (length - len(s)) + s
+
+
+def get_ecdsa_signature(der, clength):
+    # The der consists of a SEQUENCE with 2 INTEGERS (r and s)
+    # The expected byte format of the file is
+    #  0:        type(SEQ), len(SEQ)
+    #  2:        type(INT), len(r)
+    #  4:        r
+    #  4+len(r): type(INT), len(s)
+    #  6+len(r): s
+    # Note that sometimes r or s is too short and must be
+    # left-padded with zeros, or they might even be one byte too long with a
+    # leading 0 byte.
+    # clength is the expected length of r and s.
+    # The following code parses the output of openssl asnparse which prints
+    # the values in hex, together with human-readble metadata.
+
+    stdout = check_output(["openssl", "asn1parse", "-inform", "der"], input=der)
+    sig = b"".join([leftpad(bytes.fromhex(re.search(r"(?<=\:)([0-9A-F]+)", num)[0]), clength) \
+                    for num in re.findall(r"INTEGER *\:[0-9A-F]+", stdout.decode())])
+
+    assert(len(sig) == 2*clength)
+    return sig
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Decode DER format using OpenSSL.",
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+
+    parser.add_argument("-a", "--alg", required=True, choices=["rsa", "ecdsa"],
+                        help="Expected algorithm")
+    parser.add_argument("-c", "--contents", required=True, choices=["signature"],
+                        help="Expected contents")
+    parser.add_argument("-i", "--in", "-in", required=False, dest="infile",
+                        type=argparse.FileType('rb'), default=sys.stdin.buffer,
+                        help="Parse the contents of the specified file instead of stdin.")
+
+    args = parser.parse_args()
+
+    return args
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    assert(args.alg == "ecdsa")  # Only ecdsa is currently supported.
+    if args.alg == "ecdsa":
+        if args.contents == "signature":
+            sys.stdout.buffer.write(get_ecdsa_signature(args.infile.read(), 32))

--- a/scripts/bootloader/asn1parse.py
+++ b/scripts/bootloader/asn1parse.py
@@ -12,10 +12,6 @@ import argparse
 import ecdsa
 
 
-def leftpad(s, length):
-    return b'\0' * (length - len(s)) + s
-
-
 def get_ecdsa_signature(der, clength):
     # The der consists of a SEQUENCE with 2 INTEGERS (r and s)
     # The expected byte format of the file is
@@ -32,7 +28,7 @@ def get_ecdsa_signature(der, clength):
     # the values in hex, together with human-readble metadata.
 
     stdout = check_output(["openssl", "asn1parse", "-inform", "der"], input=der)
-    sig = b"".join([leftpad(bytes.fromhex(re.search(r"(?<=\:)([0-9A-F]+)", num)[0]), clength) \
+    sig = b"".join([bytes.fromhex(re.search(r"(?<=\:)([0-9A-F]+)", num)[0]).ljust(clength, b'\0') \
                     for num in re.findall(r"INTEGER *\:[0-9A-F]+", stdout.decode())])
 
     assert(len(sig) == 2*clength)

--- a/scripts/bootloader/do_sign.py
+++ b/scripts/bootloader/do_sign.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2018 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+
+
+import sys
+import os
+import argparse
+import hashlib
+from ecdsa import SigningKey
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Sign data from stdin or file.",
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+
+    parser.add_argument("-k", "--private-key", required=True, type=argparse.FileType('rb'),
+                        help="Private key to use.")
+    parser.add_argument("-i", "--in", "-in", required=False, dest="infile",
+                        type=argparse.FileType('rb'), default=sys.stdin.buffer,
+                        help="Sign the contents of the specified file instead of stdin.")
+    parser.add_argument("-o", "--out", "-out", required=False, dest="outfile",
+                        type=argparse.FileType('wb'), default=sys.stdout.buffer,
+                        help="Write the signature to the specified file instead of stdout.")
+
+    args = parser.parse_args()
+
+    return args
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    private_key = SigningKey.from_pem(args.private_key.read())
+    data = args.infile.read()
+    signature = private_key.sign(data, hashfunc=hashlib.sha256)
+    args.outfile.write(signature)

--- a/scripts/bootloader/hash.py
+++ b/scripts/bootloader/hash.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2018 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+
+
+import hashlib
+import sys
+import argparse
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Hash data from stdin or file.",
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+
+    parser.add_argument("--infile", "-i", "--in", "-in", required=False,
+                        type=argparse.FileType('rb'), default=sys.stdin.buffer,
+                        help="Hash the contents of the specified file instead of stdin.")
+
+    args = parser.parse_args()
+
+    return args
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    sys.stdout.buffer.write(hashlib.sha256(args.infile.read()).digest())

--- a/scripts/bootloader/provision.py
+++ b/scripts/bootloader/provision.py
@@ -57,8 +57,6 @@ def parse_args():
     parser.add_argument("--generated-conf-file", required=True, help="Generated conf file.")
     parser.add_argument("--public-key-files", required=True,
                         help="Semicolon-separated list of public key .pem files.")
-    parser.add_argument("--signature-private-key-file", required=True,
-                        help="Path to private key PEM file used to generate the signature of the image.")
     parser.add_argument("-o", "--output", required=False, default="provision.hex",
                         help="Output file name.")
     parser.add_argument("-v", "--verbose", required=False, action="count",
@@ -66,11 +64,8 @@ def parse_args():
     return parser.parse_args()
 
 
-def get_hashes(private_signing_key_file, public_key_files):
+def get_hashes(public_key_files):
     hashes = list()
-    with open(private_signing_key_file, 'r') as fn:
-        hashes.append(sha256(SigningKey.from_pem(fn.read()).get_verifying_key().to_string()).digest()[:16])
-        verbose_print("hash: " + hashes[-1].hex())
     for fn in public_key_files:
         verbose_print("Getting hash of %s" % fn)
         with open(fn, 'rb') as f:
@@ -86,7 +81,7 @@ def main():
     VERBOSE = args.verbose
 
     s0_address, s1_address, provision_address = find_provision_memory_section(args.generated_conf_file)
-    hashes = get_hashes(args.signature_private_key_file, args.public_key_files.split(','))
+    hashes = get_hashes(args.public_key_files.split(','))
     generate_provision_hex_file(s0_address=s0_address,
                                 s1_address=s1_address,
                                 hashes=hashes,

--- a/scripts/bootloader/validation_data.py
+++ b/scripts/bootloader/validation_data.py
@@ -10,49 +10,34 @@ from intelhex import IntelHex
 import hashlib
 import argparse
 import struct
-from ecdsa import SigningKey
-from ecdsa.keys import sigencode_string
+import ecdsa
 
 VERBOSE = False
 
 
-def verbose_print(printstr):
+def verbose_print(*printstrs):
     if VERBOSE:
-        print(printstr)
-
-
-def get_signature_bytes(private_key, hash_to_sign):
-    return private_key.sign(hash_to_sign, hashfunc=hashlib.sha256, sigencode=sigencode_string)
-
-
-def get_private_key(pem_file):
-    return SigningKey.from_pem(pem_file.read())
+        print(*printstrs)
 
 
 def get_hash(input_hex):
-    m = hashlib.sha256()
     firmware_bytes = input_hex.tobinstr()
     verbose_print("firmware len: %d (0x%x)" % (len(firmware_bytes), len(firmware_bytes)))
-    m.update(firmware_bytes)
-    return m.digest()
+    return hashlib.sha256(firmware_bytes).digest()
 
 
-def get_public_key_bytes(private_key):
-    return private_key.get_verifying_key().to_string()
-
-
-def get_validation_data(pem_file, input_hex, magic_value, pk_hash_len):
+def get_validation_data(signature_bytes, input_hex, public_key, magic_value, pk_hash_len):
     hash_bytes = get_hash(input_hex)
-    private_key = get_private_key(pem_file)
-    public_key_bytes = get_public_key_bytes(private_key)
+    public_key_bytes = public_key.to_string()
     public_key_hash_bytes = hashlib.sha256(public_key_bytes).digest()[:pk_hash_len]
-    signature_bytes = get_signature_bytes(private_key, hash_bytes)
 
-    verbose_print("magic value (hex): %s" % bytes.hex(magic_value))
-    verbose_print("firmware hash (hex): %s" % bytes.hex(hash_bytes))
-    verbose_print("public key (hex): %s" % bytes.hex(public_key_bytes))
-    verbose_print("truncated public key hash (hex): %s" % bytes.hex(public_key_hash_bytes))
-    verbose_print("signature (hex): %s" % bytes.hex(signature_bytes))
+    verbose_print("magic value (hex) (len: %d): %s" % (len(magic_value), bytes.hex(magic_value)))
+    verbose_print("firmware hash (hex) (len: %d): %s" % (len(hash_bytes), bytes.hex(hash_bytes)))
+    verbose_print("public key (hex) (len: %d): %s" % (len(public_key_bytes), bytes.hex(public_key_bytes)))
+    verbose_print("truncated public key hash (hex) (len: %d): %s" % (len(public_key_hash_bytes), bytes.hex(public_key_hash_bytes)))
+    verbose_print("signature (hex) (len: %d): %s" % (len(signature_bytes), bytes.hex(signature_bytes)))
+
+    verbose_print("signature ok? ", public_key.verify(signature_bytes, hash_bytes, hashfunc=hashlib.sha256))
 
     validation_bytes = magic_value
     validation_bytes += struct.pack('I', input_hex.addresses()[0])
@@ -63,7 +48,7 @@ def get_validation_data(pem_file, input_hex, magic_value, pk_hash_len):
     return validation_bytes
 
 
-def sign_and_append_validation_data(pem_file, input_file, offset, output_file, magic_value, pk_hash_len):
+def sign_and_append_validation_data(signature, input_file, public_key, offset, output_file, magic_value, pk_hash_len):
     ih = IntelHex(input_file)
     ih.start_addr = None  # OBJCOPY incorrectly inserts x86 specific records, remove the start_addr as it is wrong.
 
@@ -75,8 +60,9 @@ def sign_and_append_validation_data(pem_file, input_file, offset, output_file, m
     # in little-endian byte order
     parsed_magic_value = b''.join([struct.pack("<I", int(m, 0)) for m in magic_value.split(",")])
 
-    validation_data = get_validation_data(pem_file=pem_file,
+    validation_data = get_validation_data(signature_bytes=signature,
                                           input_hex=ih,
+                                          public_key=public_key,
                                           magic_value=parsed_magic_value,
                                           pk_hash_len=pk_hash_len)
     validation_data_hex = IntelHex()
@@ -100,8 +86,10 @@ def parse_args():
                         help="Hex file to sign.")
     parser.add_argument("-o", "--offset", required=False, type=int,
                         help="Offset to store validation metadata at.", default=0)
-    parser.add_argument("-p", "--pem", required=True, type=argparse.FileType('r', encoding='UTF-8'),
-                        help="Private key pem file.")
+    parser.add_argument("-s", "--signature", required=True, type=argparse.FileType('rb'),
+                        help="Signature file (DER).")
+    parser.add_argument("-p", "--public-key", required=True, type=argparse.FileType('r', encoding='UTF-8'),
+                        help="Public key file (PEM).")
     parser.add_argument("-m", "--magic-value", required=True,
                         help="ASCII representation of magic value.")
     parser.add_argument("-l", "--pk-hash-len", required=False, type=int, default=-1,
@@ -125,8 +113,9 @@ def main():
     global VERBOSE
     VERBOSE = args.verbose
 
-    sign_and_append_validation_data(pem_file=args.pem,
+    sign_and_append_validation_data(signature=args.signature.read(),
                                     input_file=args.input,
+                                    public_key=ecdsa.VerifyingKey.from_pem(args.public_key.read()),
                                     offset=args.offset,
                                     output_file=args.output,
                                     magic_value=args.magic_value,

--- a/subsys/bootloader/CMakeLists.txt
+++ b/subsys/bootloader/CMakeLists.txt
@@ -168,27 +168,8 @@ list(APPEND to_merge ${PROVISION_HEX})
 set_property(GLOBAL APPEND PROPERTY HEX_FILES_TO_MERGE ${to_merge})
 
 include (${CMAKE_CURRENT_LIST_DIR}/cmake/debug_keys.cmake)
+include (${CMAKE_CURRENT_LIST_DIR}/cmake/sign.cmake)
 
-set(sign_depends kernel_elf ${key_file_depends})
-
-add_custom_command(
-  OUTPUT
-  ${SIGNED_KERNEL_HEX}
-  COMMAND
-  ${PYTHON_EXECUTABLE}
-  ${NRF_BOOTLOADER_SCRIPTS}/sign.py
-  --input ${PROJECT_BINARY_DIR}/${KERNEL_HEX_NAME}
-  --output ${SIGNED_KERNEL_HEX}
-  --offset ${CONFIG_SB_VALIDATION_METADATA_OFFSET}
-  --pem ${signature_private_key_file}
-  --magic-value "${VALIDATION_INFO_MAGIC}"
-  --pk-hash-len ${CONFIG_SB_PUBLIC_KEY_HASH_LEN}
-  DEPENDS ${sign_depends}
-  WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-  COMMENT
-  "Creating validation for ${KERNEL_HEX_NAME}, storing to ${SIGNED_KERNEL_HEX_NAME}"
-  USES_TERMINAL
-  )
 add_custom_target(
   sign_target
   DEPENDS
@@ -203,10 +184,9 @@ add_custom_command(
   ${PYTHON_EXECUTABLE}
   ${NRF_BOOTLOADER_SCRIPTS}/provision.py
   --generated-conf-file ${PROJECT_BINARY_DIR}/include/generated/generated_dts_board.conf
-  --signature-private-key-file "${signature_private_key_file}"
-  --public-key-files "${public_key_files}"
+  --public-key-files "${public_key_file},${PUBLIC_KEY_FILES}"
   --output ${PROVISION_HEX}
-  DEPENDS ${provision_depends}
+  DEPENDS ${PROVISION_DEPENDS}
   WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
   COMMENT
   "Creating provision data for Bootloader, storing to ${PROVISION_HEX_NAME}"

--- a/subsys/bootloader/Kconfig
+++ b/subsys/bootloader/Kconfig
@@ -17,9 +17,32 @@ config CUSTOM_DTS_OVERLAY_CMAKE_FILE
 	# variable is not yet available when this config is used.
 	default "${ZEPHYR_BASE}/../nrf/subsys/bootloader/dts/overlay.cmake"
 
+config SB_PRIVATE_KEY_PROVIDED
+	bool
+	help
+	  Hidden config specifying whether the build system has access to the
+	  private key used for signing, and will use it to perform signing and
+	  create the public key for the provision page.
+
+
+choice SB_SIGNING
+	prompt "Firmware signing method"
+	default SB_SIGNING_PYTHON
+	config SB_SIGNING_PYTHON
+		bool "Sign with Python ecdsa library."
+		select SB_PRIVATE_KEY_PROVIDED
+
+	config SB_SIGNING_OPENSSL
+		bool "Sign with openssl command line tool."
+		select SB_PRIVATE_KEY_PROVIDED
+
+	config SB_SIGNING_CUSTOM
+		bool "Sign with custom command."
+endchoice
 
 config SB_SIGNING_KEY_FILE
-	string "Private key PEM file"
+	string
+	prompt "Private key PEM file" if SB_PRIVATE_KEY_PROVIDED
 	default ""
 	help
 	  Absolute path to the private key PEM file.
@@ -30,6 +53,27 @@ config SB_SIGNING_KEY_FILE
 	  named 'SB_SIGNING_KEY_FILE' or passing
 	  '-DSB_SIGNING_KEY_FILE=/path/to/my/pem' when running cmake.
 	  See also SB_PUBLIC_KEY_FILES.
+
+config SB_SIGNING_COMMAND
+	string
+	prompt "Custom signing command" if !SB_PRIVATE_KEY_PROVIDED
+	default ""
+	help
+	  This command will be called to produce a signature of the firmware.
+	  It will be called as "${CONFIG_SB_SIGNING_COMMAND} <file>"
+	  The command must take calculate the signature over the the contents
+	  of the <file> and write the signature to stdout.
+	  The signature must be on DER format.
+
+config SB_SIGNING_PUBLIC_KEY
+	string
+	prompt "Public key PEM file" if !SB_PRIVATE_KEY_PROVIDED
+	default ""
+	help
+	  Path to a PEM file.
+	  When using a custom signing command, specify the corresponding public
+	  key here. This public key is checked during building, and added to
+	  the provision page as the first entry. See SB_PUBLIC_KEY_FILES.
 
 config SB_PUBLIC_KEY_FILES
 	string "Public Key PEM files"

--- a/subsys/bootloader/cmake/debug_keys.cmake
+++ b/subsys/bootloader/cmake/debug_keys.cmake
@@ -8,9 +8,14 @@ set(DEBUG_SIGN_KEY ${PROJECT_BINARY_DIR}/GENERATED_NON_SECURE_0.pem)
 set(DEBUG_PUBLIC_KEY_0 ${PROJECT_BINARY_DIR}/GENERATED_NON_SECURE_PUBLIC_0.pem)
 set(DEBUG_PUBLIC_KEY_1 ${PROJECT_BINARY_DIR}/GENERATED_NON_SECURE_PUBLIC_1.pem)
 
-set(cmd
+set(privcmd
   ${PYTHON_EXECUTABLE}
-  ${NRF_BOOTLOADER_SCRIPTS}/keygen.py
+  ${NRF_BOOTLOADER_SCRIPTS}/keygen.py --private
+  )
+
+set(pubcmd
+  ${PYTHON_EXECUTABLE}
+  ${NRF_BOOTLOADER_SCRIPTS}/keygen.py --public
   )
 
 add_custom_command(
@@ -19,14 +24,14 @@ add_custom_command(
   ${DEBUG_PUBLIC_KEY_0}
   ${DEBUG_PUBLIC_KEY_1}
   COMMAND
-  ${cmd}
-  --output-private ${DEBUG_SIGN_KEY}
+  ${privcmd}
+  --out ${DEBUG_SIGN_KEY}
   COMMAND
-  ${cmd}
-  --output-public ${DEBUG_PUBLIC_KEY_0}
+  ${pubcmd}
+  --out ${DEBUG_PUBLIC_KEY_0}
   COMMAND
-  ${cmd}
-  --output-public ${DEBUG_PUBLIC_KEY_1}
+  ${pubcmd}
+  --out ${DEBUG_PUBLIC_KEY_1}
   DEPENDS kernel_elf
   WORKING_DIRECTORY ${APPLICATION_BINARY_DIR}
   COMMENT
@@ -41,31 +46,31 @@ if (DEFINED ENV{SB_SIGNING_KEY_FILE} AND NOT SB_SIGNING_KEY_FILE)
   if (NOT EXISTS "$ENV{SB_SIGNING_KEY_FILE}")
     message(FATAL_ERROR "ENV points to non-existing PEM file '$ENV{SB_SIGNING_KEY_FILE}'")
   else()
-    set(signature_private_key_file $ENV{SB_SIGNING_KEY_FILE})
+    set(SIGNATURE_PRIVATE_KEY_FILE $ENV{SB_SIGNING_KEY_FILE})
   endif()
 endif()
 
 # Next, check command line arguments
 if (DEFINED SB_SIGNING_KEY_FILE)
-  set(signature_private_key_file ${SB_SIGNING_KEY_FILE})
+  set(SIGNATURE_PRIVATE_KEY_FILE ${SB_SIGNING_KEY_FILE})
 endif()
 
 # Lastly, check if debug keys should be used.
 if( "${CONFIG_SB_SIGNING_KEY_FILE}" STREQUAL "")
-  set(signature_private_key_file ${DEBUG_SIGN_KEY})
-  set(key_file_depends ${signature_private_key_file})
+  set(SIGNATURE_PRIVATE_KEY_FILE ${DEBUG_SIGN_KEY})
+  set(KEY_FILE_DEPENDS ${SIGNATURE_PRIVATE_KEY_FILE})
 else()
   if (NOT EXISTS "${CONFIG_SB_SIGNING_KEY_FILE}")
     message(FATAL_ERROR "Config points to non-existing PEM file '${CONFIG_SB_SIGNING_KEY_FILE}'")
   endif()
-  set(signature_private_key_file ${CONFIG_SB_SIGNING_KEY_FILE})
+  set(SIGNATURE_PRIVATE_KEY_FILE ${CONFIG_SB_SIGNING_KEY_FILE})
 endif()
 
 if ("${CONFIG_SB_PUBLIC_KEY_FILES}" STREQUAL "")
-  set (public_key_files "${DEBUG_PUBLIC_KEY_0},${DEBUG_PUBLIC_KEY_1}")
-  set (provision_depends  ${DEBUG_PUBLIC_KEY_0} ${DEBUG_PUBLIC_KEY_1})
+  set (PUBLIC_KEY_FILES "${DEBUG_PUBLIC_KEY_0},${DEBUG_PUBLIC_KEY_1}")
+  set (PROVISION_DEPENDS  ${DEBUG_PUBLIC_KEY_0} ${DEBUG_PUBLIC_KEY_1})
 else ()
   # TODO see if we can use some generator expression to avoid using 'kerne_elf' directly.
-  set (public_key_files ${CONFIG_SB_PUBLIC_KEY_FILES})
-  set (provision_depends kernel_elf)
+  set (PUBLIC_KEY_FILES ${CONFIG_SB_PUBLIC_KEY_FILES})
+  set (PROVISION_DEPENDS kernel_elf)
 endif()

--- a/subsys/bootloader/cmake/sign.cmake
+++ b/subsys/bootloader/cmake/sign.cmake
@@ -1,0 +1,99 @@
+#
+# Copyright (c) 2018 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+set(sign_depends kernel_elf ${KEY_FILE_DEPENDS})
+
+set(hash_file firmware.sha256)
+set(signature_file firmware.signature)
+set(public_key_file public.pem)
+
+set(hashcmd
+  ${PYTHON_EXECUTABLE}
+  ${NRF_BOOTLOADER_SCRIPTS}/hash.py --in ${PROJECT_BINARY_DIR}/${KERNEL_BIN_NAME} > ${hash_file}
+  )
+
+if (CONFIG_SB_SIGNING_PYTHON)
+  set(signcmd
+    ${PYTHON_EXECUTABLE}
+    ${NRF_BOOTLOADER_SCRIPTS}/do_sign.py --private-key ${SIGNATURE_PRIVATE_KEY_FILE} --in ${hash_file} > ${signature_file}
+    )
+  set(pubgencmd
+    ${PYTHON_EXECUTABLE}
+    ${NRF_BOOTLOADER_SCRIPTS}/keygen.py --public --in ${SIGNATURE_PRIVATE_KEY_FILE} --out ${public_key_file}
+    )
+elseif (CONFIG_SB_SIGNING_OPENSSL)
+  set(signcmd
+    openssl dgst -sha256 -sign ${SIGNATURE_PRIVATE_KEY_FILE} ${hash_file} |
+    ${PYTHON_EXECUTABLE}
+    ${NRF_BOOTLOADER_SCRIPTS}/asn1parse.py --alg ecdsa --contents signature > ${signature_file}
+    )
+  set(pubgencmd
+    openssl ec -pubout -in ${SIGNATURE_PRIVATE_KEY_FILE} -out ${public_key_file}
+    )
+elseif (CONFIG_SB_SIGNING_CUSTOM)
+  set(signcmd
+    ${CONFIG_SB_SIGNING_COMMAND} ${hash_file} > ${signature_file}
+    )
+  set(public_key_file ${CONFIG_SB_SIGNING_PUBLIC_KEY})
+  if (signcmd STREQUAL "" OR NOT EXISTS ${public_key_file})
+    message(WARNING "You must specify a signing command and valid public key file.")
+  endif()
+else ()
+  message(WARNING "Unable to parse signing config.")
+endif()
+
+add_custom_command(
+  OUTPUT
+  ${signature_file}
+  COMMAND
+  ${hashcmd}
+  COMMAND
+  ${signcmd}
+  DEPENDS
+  ${sign_depends}
+  WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+  COMMENT
+  "Creating signature of application."
+  USES_TERMINAL
+  )
+
+if (CONFIG_SB_PRIVATE_KEY_PROVIDED)
+  add_custom_command(
+    OUTPUT
+    ${public_key_file}
+    COMMAND
+    ${pubgencmd}
+    DEPENDS
+    ${sign_depends}
+    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+    COMMENT
+    "Creating public key."
+    USES_TERMINAL
+    )
+endif()
+
+add_custom_command(
+  OUTPUT
+  ${SIGNED_KERNEL_HEX}
+  COMMAND
+  ${PYTHON_EXECUTABLE}
+  ${NRF_BOOTLOADER_SCRIPTS}/validation_data.py
+  --input ${PROJECT_BINARY_DIR}/${KERNEL_HEX_NAME}
+  --output ${SIGNED_KERNEL_HEX}
+  --offset ${CONFIG_SB_VALIDATION_METADATA_OFFSET}
+  --signature ${signature_file}
+  --public-key ${public_key_file}
+  --magic-value "${VALIDATION_INFO_MAGIC}"
+  --pk-hash-len ${CONFIG_SB_PUBLIC_KEY_HASH_LEN}
+  DEPENDS
+  ${sign_depends}
+  ${signature_file}
+  ${public_key_file}
+  WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+  COMMENT
+  "Creating validation for ${KERNEL_HEX_NAME}, storing to ${SIGNED_KERNEL_HEX_NAME}"
+  USES_TERMINAL
+  )


### PR DESCRIPTION

 - Add a Kconfig to choose between Python (ECDSA), OpenSSL, and custom command.
   openssl is installed together with git.
   When using custom command, the private key is never known to the build system.
 - Add do_sign.py that signs using the ECDSA library.
 - Rename sign.py to validation_data.py since it no longer does signing.
 - Add hash.py that hashes using hashlib. This script is always used, no
   matter which signing backend is used.
 - Add asn1parse.py for parsing signatures from OpenSSL.
 - Change CLI of keygen.py to more closely match OpenSSL, to allow
   generating a public key from a given private key and in case OpenSSL
   is used for RSA key generation in the furture
 - Remove handling of private key from provision.py. Generation of the
   first public key is now done by either keygen.py or OpenSSL depending
   on the new Kconfig.
 - Refactor arg parsing in scripts to use type=argparse.FileType(...).
   This means "with open..." is mostly not needed anymore.
