### PR TITLE
doc: remove mentions of nrf91 branch

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -26,8 +26,8 @@ Repositories
      - master
    * - `nrfxlib <https://github.com/NordicPlayground/nrfxlib>`_
      - master
-   * - `_fw-nrfconnect-zephyr <https://github.com/NordicPlayground/_fw-nrfconnect-zephyr>`_
-     - nrf91
+   * - `fw-nrfconnect-zephyr <https://github.com/NordicPlayground/fw-nrfconnect-zephyr>`_
+     - master
    * - `fw-nrfconnect-mcuboot <https://github.com/NordicPlayground/fw-nrfconnect-mcuboot>`_
      - master
 
@@ -37,4 +37,13 @@ Major changes
 
 The following list contains the most important changes since the last release:
 
-* n/a
+* All updates needed to develop for the nRF9160 SiP have been merged to the master branch of the fw-nrfconnect-zephyr repository.
+  The nrf91 branch will therefore be deleted in the near future.
+
+
+
+The following documentation has been added or updated:
+
+* :ref:`bt_conn_ctx_readme` (added)
+* :ref:`dk_buttons_and_leds_readme` (added)
+* :ref:`asset_tracker` (updated)

--- a/doc/nrf/gs_ins_fork.rst
+++ b/doc/nrf/gs_ins_fork.rst
@@ -58,16 +58,3 @@ To fork and clone the repositories, complete the following steps:
 .. include:: gs_ins_windows.rst
    :start-after: dirstructure_start
    :end-before: dirstructure_end
-
-To be able to build |NCS| applications for nRF91, check out branch ``nrf91`` in the fw-nrfconnect-zephyr repository:
-
-   .. code-block:: console
-
-	cd ../zephyr
-	git checkout nrf91
-
-Pull requests related to nRF91 (for example, for nRF9160 SiP or board support, drivers, and so on) in the fw-nrfconnect-zephyr repository must be submitted against the ``nrf91`` branch.
-
-.. note::
-   The ``nrf91`` branch is temporary.
-   Code changes to support the nRF9160 SiP and the nRF9160 DK board will be submitted upstream to the official Zephyr repository shortly after the v0.3.0 release.

--- a/doc/nrf/gs_ins_windows.rst
+++ b/doc/nrf/gs_ins_windows.rst
@@ -102,7 +102,7 @@ Your directory structure now looks like this::
 
 .. dirstructure_end
 
-The latest state of development is on the master branches of the fw-nrfconnect-nrf, fw-nrfconnect-mcuboot, and nrfxlib repositories and the nrf91 branch of the fw-nrfconnect-zephyr repository.
+The latest state of development is on the master branches of the repositories.
 Note that this might not be a stable state.
 Therefore, unless you are familiar with the development process, you should always work with a specific release of the |NCS|.
 

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -32,7 +32,7 @@
 .. |link_mcuboot| replace:: MCUboot
 .. _link_mcuboot: https://mcuboot.com
 
-.. _`nrf9160_pca10090_partition_conf.dts`: https://github.com/NordicPlayground/_fw-nrfconnect-zephyr/blob/nrf91/boards/arm/nrf9160_pca10090/nrf9160_pca10090_partition_conf.dts
+.. _`nrf9160_pca10090_partition_conf.dts`: https://github.com/NordicPlayground/fw-nrfconnect-zephyr/blob/master/boards/arm/nrf9160_pca10090/nrf9160_pca10090_partition_conf.dts
 
 .. _`J-Link Software and Documentation Pack`: https://www.segger.com/downloads/jlink
 


### PR DESCRIPTION
All changes on the nrf91 branch in fw-nrfconnect-zephyr have
been merged to the master branch, so there is no need to mention
the nrf91 branch anymore.

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>