### PR TITLE
udev rule to access HID devices on Linux & friends

### DIFF
--- a/samples/nrf_desktop/src/hw_interface/motion_optical.c
+++ b/samples/nrf_desktop/src/hw_interface/motion_optical.c
@@ -499,7 +499,7 @@ static void update_downshift_time(u8_t reg_addr, u32_t time)
 	/* Convert time to register value */
 	u8_t value = time / mintime;
 
-	LOG_INF("Setting run downshift to %u ms (reg value 0x%x)", time, value);
+	LOG_INF("Setting downshift time to %u ms (reg value 0x%x)", time, value);
 
 	int err = reg_write(reg_addr, value);
 	if (err) {

--- a/scripts/hid_configurator/99-hid.rules
+++ b/scripts/hid_configurator/99-hid.rules
@@ -1,0 +1,22 @@
+# udev rules which allow using configuration channel for nRF52 Desktop without
+# root permissions on Linux. Adapted from HIDAPI project.
+
+# To apply the rule, drop this file into /etc/udev/rules.d and unplug
+# and re-plug your device. This is all that is necessary to see the new
+# permissions. Udev does not have to be restarted.
+
+# Rules change the permissions to 0666 (world readable/writable) for specified
+# device on Linux systems.
+
+# Note that for kernels before 2.6.24, you will need
+# to substitute "usb" with "usb_device". It shouldn't hurt to use two lines
+# (one each way) for compatibility with older systems.
+
+# HIDAPI/libusb
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1915", ATTRS{idProduct}=="52de", MODE="0666", SYMLINK+="desktop-mouse-usb"
+
+# HIDAPI/hidraw
+KERNEL=="hidraw*", ATTRS{idVendor}=="1915", ATTRS{idProduct}=="52de", MODE="0666", SYMLINK+="desktop-mouse-hidraw"
+
+# Note that the hexadecimal values for VID and PID are case sensitive and
+# must be lower case.

--- a/scripts/hid_configurator/99-hid.rules
+++ b/scripts/hid_configurator/99-hid.rules
@@ -1,15 +1,15 @@
 # udev rules which allow using configuration channel for nRF52 Desktop without
 # root permissions on Linux. Adapted from HIDAPI project.
 
-# To apply the rule, drop this file into /etc/udev/rules.d and unplug
-# and re-plug your device. This is all that is necessary to see the new
-# permissions. Udev does not have to be restarted.
+# To apply the rule, drop this file into `/etc/udev/rules.d` and unplug
+# and replug your device. These are the only steps necessary to see the new
+# permissions. You do not need to restart udev.
 
 # Rules change the permissions to 0666 (world readable/writable) for specified
 # device on Linux systems.
 
-# Note that for kernels before 2.6.24, you will need
-# to substitute "usb" with "usb_device". It shouldn't hurt to use two lines
+# Note that for kernels before 2.6.24, you must
+# substitute "usb" with "usb_device". It is recommended to use two lines
 # (one each way) for compatibility with older systems.
 
 # HIDAPI/libusb

--- a/scripts/hid_configurator/README.rst
+++ b/scripts/hid_configurator/README.rst
@@ -38,11 +38,17 @@ On Linux:
 	pip3 install --user -r requirements.txt
 
 This installs:
+
 * HIDAPI library - on Windows provided by `hidapi.dll` or `hidapi-x64.dll`
 * pyhidapi Python wrapper - installed from GitHub repository with additional patches included. The version on PyPI is obsolete and will not work.
+
+On Linux, if you want to be able to call Python script without root rights,
+install the provided udev rule `99-hid.rules` by copying it to
+`/etc/udev/rules.d` and re-plugging the device.
 
 Note:
 ************
 When using Python Launcher for Windows, `--user` installation option will not work, since DLL files will be copied to `user\AppData\Roaming\Python\PythonX` which is not searched for DLL libraries by default. You can either install without `--user` option or copy the DLL library next to the program being run. To uninstall all files, run
 
 	py -3 -m pip uninstall hid
+

--- a/scripts/hid_configurator/README.rst
+++ b/scripts/hid_configurator/README.rst
@@ -11,9 +11,15 @@ This application is an example of controlling nRF52 Desktop firmware parameters 
 It uses HID feature reports to communicate with firmware.
 
 Right now, it can be used to change following parameters:
+
 * mouse optical sensor resolution (CPI)
+* optical sensor power saving modes:
+	* downshift time from "Run" to "Rest1" mode
+	* downshift time from "Rest1" to "Rest2" mode
+	* downshift time from "Rest2" to "Rest3" mode
 
 Supported transports:
+
 * USB
 
 Usage
@@ -25,6 +31,8 @@ On Windows:
 On Linux:
 
 	python3 configurator.py --cpi 12000
+
+To get a list of possible arguments, call with `--help` option.
 
 Installation
 ************
@@ -42,9 +50,9 @@ This installs:
 * HIDAPI library - on Windows provided by `hidapi.dll` or `hidapi-x64.dll`
 * pyhidapi Python wrapper - installed from GitHub repository with additional patches included. The version on PyPI is obsolete and will not work.
 
-On Linux, if you want to be able to call Python script without root rights,
+On Linux, to call the Python script without root rights,
 install the provided udev rule `99-hid.rules` by copying it to
-`/etc/udev/rules.d` and re-plugging the device.
+`/etc/udev/rules.d` and replugging the device.
 
 Note:
 ************


### PR DESCRIPTION
Configuration channel script opens the device, on Windows natively and on Linux with hidraw or libusb. On Linux, a proper udev rule is needed for user to do that.

Included also a not-connected fix in the optical sensor.