### PR TITLE
ci: Bump version of Docker image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 // Due to JENKINS-42369 we put these defines outside the pipeline
-def IMAGE_TAG = "ncs-toolchain:1.06"
+def IMAGE_TAG = "ncs-toolchain:1.07"
 def REPO_ZEPHYR = "https://github.com/NordicPlayground/fw-nrfconnect-zephyr.git"
 def REPO_NRFXLIB = "https://github.com/NordicPlayground/nrfxlib.git"
 


### PR DESCRIPTION
New image that includes latest cmake and some updated internal tools.
Also changed cmake/ninja to be installed from pip, so it is easier
to update in the future through build scripts.

Signed-off-by: Ulrich Myhre <ulrich.solli.myhre@nordicsemi.no>