### PR TITLE
[DNM] manifest: update mcuboot reference

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -37,7 +37,7 @@ manifest:
       revision: a76f833d2475af488fd86583142a79580e986a4c
     - name: fw-nrfconnect-mcuboot
       path: mcuboot
-      revision: d75212468ce0f88ed57a4aacac8aa07cc8a725bc
+      revision: 59fde9c792bfaa36887c860fb8cd0ca1f1bc4db5
     - name: nrfxlib
       path: nrfxlib
       revision: 608d4d9a9ea8248bd70255c4021f15cf3ec2847a


### PR DESCRIPTION
Updated fw-nrfconnect-mcuboot revision

[NordicPlayground/fw-nrfconnect-mcuboot#14](https://github.com/NordicPlayground/fw-nrfconnect-mcuboot/pull/14)

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>