### PR TITLE
Doc cleanup

### DIFF
--- a/doc/nrf/conf.py
+++ b/doc/nrf/conf.py
@@ -88,7 +88,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'nRF Connect SDK'
-copyright = '2018, Nordic Semiconductor'
+copyright = '2019, Nordic Semiconductor'
 author = 'Nordic Semiconductor'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/doc/nrf/ug_nrf9160.rst
+++ b/doc/nrf/ug_nrf9160.rst
@@ -155,7 +155,7 @@ Asset Tracker
 	The **Asset Tracker** sample is a comprehensive application that demonstrates
 	how to use the nRF Cloud library to connect an nRF9160 DK to
 	the `nRF Cloud`_ through LTE, and transmit GPS and device orientation data.
-	For details, see :ref:`nrf_cloud`.
+	For details, see :ref:`asset_tracker`.
 
 LTE Sensor Gateway
 	The **LTE Sensor Gateway** sample demonstrates how to transmit sensor data

--- a/doc/release-notes-0.3.0.rst
+++ b/doc/release-notes-0.3.0.rst
@@ -20,7 +20,7 @@ Highlights
 
 * Added the following samples for nRF9160:
 
-  * :ref:`nrf_cloud`
+  * :ref:`asset_tracker`
   * :ref:`lte_sensor_gateway`
   * AT Client
 
@@ -97,7 +97,7 @@ nRF9160
     The sample configures resources for the secure domain and boots an application from the non-secure domain.
   * **at_client**:
     This sample uses the **at_host** library to provide a UART interface for AT commands.
-  * :ref:`nrf_cloud`:
+  * :ref:`asset_tracker`:
     This sample uses the **nrf_cloud** library to transmit GPS and device orientation data to the nRF Cloud via LTE.
   * :ref:`lte_sensor_gateway`:
     This sample uses the **nrf_cloud** library to transmit sensor data collected via Bluetooth LE to the nRF Cloud via LTE.
@@ -210,9 +210,9 @@ Known issues
 nRF9160
 =======
 
-* The :ref:`nrf_cloud` sample does not wait for connection to nRF Cloud before trying to send data.
+* The :ref:`asset_tracker` sample does not wait for connection to nRF Cloud before trying to send data.
   This causes the sample to crash if the user toggles one of the switches before the board is connected to the cloud.
-* The :ref:`nrf_cloud` sample might show up to 2.5 mA current consumption in idle mode with ``CONFIG_POWER_OPTIMIZATION_ENABLE=y``.
+* The :ref:`asset_tracker` sample might show up to 2.5 mA current consumption in idle mode with ``CONFIG_POWER_OPTIMIZATION_ENABLE=y``.
 * If a debugger (for example, J-Link) is connected via SWD to the nRF9160, the modem firmware will reset.
   Therefore, the LTE modem cannot be operational during debug sessions.
 * The SEGGER Control Block cannot be found by automatic search by the RTT Viewer/Logger.

--- a/samples/nrf9160/asset_tracker/README.rst
+++ b/samples/nrf9160/asset_tracker/README.rst
@@ -1,4 +1,4 @@
-.. _nrf_cloud:
+.. _asset_tracker:
 
 nRF9160: Asset Tracker
 ######################
@@ -29,7 +29,7 @@ Requirements
   The sample is configured to compile and run as a non-secure application on nRF91's Cortex-M33.
   Therefore, it requires the :ref:`secure_boot` bootloader that prepares the required peripherals to be available for the application.
 
-.. _nrf_cloud_user_interface:
+.. _asset_tracker_user_interface:
 
 User interface
 **************

--- a/samples/nrf9160/lte_ble_gateway/README.rst
+++ b/samples/nrf9160/lte_ble_gateway/README.rst
@@ -4,7 +4,7 @@ nRF9160: LTE Sensor Gateway
 ###########################
 
 The LTE Sensor Gateway sample demonstrates how to transmit sensor data from an nRF9160 DK to the `nRF Cloud`_.
-Unlike the :ref:`nrf_cloud` sample, the sensor data is collected via Bluetooth LE.
+Unlike the :ref:`asset_tracker` sample, the sensor data is collected via Bluetooth LE.
 Therefore, this sample acts as a gateway between Bluetooth LE and the LTE connection to the nRF Cloud.
 
 Overview
@@ -85,7 +85,7 @@ After programming the sample and all prerequisites to the board, test it by perf
    This might take several minutes.
 #. Observe that LED 3 starts blinking as the connection to nRF Cloud is established.
 
-   See :ref:`nrf_cloud_user_interface` in the :ref:`nrf_cloud` sample documentation for detailed information about the different LED states used by the sample.
+   See :ref:`asset_tracker_user_interface` in the :ref:`asset_tracker` sample documentation for detailed information about the different LED states used by the sample.
 #. The first time you start the sample, pair the device to your account:
 
    a. Observe that both LED 3 and 4 start blinking, indicating that the pairing procedure has been initiated.


### PR DESCRIPTION
Just small fixes to the documentation - updating the copyright year and changing the ID of the asset_tracker sample.