### PR TITLE
bootloader: raise error if duplicate public keys are provided

### DIFF
--- a/scripts/bootloader/provision.py
+++ b/scripts/bootloader/provision.py
@@ -71,6 +71,11 @@ def get_hashes(public_key_files):
         with open(fn, 'rb') as f:
             hashes.append(sha256(VerifyingKey.from_pem(f.read()).to_string()).digest()[:16])
         verbose_print("hash: " + hashes[-1].hex())
+
+    if len(hashes) != len(set(hashes)):
+        raise RuntimeError("Duplicate public key found. Note that the public key corresponding to the private"
+                           "key used for signing is automatically added, and must not be added explicitly.")
+
     return hashes
 
 


### PR DESCRIPTION
Ensure that the user has not provided a publicate public key as this would
waste valuable key slot space.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>