### PR TITLE
GPS simulator updates

### DIFF
--- a/lib/gps_sim/Kconfig
+++ b/lib/gps_sim/Kconfig
@@ -130,19 +130,12 @@ config GPS_SIM_GPIO_PIN
 		GPIO pin for trigger button.
 endif
 
-if GPS_SIM_TRIGGER && GPS_SIM_TRIGGER_USE_TIMER
-	config GPS_SIM_TRIGGER_TIMER_MSEC
-		int "Time between triggers, in milliseconds"
-		default 1000
-		help
-			The time interval between each 'data ready' trigger event.
-endif
-
-if GPS_SIM_TRIGGER && !GPS_SIM_TRIGGER_USE_TIMER
-	config GPS_SIM_TRIGGER_TIMER_MSEC
-		int
-		default 0
-endif
+config GPS_SIM_TRIGGER_TIMER_MSEC
+	int "Time between triggers, in milliseconds"
+	depends on GPS_SIM_TRIGGER_USE_TIMER
+	default 1000
+	help
+		The time interval between each 'data ready' trigger event.
 
 config GPS_SIM_THREAD_PRIORITY
 	int "Thread priority"

--- a/lib/gps_sim/Kconfig
+++ b/lib/gps_sim/Kconfig
@@ -103,6 +103,20 @@ config GPS_SIM_TRIGGER_USE_BUTTON
 
 endchoice
 
+if GPS_SIM_TRIGGER_USE_BUTTON
+config GPS_SIM_GPIO_CONTROLLER
+	string "GPIO controller"
+	default "GPIO_0"
+	help
+		GPIO controller for GPS simulator trigger button.
+
+config GPS_SIM_GPIO_PIN
+	int "GPIO pin"
+	default 6
+	help
+		GPIO pin for trigger button.
+endif
+
 if GPS_SIM_TRIGGER && GPS_SIM_TRIGGER_USE_TIMER
 	config GPS_SIM_TRIGGER_TIMER_MSEC
 		int "Time between triggers, in milliseconds"

--- a/lib/gps_sim/Kconfig
+++ b/lib/gps_sim/Kconfig
@@ -24,8 +24,10 @@ config GPS_SIM_BASE_LATITUDE
 	help
 		Start-point latitude for simulated GPS data,
 		from which the generated data will continue.
-		Calculated by deg * 100000 + minutes * 1000 N,
-		for example 63 deg 25.280' will be 6325280.
+		Calculated by deg * 100000 + minutes * 1000,
+		for example 63 deg 25.280'N will be 6325280.
+		Positive values are North, while negative
+		values are South.
 
 config GPS_SIM_BASE_LONGITUDE
 	int "Base longitude for GPS data"
@@ -33,8 +35,10 @@ config GPS_SIM_BASE_LONGITUDE
 	help
 		Start-point longitude for simulated GPS data,
 		from which the generated data will continue.
-		Calculated by deg * 100000 + minutes * 1000 E,
-		for example 10 deg 26.201' will be 1026201.
+		Calculated by deg * 100000 + minutes * 1000,
+		for example 10 deg 26.201'E will be 1026201.
+		Positive values are East, while negative
+		values are West.
 
 config GPS_SIM_BASE_TIMESTAMP
 	int "Base timestamp for GPS data"

--- a/lib/gps_sim/Kconfig
+++ b/lib/gps_sim/Kconfig
@@ -82,7 +82,7 @@ config GPS_SIM_FIX_TIME
 
 config GPS_SIM_MAX_STEP
 	int "Maximum step size each iteration"
-	default 5
+	default 100
 	help
 		Sets the maximum step size that can be taken in latitude or longitude
 		for each simulation iteration. In units of 1/1000 degrees.

--- a/lib/gps_sim/Kconfig
+++ b/lib/gps_sim/Kconfig
@@ -71,6 +71,15 @@ config GPS_SIM_DYNAMIC_VALUES
 		Enables dynamically created simulator otuput as opposed
 		to static values.
 
+config GPS_SIM_FIX_TIME
+	int "Time in milliseconds between position generations"
+	range 500 60000
+	default GPS_SIM_TRIGGER_TIMER_MSEC if GPS_SIM_TRIGGER_USE_TIMER
+	default 1000
+	help
+		Time in milliseconds that the GPS simulator will return the same
+		position before generating new coordinates.
+
 config GPS_SIM_MAX_STEP
 	int "Maximum step size each iteration"
 	default 5

--- a/lib/gps_sim/gps_sim.c
+++ b/lib/gps_sim/gps_sim.c
@@ -302,12 +302,13 @@ static int gps_sim_init(struct device *dev)
 	base_gps_sample_lng = CONFIG_GPS_SIM_BASE_LONGITUDE / 1000.0;
 
 	if (IS_ENABLED(CONFIG_GPS_SIM_TRIGGER)) {
-		if (IS_ENABLED(CONFIG_GPS_SIM_TRIGGER_USE_BUTTON)) {
-			struct gps_sim_data *drv_data = dev->driver_data;
+#ifdef CONFIG_GPS_SIM_TRIGGER_USE_BUTTON
+		struct gps_sim_data *drv_data = dev->driver_data;
 
-			drv_data->gpio_port = SW1_GPIO_CONTROLLER;
-			drv_data->gpio_pin = SW1_GPIO_PIN;
-		}
+		drv_data->gpio_port = CONFIG_GPS_SIM_GPIO_CONTROLLER;
+		drv_data->gpio_pin = CONFIG_GPS_SIM_GPIO_PIN;
+#endif /* GPS_SIM_TRIGGER_USE_BUTTON */
+
 		if (gps_sim_init_thread(dev) < 0) {
 			LOG_ERR("Failed to initialize trigger interrupt");
 			return -EIO;

--- a/lib/gps_sim/gps_sim.c
+++ b/lib/gps_sim/gps_sim.c
@@ -199,7 +199,7 @@ static u8_t nmea_checksum_get(const u8_t *nmea_sentence)
  */
 static double generate_sine(double offset, double amplitude)
 {
-	u32_t time = k_uptime_get_32();
+	u32_t time = k_uptime_get_32() / K_MSEC(CONFIG_GPS_SIM_FIX_TIME);
 
 	return offset + amplitude * sin(time % UINT16_MAX);
 }
@@ -213,7 +213,7 @@ static double generate_sine(double offset, double amplitude)
  */
 static double generate_cosine(double offset, double amplitude)
 {
-	u32_t time = k_uptime_get_32();
+	u32_t time = k_uptime_get_32() /  K_MSEC(CONFIG_GPS_SIM_FIX_TIME);
 
 	return offset + amplitude * cos(time % UINT16_MAX);
 }

--- a/lib/gps_sim/gps_sim.c
+++ b/lib/gps_sim/gps_sim.c
@@ -11,10 +11,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <logging/log.h>
-
-#if defined(CONFIG_GPS_SIM_DYNAMIC_VALUES)
 #include <math.h>
-#endif
 
 #define BASE_GPS_SAMPLE_HOUR	(CONFIG_GPS_SIM_BASE_TIMESTAMP / 10000)
 #define BASE_GPS_SAMPLE_MINUTE	((CONFIG_GPS_SIM_BASE_TIMESTAMP / 100) % 100)

--- a/lib/gps_sim/gps_sim.c
+++ b/lib/gps_sim/gps_sim.c
@@ -256,7 +256,7 @@ static void generate_gps_data(
 	char lng_heading = 'E';
 
 	if (IS_ENABLED(CONFIG_GPS_SIM_ELLIPSOID)) {
-		lat = generate_sine(base_gps_sample_lat, max_variation);
+		lat = generate_sine(base_gps_sample_lat, max_variation / 2.0);
 		lng = generate_cosine(base_gps_sample_lng, max_variation);
 	}
 

--- a/lib/gps_sim/gps_sim.c
+++ b/lib/gps_sim/gps_sim.c
@@ -251,6 +251,9 @@ static void generate_gps_data(
 	static u32_t last_uptime;
 	double lat = base_gps_sample_lat;
 	double lng = base_gps_sample_lng;
+	char tmp_str[GPS_NMEA_SENTENCE_MAX_LENGTH];
+	char lat_heading = 'N';
+	char lng_heading = 'E';
 
 	if (IS_ENABLED(CONFIG_GPS_SIM_ELLIPSOID)) {
 		lat = generate_sine(base_gps_sample_lat, max_variation);
@@ -282,12 +285,20 @@ static void generate_gps_data(
 		}
 	}
 
-	char tmp_str[GPS_NMEA_SENTENCE_MAX_LENGTH];
+	if (lat < 0) {
+		lat *= -1.0;
+		lat_heading = 'S';
+	}
+
+	if (lng < 0) {
+		lng *= -1.0;
+		lng_heading = 'W';
+	}
 
 	snprintf(tmp_str, GPS_NMEA_SENTENCE_MAX_LENGTH,
-		"$GPGGA,%02d%02d%02d.200,%8.3f,N,%09.3f,E,1,"
+		"$GPGGA,%02d%02d%02d.200,%8.3f,%c,%09.3f,%c,1,"
 		"12,1.0,0.0,M,0.0,M,,*",
-		hour, minute, second, lat, lng);
+		hour, minute, second, lat, lat_heading, lng, lng_heading);
 
 	u8_t checksum = nmea_checksum_get(tmp_str);
 


### PR DESCRIPTION
This pull request contains a few updates to the GPS simulator:
- GPIO controller/pin used for triggering can be set using Kconfig
- Also allow coordinates in degrees south and west, not hard-coded to be east and north
- Make the ellipsoid movement circular
- To be a bit more like a real GPS, the update interval can be set in Kconfig. Before a new and different position could be obtained every millisecond. Now defaults to every 10 seconds, taking about 1 minute to "walk" a full circle.