### PR TITLE
Vector table relay

### DIFF
--- a/subsys/bootloader/Kconfig
+++ b/subsys/bootloader/Kconfig
@@ -8,6 +8,7 @@ menuconfig SECURE_BOOT
 	bool "Secure Boot"
 	select SECURE_BOOT_CRYPTO
 	select SB_FLASH_PROTECT
+	select SW_VECTOR_RELAY if SOC_SERIES_NRF51X
 
 if SECURE_BOOT
 

--- a/subsys/bootloader/c_runtime_setup/CMakeLists.txt
+++ b/subsys/bootloader/c_runtime_setup/CMakeLists.txt
@@ -27,6 +27,12 @@ target_sources_ifdef(CONFIG_SB_C_RUNTIME_SETUP_VARIANT_CUSTOM
   startup.c
   )
 
+target_sources_ifdef(CONFIG_CPU_CORTEX_M0
+  c_runtime_setup
+  PUBLIC
+  ${ARM}/irq_relay.S
+  )
+
 target_sources_ifdef(CONFIG_SB_C_RUNTIME_SETUP_VARIANT_ZEPHYR
   c_runtime_setup
   PRIVATE

--- a/subsys/bootloader/fw_metadata/fw_metadata.c
+++ b/subsys/bootloader/fw_metadata/fw_metadata.c
@@ -10,7 +10,7 @@ extern const u32_t _image_rom_start;
 extern const u32_t _flash_used;
 
 const struct fw_firmware_info m_firmware_info
-__attribute__((section(".firmware_info")))
+_GENERIC_SECTION(.firmware_info)
 __attribute__((used)) = {
 	.magic = {FIRMWARE_INFO_MAGIC},
 	.firmware_size = (u32_t)&_flash_used,

--- a/subsys/bootloader/include/bootloader.ld
+++ b/subsys/bootloader/include/bootloader.ld
@@ -26,8 +26,37 @@ MEMORY
     IDT_LIST  (wx)      : ORIGIN = (RAM_ADDR + RAM_SIZE), LENGTH = 2K
 }
 
+
+SECTIONS
+    {
+	SECTION_PROLOGUE(text0,,)
+	{
+	. = CONFIG_TEXT_SECTION_OFFSET;
+
+#if defined(CONFIG_SW_VECTOR_RELAY)
+	KEEP(*(.vector_relay_table))
+	KEEP(*(".vector_relay_table.*"))
+	KEEP(*(.vector_relay_handler))
+	KEEP(*(".vector_relay_handler.*"))
+#endif
+	} GROUP_LINK_IN(ROMABLE_REGION)
+
+#if defined(CONFIG_SW_VECTOR_RELAY)
+	/* Reserved 4 bytes to save vector table base address */
+	SECTION_PROLOGUE(.vt_pointer,(NOLOAD),)
+	{
+		*(.vt_pointer_section)
+		*(".vt_pointer_section.*")
+	} GROUP_LINK_IN(RAMABLE_REGION)
+#endif
+    }
+
 /* Set this first so we are sure relevant sections are placed where the MDK expect it to be */
 #include <nrf_common.ld>
+
+/* Define Zephyr symbols for compatibility with Zephyr code. */
+_main_stack = __StackLimit;
+__reset = Reset_Handler;
 
 SECTIONS
     {
@@ -46,8 +75,6 @@ SECTIONS
 
 	SECTION_PROLOGUE(_TEXT_SECTION_NAME,,)
 	{
-	. = CONFIG_TEXT_SECTION_OFFSET;
-
 	_vector_start = .;
 	KEEP(*(.exc_vector_table))
 	KEEP(*(".exc_vector_table.*"))


### PR DESCRIPTION
subsys: bootloader: Use Zephyr's SW_VECTOR_RELAY functionality for nRF51

Implemented in arch/arm/core/irq_relay.S.

The linker changes define sections and symbols needed by irq_relay.S.
Some sections need to be placed at the very beginning of flash/RAM,
so they are defined before #include<nrf_common.ld>.

Together with #333 and #334 this makes the immutable bootloader work on nRF51.