### PR TITLE
Add support for receiving data from cloud

### DIFF
--- a/include/nrf_cloud.h
+++ b/include/nrf_cloud.h
@@ -151,6 +151,7 @@ struct nrf_cloud_evt {
 		 *  @ref NRF_CLOUD_EVT_USER_ASSOCIATION_REQUEST event.
 		 */
 		struct nrf_cloud_ua_param ua_req;
+		struct nrf_cloud_data data;
 	} param;
 };
 

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_fsm.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_fsm.c
@@ -661,7 +661,15 @@ static int dc_connection_handler(const struct nct_evt *nct_evt)
 
 static int dc_rx_data_handler(const struct nct_evt *nct_evt)
 {
-	return 0; /* Nothing to do */
+	struct nrf_cloud_evt cloud_evt = {
+		.type = NRF_CLOUD_EVT_RX_DATA,
+		.param.data = nct_evt->param.dc->data,
+	};
+
+	/* All data is forwared to the app */
+	nfsm_set_current_state_and_notify(nfsm_get_current_state(), &cloud_evt);
+
+	return 0;
 }
 
 static int dc_tx_cnf_handler(const struct nct_evt *nct_evt)

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
@@ -236,7 +236,7 @@ static bool control_channel_topic_match(u32_t list_id,
 	}
 
 	for (u32_t index = 0; index < list_size; index++) {
-		if (!strings_compare(
+		if (strings_compare(
 			    topic->topic.utf8,
 			    topic_list[index].topic.utf8,
 			    topic->topic.size,
@@ -470,6 +470,7 @@ static void nct_mqtt_evt_handler(struct mqtt_client *const mqtt_client,
 		.status = _mqtt_evt->result
 	};
 	struct nct_cc_data cc;
+	struct nct_dc_data dc;
 	bool event_notify = false;
 
 	switch (_mqtt_evt->type) {
@@ -502,6 +503,13 @@ static void nct_mqtt_evt_handler(struct mqtt_client *const mqtt_client,
 			event_notify = true;
 		} else {
 			/* Try to match it with one of the data topics. */
+			dc.id = p->message_id;
+			dc.data.ptr = p->message.payload.data;
+			dc.data.len = p->message.payload.len;
+
+			evt.type = NCT_EVT_DC_RX_DATA;
+			evt.param.dc = &dc;
+			event_notify = true;
 		}
 
 		if (p->message.topic.qos == MQTT_QOS_1_AT_LEAST_ONCE) {


### PR DESCRIPTION
To test:
curl -X POST "https://api.nrfcloud.com/v1/devices/< client-id >/messages" -H "accept: */*" -H "Authorization: Bearer < API key >" -H "Content-Type: application/json" -d "{\"message\":{\"led\":\"on\"},\"topic\":\"d/< client-id >/c2d\"}"

For more information see: https://nrfcloud.com/#/docs/guide/nrf91
