### PR TITLE
lib: bsdlib: Fix poll() when requesting POLLERR

### DIFF
--- a/lib/bsdlib/nrf91_sockets.c
+++ b/lib/bsdlib/nrf91_sockets.c
@@ -612,7 +612,7 @@ static inline int nrf91_socket_offload_poll(struct pollfd *fds, int nfds,
 		if (tmp[i].returned & NRF_POLLOUT) {
 			fds[i].revents |= POLLOUT;
 		}
-		if (tmp[i].requested & NRF_POLLERR) {
+		if (tmp[i].returned & NRF_POLLERR) {
 			fds[i].revents |= POLLERR;
 		}
 	}


### PR DESCRIPTION
Fix nrf91_socket_offload_poll() to return correct events when
requesting POLLERR.

Signed-off-by: Stig Bjørlykke <stig.bjorlykke@nordicsemi.no>