### PR TITLE
scripts: bootloader: add error message if address not found.

### DIFF
--- a/scripts/bootloader/provision.py
+++ b/scripts/bootloader/provision.py
@@ -46,6 +46,9 @@ def find_provision_memory_section(config_file):
             elif "FLASH_AREA_PROVISION_OFFSET" in line:
                 provision_address = int(line.split('=')[1])
 
+    if s0_address == 0 or s1_address == 0 or provision_address == 0:
+        raise RuntimeError("Could not find value for one of S0, S1 or provision address.")
+    
     return s0_address, s1_address, provision_address
 
 


### PR DESCRIPTION
If one of the required addresses required for
generating the provision hex file is not found
raise an error.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>