### PR TITLE
ci: Switch to using fw-nrfconnect-zephyr master

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,7 +53,7 @@ pipeline {
     stage('Checkout repositories') {
       steps {
         dir("zephyr") {
-          git branch: "nrf91", url: "$REPO_ZEPHYR", credentialsId: 'github'
+          git branch: "master", url: "$REPO_ZEPHYR", credentialsId: 'github'
         }
         dir("nrfxlib") {
           git branch: "master", url: "$REPO_NRFXLIB", credentialsId: 'github'


### PR DESCRIPTION
As part of deprecating the nrf91 branch, switch to zephyr's
master in CI.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>