### PR TITLE
subsys: net: Non-blocking CoAP

### DIFF
--- a/include/net/coap_transport.h
+++ b/include/net/coap_transport.h
@@ -86,6 +86,9 @@ typedef struct {
 	 *  Otherwise ignored.
 	 */
 	coap_sec_config_t *setting;
+
+	/** Indication to do a non-blocking socket connect. */
+	u8_t non_blocking : 1;
 } coap_local_t;
 
 /**@brief Transport initialization information. */


### PR DESCRIPTION
Add an option in coap_local_t to create a non-blocking socket.
Use fcntl() to set O_NONBLOCK on the socket if this option is set.

Signed-off-by: Stig Bjørlykke <stig.bjorlykke@nordicsemi.no>