### PR TITLE
scripts: Configuration channel application for nRF52 Desktop

### DIFF
--- a/scripts/hid_configurator/README.rst
+++ b/scripts/hid_configurator/README.rst
@@ -1,0 +1,48 @@
+.. _configuration_channel:
+
+Configuration channel for nRF52 Desktop
+#######################################
+
+Overview
+********
+
+This application is an example of controlling nRF52 Desktop firmware parameters at runtime.
+
+It uses HID feature reports to communicate with firmware.
+
+Right now, it can be used to change following parameters:
+* mouse optical sensor resolution (CPI)
+
+Supported transports:
+* USB
+
+Usage
+*****
+On Windows:
+
+	py -3 configurator.py --cpi 12000
+
+On Linux:
+
+	python3 configurator.py --cpi 12000
+
+Installation
+************
+To setup dependencies for the configurator program, run:
+On Windows:
+
+	py -3 -m pip install -r requirements.txt
+
+On Linux:
+
+	pip3 install --user -r requirements.txt
+
+This installs:
+* HIDAPI library - on Windows provided by `hidapi.dll` or `hidapi-x64.dll`
+* pyhidapi Python wrapper - installed from GitHub repository with additional patches included. The version on PyPI is obsolete and will not work.
+
+Note:
+************
+When using Python Launcher for Windows, `--user` installation option will not work, since DLL files will be copied to `user\AppData\Roaming\Python\PythonX` which is not searched for DLL libraries by default. You can either install without `--user` option or copy the DLL library next to the program being run. To uninstall all files, run
+
+	py -3 -m pip uninstall hid

--- a/scripts/hid_configurator/configurator.py
+++ b/scripts/hid_configurator/configurator.py
@@ -1,0 +1,50 @@
+import hid
+import struct
+from enum import Enum
+
+import argparse
+import logging
+
+REPORT_ID = 4
+MOUSE_VID = 0x1915
+MOUSE_PID = 0x52DE
+
+
+class ConfigEventID(Enum):
+    MOUSE_CPI = 1
+
+
+def configurator():
+    logging.basicConfig(level=logging.DEBUG)
+    logging.info('Configuration channel for nRF52 Desktop')
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--cpi', type=int,
+                        help='CPI resolution of a mouse sensor')
+    args = parser.parse_args()
+
+    # Open HID device
+    dev = hid.Device(vid=MOUSE_VID, pid=MOUSE_PID)
+    logging.debug('Opened device')
+
+    if (args.cpi):
+        data = create_report_mouse_cpi(args.cpi)
+
+        # Send configuration report
+        dev.send_feature_report(data)
+
+
+def create_report_mouse_cpi(cpi):
+    """ Function creating a HID feature report with 16-bit unsigned CPI resolution """
+    if cpi > 12000 or cpi < 100:
+        raise ValueError('CPI out of range')
+
+    event_id = ConfigEventID.MOUSE_CPI.value
+
+    data = struct.pack('<BBH', REPORT_ID, event_id, cpi)
+    logging.debug('Sent request to update CPI: %d' % cpi)
+    return data
+
+
+if __name__ == '__main__':
+    configurator()

--- a/scripts/hid_configurator/requirements.txt
+++ b/scripts/hid_configurator/requirements.txt
@@ -1,0 +1,1 @@
+git+https://github.com/Qbicz/pyhidapi.git@master


### PR DESCRIPTION
Application works with nRF52 Desktop firmware in order to control the
firmware parameters at runtime. It uses HID feature reports to
communicate with the device.

In initial version, controlling the mouse sensor resolution (CPI) is
supported.

Jira: DESK-301

Signed-off-by: Filip Kubicz <filip.kubicz@nordicsemi.no>