### PR TITLE
subsys: bluetooth: samples: Security request in central samples

### DIFF
--- a/samples/bluetooth/peripheral_hids_mouse/Kconfig
+++ b/samples/bluetooth/peripheral_hids_mouse/Kconfig
@@ -15,39 +15,4 @@ config BT_GATT_HIDS_SECURITY_ENABLED
 	help
 	  "Enable BLE security for the HIDS service"
 
-if BT_GATT_HIDS_SECURITY_ENABLED
-
-choice BT_GATT_HIDS_SECURITY
-	prompt "Bluetooth security level"
-	default BT_GATT_HIDS_SECURITY_LEVEL_HIGH
-
-config BT_GATT_HIDS_SECURITY_LEVEL_FIPS
-	bool "Authenticated Secure Connections"
-	select BT_SMP
-	help
-	  "This level has high security level with FIPS
-	   approved encryption cipher"
-
-config BT_GATT_HIDS_SECURITY_LEVEL_HIGH
-	bool "High security level"
-	select BT_SMP
-	help
-	  "This level has encryption and authentication"
-
-config BT_GATT_HIDS_SECURITY_LEVEL_MED
-	bool "Medium security level"
-	select BT_SMP
-	help
-	  "This level has encryption and no authentication"
-
-config BT_GATT_HIDS_SECURITY_LEVEL_LOW
-	bool "Low security level"
-	select BT_SMP
-	help
-	  "This level has no encryption and no authentication"
-
-endchoice
-
-endif
-
 endmenu

--- a/samples/bluetooth/peripheral_hids_mouse/src/main.c
+++ b/samples/bluetooth/peripheral_hids_mouse/src/main.c
@@ -64,19 +64,6 @@ HIDS_DEF(hids_obj,
 	 INPUT_REP_MOVEMENT_LEN,
 	 INPUT_REP_MEDIA_PLAYER_LEN);
 
-
-#ifdef CONFIG_BT_GATT_HIDS_SECURITY_LEVEL_LOW
-static const bt_security_t sec_level = BT_SECURITY_LOW;
-#elif CONFIG_BT_GATT_HIDS_SECURITY_LEVEL_MED
-static const bt_security_t sec_level = BT_SECURITY_MEDIUM;
-#elif CONFIG_BT_GATT_HIDS_SECURITY_LEVEL_HIGH
-static const bt_security_t sec_level = BT_SECURITY_HIGH;
-#elif CONFIG_BT_GATT_HIDS_SECURITY_LEVEL_FIPS
-static const bt_security_t sec_level = BT_SECURITY_FIPS;
-#else
-static const bt_security_t sec_level = BT_SECURITY_LOW;
-#endif
-
 static struct k_delayed_work hids_work;
 struct mouse_pos {
 	s16_t x_val;
@@ -138,12 +125,6 @@ static void connected(struct bt_conn *conn, u8_t err)
 	}
 
 	printk("Connected %s\n", addr);
-
-	if (IS_ENABLED(CONFIG_BT_GATT_HIDS_SECURITY_ENABLED)) {
-		if (bt_conn_security(conn, sec_level)) {
-			printk("Failed to set security\n");
-		}
-	}
 
 	err = hids_notify_connected(&hids_obj, conn);
 
@@ -440,8 +421,7 @@ static void bt_ready(int err)
 }
 
 
-#if !defined(CONFIG_BT_GATT_HIDS_SECURITY_LEVEL_LOW) && \
-	defined(CONFIG_BT_GATT_HIDS_SECURITY_ENABLED)
+#if defined(CONFIG_BT_GATT_HIDS_SECURITY_ENABLED)
 static void auth_passkey_display(struct bt_conn *conn, unsigned int passkey)
 {
 	char addr[BT_ADDR_LE_STR_LEN];

--- a/samples/bluetooth/peripheral_lbs/Kconfig
+++ b/samples/bluetooth/peripheral_lbs/Kconfig
@@ -15,39 +15,4 @@ config BT_GATT_LBS_SECURITY_ENABLED
 	help
 	  "Enable BLE security for the LED-Button service"
 
-if BT_GATT_LBS_SECURITY_ENABLED
-
-choice BT_GATT_LBS_SECURITY
-	prompt "Bluetooth security level"
-	default BT_GATT_LBS_SECURITY_LEVEL_HIGH
-
-config BT_GATT_LBS_SECURITY_LEVEL_FIPS
-	bool "Authenticated Secure Connections"
-	select BT_SMP
-	help
-	  "This level has high security level with FIPS
-	   approved encryption cipher"
-
-config BT_GATT_LBS_SECURITY_LEVEL_HIGH
-	bool "High security level"
-	select BT_SMP
-	help
-	  "This level has encryption and authentication"
-
-config BT_GATT_LBS_SECURITY_LEVEL_MED
-	bool "Medium security level"
-	select BT_SMP
-	help
-	  "This level has encryption and no authentication"
-
-config BT_GATT_LBS_SECURITY_LEVEL_LOW
-	bool "Low security level"
-	select BT_SMP
-	help
-	  "This level has no encryption and no authentication"
-
-endchoice
-
-endif
-
 endmenu

--- a/samples/bluetooth/peripheral_uart/Kconfig
+++ b/samples/bluetooth/peripheral_uart/Kconfig
@@ -27,39 +27,4 @@ config BT_GATT_NUS_SECURITY_ENABLED
 	help
 	  "Enable BLE security for the UART service"
 
-if BT_GATT_NUS_SECURITY_ENABLED
-
-choice BT_GATT_NUS_SECURITY
-	prompt "Bluetooth security level"
-	default BT_GATT_NUS_SECURITY_LEVEL_HIGH
-
-config BT_GATT_NUS_SECURITY_LEVEL_FIPS
-	bool "Authenticated Secure Connections"
-	select BT_SMP
-	help
-	  "This level has high security level with FIPS
-	   approved encryption chipher"
-
-config BT_GATT_NUS_SECURITY_LEVEL_HIGH
-	bool "High security level"
-	select BT_SMP
-	help
-	  "This level has encryption and authentication"
-
-config BT_GATT_NUS_SECURITY_LEVEL_MED
-	bool "Medium security level"
-	select BT_SMP
-	help
-	  "This level has encryption and no authentication"
-
-config BT_GATT_NUS_SECURITY_LEVEL_LOW
-	bool "Low security level"
-	select BT_SMP
-	help
-	  "This level has no encryption and no authentication"
-
-endchoice
-
-endif
-
 endmenu

--- a/samples/bluetooth/peripheral_uart/src/main.c
+++ b/samples/bluetooth/peripheral_uart/src/main.c
@@ -47,18 +47,6 @@
 
 #define UART_BUF_SIZE           CONFIG_BT_GATT_NUS_UART_BUFFER_SIZE
 
-#ifdef CONFIG_BT_GATT_NUS_SECURITY_ENABLED
-#ifdef CONFIG_BT_GATT_NUS_SECURITY_LEVEL_LOW
-static const bt_security_t sec_level = BT_SECURITY_LOW;
-#elif CONFIG_BT_GATT_NUS_SECURITY_LEVEL_MED
-static const bt_security_t sec_level = BT_SECURITY_MEDIUM;
-#elif CONFIG_BT_GATT_NUS_SECURITY_LEVEL_HIGH
-static const bt_security_t sec_level = BT_SECURITY_HIGH;
-#elif CONFIG_BT_GATT_NUS_SECURITY_LEVEL_FIPS
-static const bt_security_t sec_level = BT_SECURITY_FIPS;
-#endif
-#endif
-
 static K_SEM_DEFINE(ble_init_ok, 0, 2);
 
 static struct bt_conn *current_conn;
@@ -190,11 +178,6 @@ static void connected(struct bt_conn *conn, u8_t err)
 	printk("Connected\n");
 	current_conn = bt_conn_ref(conn);
 
-#ifdef CONFIG_BT_GATT_NUS_SECURITY_ENABLED
-	if (bt_conn_security(conn, sec_level)) {
-		printk("Failed to set security level %d\n", sec_level);
-	}
-#endif
 	set_led_state(CON_STATUS_LED, LED_ON);
 }
 
@@ -224,8 +207,7 @@ static struct bt_conn_cb conn_callbacks = {
 #endif
 };
 
-#if !defined(CONFIG_BT_GATT_NUS_SECURITY_LEVEL_LOW) && \
-	defined(CONFIG_BT_GATT_NUS_SECURITY_ENABLED)
+#if defined(CONFIG_BT_GATT_NUS_SECURITY_ENABLED)
 static void auth_passkey_display(struct bt_conn *conn, unsigned int passkey)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
@@ -249,6 +231,8 @@ static struct bt_conn_auth_cb conn_auth_callbacks = {
 	.passkey_entry = NULL,
 	.cancel = auth_cancel,
 };
+#else
+static struct bt_conn_auth_cb conn_auth_callbacks;
 #endif
 
 static void bt_receive_cb(const u8_t *const data, u16_t len)
@@ -387,10 +371,10 @@ static void led_blink_thread(void)
 
 	if (!err) {
 		bt_conn_cb_register(&conn_callbacks);
-		#if !defined(CONFIG_BT_GATT_NUS_SECURITY_LEVEL_LOW) && \
-		     defined(CONFIG_BT_GATT_NUS_SECURITY_ENABLED)
-		bt_conn_auth_cb_register(&conn_auth_callbacks);
-		#endif
+
+		if (IS_ENABLED(CONFIG_BT_GATT_NUS_SECURITY_ENABLED)) {
+			bt_conn_auth_cb_register(&conn_auth_callbacks);
+		}
 
 		err = k_sem_take(&ble_init_ok, K_MSEC(100));
 


### PR DESCRIPTION
Security request is only on the central site, from
peripheral side scurity request was removed. Paring
error have been removed. The security level is determined by
the central side. The maximum level of security supported
by the peripheral side is 4. Also removed the need to configure
the level with security from Kconfig.

Signed-off-by: Kamil Gawor <Kamil.Gawor@nordicsemi.no>