### PR TITLE
bluetooth: hids_c: Align bt_gatt_hids_ready_check with HIDS Client API

### DIFF
--- a/include/bluetooth/services/hids_c.h
+++ b/include/bluetooth/services/hids_c.h
@@ -405,7 +405,7 @@ bool bt_gatt_hids_c_assign_check(const struct bt_gatt_hids_c *hids_c);
  * @retval false If the HIDS client is not ready.
  *
  */
-bool bt_gatt_hids_ready_check(const struct bt_gatt_hids_c *hids_c);
+bool bt_gatt_hids_c_ready_check(const struct bt_gatt_hids_c *hids_c);
 
 /**
  * @brief Send a read request addressing the report value descriptor.

--- a/include/bluetooth/services/hids_c.rst
+++ b/include/bluetooth/services/hids_c.rst
@@ -39,7 +39,7 @@ The following functions are available to retrieve the readiness state of the ser
 :cpp:func:`bt_gatt_hids_c_assign_check`
   Checks if :cpp:func:`bt_gatt_hids_c_handles_assign` was already called and the post discovery process has been started.
 
-:cpp:func:`bt_gatt_hids_ready_check`
+:cpp:func:`bt_gatt_hids_c_ready_check`
   Checks if the client object is fully ready to interact with the HID server.
   The ready flag is set just before the :cpp:type:`bt_gatt_hids_c_ready_cb` function is called.
 

--- a/samples/bluetooth/central_hids/src/main.c
+++ b/samples/bluetooth/central_hids/src/main.c
@@ -341,7 +341,7 @@ static const struct bt_gatt_hids_c_init_params hids_c_init_params = {
 
 static void button_bootmode(void)
 {
-	if (!bt_gatt_hids_ready_check(&hids_c)) {
+	if (!bt_gatt_hids_c_ready_check(&hids_c)) {
 		printk("HID device not ready\n");
 		return;
 	}
@@ -366,7 +366,7 @@ static void button_capslock(void)
 	int err;
 	u8_t data;
 
-	if (!bt_gatt_hids_ready_check(&hids_c)) {
+	if (!bt_gatt_hids_c_ready_check(&hids_c)) {
 		printk("HID device not ready\n");
 		return;
 	}
@@ -428,7 +428,7 @@ static void capslock_write_cb(struct bt_gatt_hids_c *hids_c,
 
 static void button_capslock_rsp(void)
 {
-	if (!bt_gatt_hids_ready_check(&hids_c)) {
+	if (!bt_gatt_hids_c_ready_check(&hids_c)) {
 		printk("HID device not ready\n");
 		return;
 	}

--- a/subsys/bluetooth/services/hids_c.c
+++ b/subsys/bluetooth/services/hids_c.c
@@ -827,7 +827,7 @@ bool bt_gatt_hids_c_assign_check(const struct bt_gatt_hids_c *hids_c)
 	return hids_c->conn != NULL;
 }
 
-bool bt_gatt_hids_ready_check(const struct bt_gatt_hids_c *hids_c)
+bool bt_gatt_hids_c_ready_check(const struct bt_gatt_hids_c *hids_c)
 {
 	return hids_c->ready;
 }


### PR DESCRIPTION
Rename the function to suit the rest of HIDS Client API.

Signed-off-by: Filip Kubicz <filip.kubicz@nordicsemi.no>