### PR TITLE
manifest: Update nrfxlib and Zephyr reference

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -40,7 +40,7 @@ manifest:
       revision: d75212468ce0f88ed57a4aacac8aa07cc8a725bc
     - name: nrfxlib
       path: nrfxlib
-      revision: 608d4d9a9ea8248bd70255c4021f15cf3ec2847a
+      revision: c6a97f729d10ef12e4def970727db1aa4eff4f39
 
   self:
     path: nrf

--- a/west.yml
+++ b/west.yml
@@ -34,7 +34,7 @@ manifest:
     - name: fw-nrfconnect-zephyr
       path: zephyr
       west-commands: scripts/west-commands.yml
-      revision: a76f833d2475af488fd86583142a79580e986a4c
+      revision: a869285d262d57c382eddce928b46e3b18daa197
     - name: fw-nrfconnect-mcuboot
       path: mcuboot
       revision: d75212468ce0f88ed57a4aacac8aa07cc8a725bc


### PR DESCRIPTION
Update nrfxlib reference to include latest fix to bsdlib header.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>