### PR TITLE
samples: nrf_desktop: Follow Zephyr API changes

### DIFF
--- a/samples/nrf_desktop/src/hw_interface/wheel.c
+++ b/samples/nrf_desktop/src/hw_interface/wheel.c
@@ -68,7 +68,7 @@ static void data_ready_handler(struct device *dev, struct sensor_trigger *trig)
 		wheel /= CONFIG_DESKTOP_WHEEL_SENSOR_VALUE_DIVIDER;
 	}
 
-	event->wheel = max(min(wheel, SCHAR_MAX), SCHAR_MIN);
+	event->wheel = MAX(MIN(wheel, SCHAR_MAX), SCHAR_MIN);
 
 	EVENT_SUBMIT(event);
 }

--- a/samples/nrf_desktop/src/modules/Kconfig.power_manager
+++ b/samples/nrf_desktop/src/modules/Kconfig.power_manager
@@ -12,7 +12,7 @@ config DESKTOP_POWER_MANAGER_ENABLE
 	select SYS_POWER_MANAGEMENT
 	select SYS_POWER_LOW_POWER_STATE_SUPPORTED
 	select SYS_POWER_LOW_POWER_STATE
-	select SYS_POWER_DEEP_SLEEP
+	select SYS_POWER_DEEP_SLEEP_STATES
 	select DEVICE_POWER_MANAGEMENT
 	help
 	  Enable power management, which will put the device to low-power mode

--- a/samples/nrf_desktop/src/modules/usb_state.c
+++ b/samples/nrf_desktop/src/modules/usb_state.c
@@ -98,11 +98,11 @@ static void send_mouse_report(const struct hid_mouse_event *event)
 		    REPORT_SIZE_MOUSE_BOOT];
 
 	if (hid_protocol == HID_PROTOCOL_REPORT) {
-		s16_t wheel = max(min(event->wheel, REPORT_MOUSE_WHEEL_MAX),
+		s16_t wheel = MAX(MIN(event->wheel, REPORT_MOUSE_WHEEL_MAX),
 				REPORT_MOUSE_WHEEL_MIN);
-		s16_t x = max(min(event->dx, REPORT_MOUSE_XY_MAX),
+		s16_t x = MAX(MIN(event->dx, REPORT_MOUSE_XY_MAX),
 				REPORT_MOUSE_XY_MIN);
-		s16_t y = max(min(event->dy, REPORT_MOUSE_XY_MAX),
+		s16_t y = MAX(MIN(event->dy, REPORT_MOUSE_XY_MAX),
 				REPORT_MOUSE_XY_MIN);
 		/* Convert to little-endian. */
 		u8_t x_buff[2];
@@ -122,9 +122,9 @@ static void send_mouse_report(const struct hid_mouse_event *event)
 		buffer[5] = (y_buff[1] << 4) | (y_buff[0] >> 4);
 
 	} else {
-		s8_t x = max(min(event->dx, REPORT_MOUSE_XY_MAX_BOOT),
+		s8_t x = MAX(MIN(event->dx, REPORT_MOUSE_XY_MAX_BOOT),
 				REPORT_MOUSE_XY_MIN_BOOT);
-		s8_t y = max(min(event->dy, REPORT_MOUSE_XY_MAX_BOOT),
+		s8_t y = MAX(MIN(event->dy, REPORT_MOUSE_XY_MAX_BOOT),
 				REPORT_MOUSE_XY_MIN_BOOT);
 
 		__ASSERT(sizeof(buffer) == 3, "Invalid boot report size");

--- a/samples/nrf_desktop/src/services/hids.c
+++ b/samples/nrf_desktop/src/services/hids.c
@@ -289,19 +289,19 @@ static void send_mouse_report(const struct hid_mouse_event *event)
 	int err;
 
 	if (report_mode == REPORT_MODE_BOOT) {
-		s8_t x = max(min(event->dx, SCHAR_MAX), SCHAR_MIN);
-		s8_t y = max(min(event->dy, SCHAR_MAX), SCHAR_MIN);
+		s8_t x = MAX(MIN(event->dx, SCHAR_MAX), SCHAR_MIN);
+		s8_t y = MAX(MIN(event->dy, SCHAR_MAX), SCHAR_MIN);
 
 		err = bt_gatt_hids_boot_mouse_inp_rep_send(&hids_obj, NULL,
 							   &event->button_bm,
 							   x, y,
 							   mouse_report_sent_cb);
 	} else {
-		s16_t wheel = max(min(event->wheel, REPORT_MOUSE_WHEEL_MAX),
+		s16_t wheel = MAX(MIN(event->wheel, REPORT_MOUSE_WHEEL_MAX),
 				  REPORT_MOUSE_WHEEL_MIN);
-		s16_t x = max(min(event->dx, REPORT_MOUSE_XY_MAX),
+		s16_t x = MAX(MIN(event->dx, REPORT_MOUSE_XY_MAX),
 			      REPORT_MOUSE_XY_MIN);
-		s16_t y = max(min(event->dy, REPORT_MOUSE_XY_MAX),
+		s16_t y = MAX(MIN(event->dy, REPORT_MOUSE_XY_MAX),
 			      REPORT_MOUSE_XY_MIN);
 
 		/* Convert to little-endian. */


### PR DESCRIPTION
Follow renaming of min/max and CONFIG_SYS_POWER_DEEP_SLEEP.

Needed after upmerge
https://github.com/NordicPlayground/fw-nrfconnect-zephyr/pull/99

Signed-off-by: Filip Kubicz <filip.kubicz@nordicsemi.no>