### PR TITLE
samples: nrf_desktop: Do not start advertising in connected state

### DIFF
--- a/samples/nrf_desktop/src/modules/ble_adv.c
+++ b/samples/nrf_desktop/src/modules/ble_adv.c
@@ -100,7 +100,7 @@ static void ble_adv_update_fn(struct k_work *work)
 				ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
 		}
 
-		if (err == -EIO) {
+		if (err == -ECONNREFUSED) {
 			LOG_WRN("Already connected, do not advertise");
 		} else if (err) {
 			LOG_ERR("Failed to restart advertising (err %d)", err);


### PR DESCRIPTION
Change complementary to
https://github.com/zephyrproject-rtos/zephyr/pull/12727

Allows application to ignore only a specific case when advertising
fails because of maximum number of connections already established.

Jira: DESK-401

Signed-off-by: Filip Kubicz <filip.kubicz@nordicsemi.no>