### PR TITLE
samples: nrf_desktop: Send queued data on empty pipeline

### DIFF
--- a/samples/nrf_desktop/src/modules/hid_state.c
+++ b/samples/nrf_desktop/src/modules/hid_state.c
@@ -724,7 +724,7 @@ static void report_issued(const void *subscriber_id, enum target_report tr,
 		}
 	}
 
-	if (update_needed) {
+	if (update_needed && (rs->cnt == 0)) {
 		/* Something was updated. Report must be issued. */
 		report_send(tr, false);
 	}


### PR DESCRIPTION
Send queued data only if report pipeline is empty.

Jira:DESK-373

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>