### PR TITLE
samples: esb: Fix renamed clock control instance

### DIFF
--- a/samples/esb/prx/src/main.c
+++ b/samples/esb/prx/src/main.c
@@ -96,7 +96,7 @@ int clocks_start(void)
 	int err;
 	struct device *hfclk;
 
-	hfclk = device_get_binding(CONFIG_CLOCK_CONTROL_NRF5_M16SRC_DRV_NAME);
+	hfclk = device_get_binding(CONFIG_CLOCK_CONTROL_NRF_M16SRC_DRV_NAME);
 	if (!hfclk) {
 		LOG_ERR("HF Clock device not found!");
 		return -EIO;

--- a/samples/esb/ptx/src/main.c
+++ b/samples/esb/ptx/src/main.c
@@ -60,7 +60,7 @@ int clocks_start(void)
 	int err;
 	struct device *hfclk;
 
-	hfclk = device_get_binding(CONFIG_CLOCK_CONTROL_NRF5_M16SRC_DRV_NAME);
+	hfclk = device_get_binding(CONFIG_CLOCK_CONTROL_NRF_M16SRC_DRV_NAME);
 	if (!hfclk) {
 		LOG_ERR("HF Clock device not found!");
 		return -EIO;


### PR DESCRIPTION
No longer .NRF5_ since the introduction of nRF91, now the name only
contains _NRF_.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>