### PR TITLE
manifest: update manifest

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -34,7 +34,7 @@ manifest:
     - name: fw-nrfconnect-zephyr
       path: zephyr
       west-commands: scripts/west-commands.yml
-      revision: 236ec2d2553536835c76dff84adcb188309eaf90
+      revision: pull/98/head
     - name: fw-nrfconnect-mcuboot
       path: mcuboot
       revision: 9d9a463f68fea23a0432e8dd597b7baad4a659ed


### PR DESCRIPTION
Update manifest to point to a newer fw-nrfconnect-zephyr SHA.

Signed-off-by: Torsten Rasmussen <torsten.rasmussen@nordicsemi.no>