### PR TITLE
samples: nrf_desktop: Temporary fix for invalid USB states

### DIFF
--- a/samples/nrf_desktop/src/modules/usb_state.c
+++ b/samples/nrf_desktop/src/modules/usb_state.c
@@ -171,7 +171,9 @@ static void device_status(enum usb_dc_status_code cb_status, const u8_t *param)
 
 	switch (cb_status) {
 	case USB_DC_CONNECTED:
-		__ASSERT_NO_MSG(state == USB_STATE_DISCONNECTED);
+		if (state != USB_STATE_DISCONNECTED) {
+			LOG_WRN("USB_DC_CONNECTED when USB is not disconnected");
+		}
 		new_state = USB_STATE_POWERED;
 		break;
 
@@ -186,7 +188,9 @@ static void device_status(enum usb_dc_status_code cb_status, const u8_t *param)
 		break;
 
 	case USB_DC_RESET:
-		__ASSERT_NO_MSG(state != USB_STATE_DISCONNECTED);
+		if (state == USB_STATE_DISCONNECTED) {
+			LOG_WRN("USB_DC_RESET when USB is disconnected");
+		}
 		new_state = USB_STATE_POWERED;
 		break;
 


### PR DESCRIPTION
USB driver broadcasts invalid USB states. Until the issue is fixed there
we need to suppress out checks.

Jira:DESK-409

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>