### PR TITLE
ci: Add ZRelease build for nrf_desktop sample.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,6 +79,8 @@ pipeline {
               for(int i=0; i<desktop_platforms.size(); i++) {
                 file_path = "zephyr/sanity-out/${desktop_platforms[i]}/nrf_desktop/test/zephyr/zephyr.hex"
                 check_and_store_sample("$file_path", "nrf_desktop_${desktop_platforms[i]}.hex")
+                file_path = "zephyr/sanity-out/${desktop_platforms[i]}/nrf_desktop/test_zrelease/zephyr/zephyr.hex"
+                check_and_store_sample("$file_path", "nrf_desktop_${desktop_platforms[i]}_ZRelease.hex")
               }
 
               /* Rename the nrf9160 samples */

--- a/samples/nrf_desktop/sample.yaml
+++ b/samples/nrf_desktop/sample.yaml
@@ -7,3 +7,9 @@ tests:
     build_on_all: true
     platform_whitelist: nrf52840_pca20041 nrf52840_pca10056 nrf52840_pca10059 nrf52_pca63519
     tags: bluetooth ci_build
+  test_zrelease:
+    build_only: true
+    build_on_all: true
+    platform_whitelist: nrf52840_pca20041 nrf52840_pca10056 nrf52840_pca10059 nrf52_pca63519
+    tags: bluetooth ci_build
+    extra_args: "CMAKE_BUILD_TYPE=ZRelease"


### PR DESCRIPTION
Add sanity_check test for nrf_desktop that builds all targets with DCMAKE_BUILD_TYPE=ZRelease option.
Copy artifacts of additional test.

Signed-off-by: Wiktor Miesok <wiktor.miesok@nordicsemi.no>