### PR TITLE
drivers: gps_sim: Increase fix time range

### DIFF
--- a/drivers/gps_sim/Kconfig
+++ b/drivers/gps_sim/Kconfig
@@ -73,7 +73,7 @@ config GPS_SIM_DYNAMIC_VALUES
 
 config GPS_SIM_FIX_TIME
 	int "Time in milliseconds between position generations"
-	range 500 60000
+	range 500 3600000
 	default GPS_SIM_TRIGGER_TIMER_MSEC if GPS_SIM_TRIGGER_USE_TIMER
 	default 1000
 	help


### PR DESCRIPTION
This fix is needed to compile `asset_tracker` in power optimized mode.

---

This patch increases the fix time range to accomodate devices
running in power optimized modes, wanting long sleep time
between each sample.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>