### PR TITLE
doc: remove an outdated note from "About the NCS"

### DIFF
--- a/doc/nrf/introduction.rst
+++ b/doc/nrf/introduction.rst
@@ -5,8 +5,6 @@ About the |NCS|
 
 The |NCS| is hosted by Nordic Semiconductor to demonstrate the integration of Nordic SoC support in open source projects, like MCUBoot and the Zephyr RTOS, with libraries and source code for low-power wireless applications.
 
-It is not intended or supported by Nordic Semiconductor for product development.
-
 See :ref:`getting_started` for information about how to install the |NCS| and about the first steps.
 
 .. toctree::


### PR DESCRIPTION
The note was removed in other places before. Remove in this file
as well.

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>