### PR TITLE
net: lib: mqtt: fix compilation when logging enabled

### DIFF
--- a/subsys/net/lib/mqtt_socket/mqtt.c
+++ b/subsys/net/lib/mqtt_socket/mqtt.c
@@ -10,7 +10,7 @@
  */
 
 #include <logging/log.h>
-LOG_MODULE_REGISTER(net_mqtt, CONFIG_MQTT_LOG_LEVEL);
+LOG_MODULE_REGISTER(net_mqtt, CONFIG_MQTT_SOCKET_LOG_LEVEL);
 
 #include <net/mqtt_socket.h>
 

--- a/subsys/net/lib/mqtt_socket/mqtt_decoder.c
+++ b/subsys/net/lib/mqtt_socket/mqtt_decoder.c
@@ -10,7 +10,7 @@
  */
 
 #include <logging/log.h>
-LOG_MODULE_REGISTER(net_mqtt_dec, CONFIG_MQTT_LOG_LEVEL);
+LOG_MODULE_REGISTER(net_mqtt_dec, CONFIG_MQTT_SOCKET_LOG_LEVEL);
 
 #include "mqtt_internal.h"
 #include "mqtt_os.h"

--- a/subsys/net/lib/mqtt_socket/mqtt_encoder.c
+++ b/subsys/net/lib/mqtt_socket/mqtt_encoder.c
@@ -10,7 +10,7 @@
  */
 
 #include <logging/log.h>
-LOG_MODULE_REGISTER(net_mqtt_enc, CONFIG_MQTT_LOG_LEVEL);
+LOG_MODULE_REGISTER(net_mqtt_enc, CONFIG_MQTT_SOCKET_LOG_LEVEL);
 
 #include "mqtt_internal.h"
 #include "mqtt_os.h"

--- a/subsys/net/lib/mqtt_socket/mqtt_rx.c
+++ b/subsys/net/lib/mqtt_socket/mqtt_rx.c
@@ -5,7 +5,7 @@
  */
 
 #include <logging/log.h>
-LOG_MODULE_REGISTER(net_mqtt_rx, CONFIG_MQTT_LOG_LEVEL);
+LOG_MODULE_REGISTER(net_mqtt_rx, CONFIG_MQTT_SOCKET_LOG_LEVEL);
 
 #include "mqtt_internal.h"
 #include "mqtt_os.h"

--- a/subsys/net/lib/mqtt_socket/mqtt_transport_socket_tcp.c
+++ b/subsys/net/lib/mqtt_socket/mqtt_transport_socket_tcp.c
@@ -10,7 +10,7 @@
  */
 
 #include <logging/log.h>
-LOG_MODULE_REGISTER(net_mqtt_sock_tcp, CONFIG_MQTT_LOG_LEVEL);
+LOG_MODULE_REGISTER(net_mqtt_sock_tcp, CONFIG_MQTT_SOCKET_LOG_LEVEL);
 
 #include <errno.h>
 #include <net/socket.h>

--- a/subsys/net/lib/mqtt_socket/mqtt_transport_socket_tls.c
+++ b/subsys/net/lib/mqtt_socket/mqtt_transport_socket_tls.c
@@ -10,7 +10,7 @@
  */
 
 #include <logging/log.h>
-LOG_MODULE_REGISTER(net_mqtt_sock_tls, CONFIG_MQTT_LOG_LEVEL);
+LOG_MODULE_REGISTER(net_mqtt_sock_tls, CONFIG_MQTT_SOCKET_LOG_LEVEL);
 
 #include <errno.h>
 #include <net/socket.h>


### PR DESCRIPTION
This fixes compilation of MQTT when logging is enabled by using the correct macro to set the log level.