### PR TITLE
lib: bsdlib: Do not copy POLLERR in request flags

### DIFF
--- a/lib/bsdlib/nrf91_sockets.c
+++ b/lib/bsdlib/nrf91_sockets.c
@@ -595,9 +595,6 @@ static inline int nrf91_socket_offload_poll(struct pollfd *fds, int nfds,
 		if (fds[i].events & POLLOUT) {
 			tmp[i].requested |= NRF_POLLOUT;
 		}
-		if (fds[i].events & POLLERR) {
-			tmp[i].requested |= NRF_POLLERR;
-		}
 	}
 
 	retval = nrf_poll((struct nrf_pollfd *)&tmp, nfds, timeout);


### PR DESCRIPTION
According to `poll` man pages:
POLLERR -  An error has occurred on the device or stream.
This  flag  is  only  valid  in  the revents bitmask; it
shall be ignored in the events member.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>