### PR TITLE
bluetooth: Fix debug dependency in DM

### DIFF
--- a/include/bluetooth/gatt_dm.h
+++ b/include/bluetooth/gatt_dm.h
@@ -302,7 +302,13 @@ int bt_gatt_dm_data_release(struct bt_gatt_dm *dm);
  *
  * @param[in] dm Discovery Manager instance
  */
+#ifdef CONFIG_BT_GATT_DM_DATA_PRINT
 void bt_gatt_dm_data_print(const struct bt_gatt_dm *dm);
+#else
+static inline void bt_gatt_dm_data_print(const struct bt_gatt_dm *dm)
+{
+}
+#endif
 
 #ifdef __cplusplus
 }

--- a/subsys/bluetooth/Kconfig.discovery
+++ b/subsys/bluetooth/Kconfig.discovery
@@ -18,10 +18,8 @@ config BT_GATT_DM_MAX_MEM_CHUNKS
 	  Maximum number of allocated memory blocks containing GATT attribute data.
 
 config BT_GATT_DM_DATA_PRINT
-	bool
-	prompt "Enable functions for printing discovery related data"
-	default y
-	select BT_DEBUG
+	bool "Enable functions for printing discovery related data"
+	depends on BT_DEBUG
 	help
 	  Enable functions for printing discovery related data
 


### PR DESCRIPTION
Discovery manager should not enable debugs by default.
Also it cannot select BT_DEBUG as it is automatically assigned
depending on BT debug level.

Jira:DESK-448

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>