### PR TITLE
lib: at_host: Workaround for spinning socket polling thread

### DIFF
--- a/lib/at_host/at_host.c
+++ b/lib/at_host/at_host.c
@@ -206,6 +206,13 @@ static void socket_thread_fn(void *arg1, void *arg2, void *arg3)
 		err = poll(fds, nfds, K_FOREVER);
 		if (err < 0) {
 			LOG_ERR("Poll error: %d\n", err);
+			continue;
+		} else if (err == 0) {
+			/* Workaround for incomplete implementation of poll.
+			 * TODO: Fix this when underlying issues are resolved.
+			 */
+			k_sleep(20);
+			continue;
 		}
 
 		k_mutex_lock(&socket_mutex, K_FOREVER);


### PR DESCRIPTION
Adding temporary workaround until #450 is finished and merged.

---

This patch adds a workaround that puts the socket polling function
to sleep for a short while whenever `poll()` times out. Currently,
`poll()` times out immediately, regardless of what the timeout
is set to, causing this thread to spin without yielding to
lower priority threads, such as the logging thread.

This fixes the issue where logging is not working when AT host
is enabled at the same time.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>