### PR TITLE
lib: bsdlib: Support poll() POLLNVAL output flag

### DIFF
--- a/lib/bsdlib/nrf91_sockets.c
+++ b/lib/bsdlib/nrf91_sockets.c
@@ -612,6 +612,9 @@ static inline int nrf91_socket_offload_poll(struct pollfd *fds, int nfds,
 		if (tmp[i].returned & NRF_POLLERR) {
 			fds[i].revents |= POLLERR;
 		}
+		if (tmp[i].returned & NRF_POLLNVAL) {
+			fds[i].revents |= POLLNVAL;
+		}
 	}
 
 	return retval;


### PR DESCRIPTION
Add POLLNVAL output flag from nrf91_socket_offload_poll().

Signed-off-by: Stig Bjørlykke <stig.bjorlykke@nordicsemi.no>