### PR TITLE
samples: nrf_desktop: Fix LEDs initialization

### DIFF
--- a/samples/nrf_desktop/src/hw_interface/leds.c
+++ b/samples/nrf_desktop/src/hw_interface/leds.c
@@ -127,6 +127,8 @@ static int leds_init(void)
 
 	for (size_t i = 0; (i < ARRAY_SIZE(leds)) && !err; i++) {
 		leds[i].pwm_dev = device_get_binding(dev_name[i]);
+		leds[i].id = i;
+
 		if (!leds[i].pwm_dev) {
 			LOG_ERR("cannot bind %s", dev_name[i]);
 			err = -ENXIO;


### PR DESCRIPTION
Recently introduced LED id should be initialized. Prior to this change,
we tried to initialize the same LED twice.

Jira: DESK-382

Signed-off-by: Filip Kubicz <filip.kubicz@nordicsemi.no>