### PR TITLE
scripts: support hashing hex files

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,3 +1,4 @@
 recommonmark==0.4.0
 git+https://github.com/carlescufi/mscgen.git@python3
 ecdsa
+intelhex


### PR DESCRIPTION
Allow hex files to be used as input
for hashing script.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>