### PR TITLE
subsys:net:lib:dfu_client: Library to download firmware objects.

### DIFF
--- a/include/download_client.h
+++ b/include/download_client.h
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/**@file download_client.h
+ *
+ * @defgroup dl_client Client to download an object.
+ * @{
+ * @brief Client to download an object.
+ */
+/* The download client provides APIs to:
+ *  - connect to a remote server
+ *  - download an object from the server
+ *  - disconnect from the server
+ *  - receive asynchronous event notification on the status of
+ *    download
+ *
+ * Currently, only the HTTP protocol is supported for download.
+ */
+
+#ifndef DOWNLOAD_CLIENT_H__
+#define DOWNLOAD_CLIENT_H__
+
+#include <zephyr/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct download_client;
+
+/** @brief Download states. */
+enum download_client_status {
+	/** Indicates that the client was either never connected
+	 *  to the server or is now disconnected.
+	 */
+	DOWNLOAD_CLIENT_STATUS_IDLE      = 0x00,
+	/** Indicates that the client is connected to the server
+	 *  and there is no ongoing download.
+	 */
+	DOWNLOAD_CLIENT_STATUS_CONNECTED = 0x01,
+	/** Indicates that the client is connected to the server
+	 *  and download is in progress.
+	 */
+	DOWNLOAD_CLIENT_STATUS_DOWNLOAD_INPROGRESS = 0x02,
+	/** Indicates that the client is connected to the server
+	 *  and download is complete.
+	 */
+	DOWNLOAD_CLIENT_STATUS_DOWNLOAD_COMPLETE = 0x03,
+	/** Indicates that the object download is halted by the
+	 *  application. This status indicates that the application
+	 *  identified a failure when handling the
+	 *  @ref DOWNLOAD_CLIENT_EVT_DOWNLOAD_FRAG event.
+	 */
+	DOWNLOAD_CLIENT_STATUS_HALTED = 0x04,
+	/** Indicates that an error occurred and the download
+	 *  cannot continue.
+	 */
+	DOWNLOAD_CLIENT_ERROR = 0xFF
+};
+
+
+/** @brief Download events. */
+enum download_client_evt {
+	/** Indicates an error during download.
+	 *  The application should disconnect and retry the operation
+	 *  when receiving this event.
+	 */
+	DOWNLOAD_CLIENT_EVT_ERROR = 0x00,
+	/** Indicates reception of a fragment during download.
+	 *  The @p fragment field of the @ref download_client object
+	 *  points to the object fragment, and the fragment size
+	 *  indicates the size of the fragment.
+	 */
+	DOWNLOAD_CLIENT_EVT_DOWNLOAD_FRAG = 0x01,
+	/** Indicates that the download is complete.
+	 */
+	DOWNLOAD_CLIENT_EVT_DOWNLOAD_DONE = 0x02,
+};
+
+/** @brief Download client asynchronous event handler.
+ *
+ * The application is notified of the status of the object download
+ * through this event handler.
+ * The application can use the return value to indicate if it handled
+ * the event successfully or not.
+ * This feedback is useful when, for example, a faulty fragment was
+ * received or the application was unable to process a object fragment.
+ *
+ * @param[in] client	The client instance.
+ * @param[in] event     The event.
+ * @param[in] status    Event status (either 0 or an errno value).
+ *
+ * @retval 0 If the event was handled successfully.
+ *           Other values indicate that the application failed to handle
+ *           the event.
+ */
+typedef int (*download_client_event_handler_t)(struct download_client *client,
+				enum download_client_evt event, u32_t status);
+
+/** @brief Object download client instance that describes the state of download.
+ */
+struct download_client {
+	/** Buffer used to receive responses from the server.
+	 *  This buffer can be read by the application if necessary,
+	 *  but must never be written to.
+	 */
+	char resp_buf[CONFIG_NRF_DOWNLOAD_MAX_RESPONSE_SIZE];
+	/** Buffer used to create requests to the server.
+	 *  This buffer can be read by the application if necessary,
+	 *  but must never be written to.
+	 */
+	char req_buf[CONFIG_NRF_DOWNLOAD_MAX_REQUEST_SIZE];
+	/** Pointer to the object fragment in @p resp_buf.
+	 *  The response from the server contains protocol metadata
+	 *  in addition to the object fragment. On every
+	 *  DOWNLOAD_CLIENT_EVT_DOWNLOAD_FRAG event, this pointer is
+	 *  updated to point to the latest object fragment.
+	 *  This pointer shall not be updated by the application.
+	 */
+	char *fragment;
+	/** Size of the fragment. The size is updated on every
+	 *  DOWNLOAD_CLIENT_EVT_DOWNLOAD_FRAG event.
+	 */
+	int fragment_size;
+	/** Transport file descriptor.
+	 *  If negative, the transport is disconnected.
+	 */
+	int fd;
+	/** Total size of the object being downloaded.
+	 * If negative, the download is in progress.
+	 * If zero, the size is unknown.
+	 */
+	int object_size;
+	/** Current size of the object being downloaded. */
+	volatile int download_size;
+	/** Status of the transfer (see @ref download_client_status). */
+	volatile int status;
+	/** Server that hosts the object. */
+	const char *host;
+	/** Resource to be downloaded. */
+	const char *resource;
+	/** Event handler. Must not be NULL. */
+	const download_client_event_handler_t callback;
+};
+
+/** @brief Initialize the download client object for a given host and resource.
+ *
+ * The server to connect to for the object download is identified by
+ * the @p host field of @p client. The @p callback field of @p client
+ * must contain an event handler.
+ *
+ * @note If this method fails, do no call any other APIs for the instance.
+ *
+ * @param[in,out] client The client instance. Must not be NULL.
+ *		      The target, host, resource, and callback fields must be
+ *		      correctly initialized in the object instance.
+ *		      The fd, status, fragment, fragment_size, download_size,
+ *                    and object_size fields are out parameters.
+ *
+ * @retval 0  If the operation was successful.
+ * @retval -1 Otherwise.
+ */
+int download_client_init(struct download_client *client);
+
+/**@brief Establish a connection to the server.
+ *
+ * The server to connect to for the object download is identified by
+ * the @p host field of @p client. The @p host field is expected to be a
+ * that can be resolved to an IP address using DNS.
+ *
+ * @note This is a blocking call.
+ *       Do not initiate a @ref download_client_start if this procedure fails.
+ *
+ * @param[in] client The client instance.
+ *
+ * @retval 0  If the operation was successful.
+ * @retval -1 Otherwise.
+ */
+int download_client_connect(struct download_client *client);
+
+/**@brief Start downloading the object.
+ *
+ * This is a blocking call used to trigger the download of an object
+ * identified by the @p resource field of @p client. The download is
+ * requested from the server in chunks of CONFIG_NRF_DOWNLOAD_MAX_FRAGMENT_SIZE.
+ *
+ * This API may be used to resume an interrupted download by setting the @p
+ * download_size field of @p client to the last successfully downloaded fragment
+ * of the object.
+ *
+ * If the API succeeds, use @ref download_client_process to advance the download
+ * until a @ref DOWNLOAD_CLIENT_EVT_ERROR or a
+ * @ref DOWNLOAD_CLIENT_EVT_DOWNLOAD_DONE event is received in the registered
+ * callback.
+ * If the API fails, disconnect using @ref download_client_disconnect, then
+ * reconnect using @ref download_client_connect and restart the procedure.
+ *
+ * @param[in] client The client instance.
+ *
+ * @retval 0  If the operation was successful.
+ * @retval -1 Otherwise.
+ */
+int download_client_start(struct download_client *client);
+
+/**@brief Advance the object download.
+ *
+ * Call this API to advance the download state identified by the @p status
+ * field of @p client. This is a blocking call. You can poll the @p fd field of
+ * @p client to decide whether to call this method.
+ *
+ * @param[in] client The client instance.
+ */
+void download_client_process(struct download_client *client);
+
+/**@brief Disconnect from the server.
+ *
+ * This API terminates the connection to the server. If called before
+ * the download is complete, it is possible to resume the interrupted transfer
+ * by reconnecting to the server using the @ref download_client_connect API and
+ * calling @ref download_client_start to continue the download.
+ * If you want to resume after a power cycle, you must store the download size
+ * persistently and supply this value in the next connection.
+ *
+ * @note You should disconnect from the server as soon as the download
+ * is complete.
+ *
+ * @param[in] client The client instance.
+ *
+ */
+void download_client_disconnect(struct download_client *client);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DOWNLOAD_CLIENT_H__ */
+
+/**@} */

--- a/include/download_client.rst
+++ b/include/download_client.rst
@@ -1,0 +1,56 @@
+.. _lib_download_client:
+
+Download client
+###############
+
+The download client library provides functions to download resources from a remote server.
+The resource could, for example, be a firmware image.
+Currently, the only supported protocol for the download is HTTP.
+
+The library is designed to download large objects like firmware images.
+However, it does not impose any requirements on the object that is being downloaded, which means that you can use the library for any kind of object, not only firmware images.
+There are also no constraints on the object if it is a firmware image.
+The image can be of any form, for example, a delta image or a full image with many merged HEX files, and there is no revision management or specification of the flash address where the image is downloaded.
+
+The size of the object to download is obtained from the server.
+The object is then downloaded in fragments of a maximum fragment size (:option:`CONFIG_NRF_DOWNLOAD_MAX_FRAGMENT_SIZE`).
+For example, if the size of the object to be downloaded is 60478 bytes and the maximum fragment size is 1024 bytes, the module downloads 60 fragments of the object; 59 fragments with a size of 1024 bytes and one fragment with a size of 62 bytes.
+If any of the download requests fail, they can be repeated.
+
+After every fragment download, a :cpp:enum:`download_client_evt` is returned, indicating if the download was successful (:cpp:member:`DOWNLOAD_CLIENT_EVT_DOWNLOAD_FRAG`), failed (:cpp:member:`DOWNLOAD_CLIENT_EVT_ERROR`), or is completed (:cpp:member:`DOWNLOAD_CLIENT_EVT_DOWNLOAD_DONE`).
+
+Make sure to configure :option:`CONFIG_NRF_DOWNLOAD_MAX_FRAGMENT_SIZE` in a way that suits your application.
+A low value causes many download requests, which can result in too much protocol overhead, while a large value requires a lot of RAM.
+
+
+Protocols
+*********
+
+The download protocol is determined from the download URI.
+Currently, only HTTP is supported.
+
+HTTP
+====
+
+For HTTP, the following requirements must be met:
+
+* The address family is IPv4.
+* TCP transport is used to communicate with the server.
+* The application protocol to communicate with the server is HTTP 1.1.
+* IETF RFC 7233 is supported by the HTTP Server.
+* :option:`CONFIG_NRF_DOWNLOAD_MAX_FRAGMENT_SIZE` is configured so that it can contain the entire HTTP response.
+
+HTTPS is not supported.
+
+The library uses the "Range" header to request firmware fragments of size :option:`CONFIG_NRF_DOWNLOAD_MAX_FRAGMENT_SIZE`.
+The firmware size is obtained from the "Content-Length" header in the response.
+To request the server to keep the TCP connection after a partial content response, the "Connection: keep-alive" header is included in the request.
+If the server response contains "Connection: close", the library automatically reconnects to the server and resumes the download.
+
+
+API documentation
+*****************
+
+.. doxygengroup:: dl_client
+   :project: nrf
+   :members:

--- a/subsys/net/lib/CMakeLists.txt
+++ b/subsys/net/lib/CMakeLists.txt
@@ -7,3 +7,4 @@
 add_subdirectory_ifdef(CONFIG_NRF_COAP_LIB coap)
 add_subdirectory_ifdef(CONFIG_MQTT_SOCKET_LIB mqtt_socket)
 add_subdirectory_ifdef(CONFIG_NRF_CLOUD nrf_cloud)
+add_subdirectory_ifdef(CONFIG_NRF_DOWNLOAD_CLIENT download_client)

--- a/subsys/net/lib/Kconfig
+++ b/subsys/net/lib/Kconfig
@@ -8,5 +8,6 @@ menu "Application protocols"
 rsource "coap/Kconfig"
 rsource "mqtt_socket/Kconfig"
 rsource "nrf_cloud/Kconfig"
+rsource "download_client/Kconfig"
 
 endmenu

--- a/subsys/net/lib/download_client/CMakeLists.txt
+++ b/subsys/net/lib/download_client/CMakeLists.txt
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2019 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+zephyr_library()
+zephyr_library_sources(
+	src/http_download_client.c
+)

--- a/subsys/net/lib/download_client/Kconfig
+++ b/subsys/net/lib/download_client/Kconfig
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2018 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+menuconfig  NRF_DOWNLOAD_CLIENT
+	bool "Download client"
+
+if NRF_DOWNLOAD_CLIENT
+config NRF_DOWNLOAD_MAX_REQUEST_SIZE
+	int "Request size"
+	default 256
+
+config NRF_DOWNLOAD_MAX_FRAGMENT_SIZE
+	int "Fragment size"
+	default 1024
+
+config NRF_DOWNLOAD_MAX_RESPONSE_SIZE
+	int "Response size"
+	default 2048
+
+endif

--- a/subsys/net/lib/download_client/src/http_download_client.c
+++ b/subsys/net/lib/download_client/src/http_download_client.c
@@ -1,0 +1,442 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <download_client.h>
+#include <net/socket.h>
+#include <zephyr/types.h>
+#include <logging/log.h>
+
+LOG_MODULE_REGISTER(http_dfu);
+
+
+#define REQUEST_TEMPLATE "GET %s HTTP/1.1\r\n"\
+	"Host: %s\r\n"\
+	"Connection: keep-alive\r\n"\
+	"Range: bytes=%d-%d\r\n\r\n"
+
+
+static int resolve_and_connect(const char *const host, const char *const port,
+					u32_t family, u32_t proto)
+{
+	int fd;
+
+	if (host == NULL) {
+		return -1;
+	}
+
+	struct addrinfo *addrinf = NULL;
+	struct addrinfo hints = {
+	    .ai_family = family,
+	    .ai_socktype = SOCK_STREAM,
+	    .ai_protocol = proto,
+	};
+
+	LOG_INF("Requesting getaddrinfo() for %s", host);
+
+	/* DNS resolve the port. */
+	int rc = getaddrinfo(host, port, &hints, &addrinf);
+
+	if (rc < 0 || (addrinf == NULL)) {
+		LOG_ERR("getaddrinfo() failed, err %d", errno);
+		return -1;
+	}
+
+	struct addrinfo *addr = addrinf;
+	struct sockaddr *remoteaddr;
+
+	int addrlen = (family == AF_INET6)
+			  ? sizeof(struct sockaddr_in6)
+			  : sizeof(struct sockaddr_in);
+
+	/* Open a socket based on the local address. */
+	fd = socket(family, SOCK_STREAM, proto);
+	if (fd >= 0) {
+		/* Look for IPv4 address of the broker. */
+		while (addr != NULL) {
+			remoteaddr = addr->ai_addr;
+
+			LOG_INF("Resolved address family %d\n",
+				addr->ai_family);
+
+			if (remoteaddr->sa_family == family) {
+				((struct sockaddr_in *)remoteaddr)->sin_port =
+					htons(80);
+
+				LOG_HEXDUMP_INF((const uint8_t *)remoteaddr,
+					addr->ai_addrlen, "Resolved addr");
+
+				/** TODO:
+				 *  Need to set security setting for HTTPS.
+				 */
+				rc = connect(fd, remoteaddr, addrlen);
+				if (rc == 0) {
+					break;
+				}
+			}
+			addr = addr->ai_next;
+		}
+	}
+
+	freeaddrinfo(addrinf);
+
+	if (rc < 0) {
+		close(fd);
+		fd = -1;
+	}
+
+	return fd;
+}
+
+static void rxdata_flush(struct download_client * const client)
+{
+	if (client == NULL || client->host == NULL ||
+		client->callback == NULL ||
+		client->status == DOWNLOAD_CLIENT_STATUS_IDLE) {
+		return;
+	}
+
+	int flush_len = recv(client->fd, client->resp_buf,
+				CONFIG_NRF_DOWNLOAD_MAX_RESPONSE_SIZE, 0);
+
+	LOG_INF("flush(): len %d\n", flush_len);
+	if (flush_len == -1) {
+		if (errno == EAGAIN) {
+			LOG_ERR("flused %d\n", flush_len);
+		} else {
+			/* Something is wrong on the socket! */
+			client->callback(client, DOWNLOAD_CLIENT_EVT_ERROR,
+					errno);
+		}
+	}
+
+	memset(client->resp_buf, 0, CONFIG_NRF_DOWNLOAD_MAX_RESPONSE_SIZE);
+}
+
+static int fragment_request(struct download_client * const client, bool flush,
+				bool connnection_close)
+{
+	if (client == NULL || client->host == NULL ||
+	    client->callback == NULL || client->resource == NULL) {
+		LOG_ERR("request(): Invalid client object!");
+		return -1;
+	}
+
+	if (flush == true) {
+		rxdata_flush(client);
+	}
+
+	if (connnection_close == true) {
+		LOG_DBG("request(): connection resume.");
+		(void)close(client->fd);
+		client->fd = -1;
+		client->fd = resolve_and_connect(client->host, NULL, AF_INET,
+					 IPPROTO_TCP);
+		if (client->fd < 0) {
+			LOG_ERR("frequest(): connect() failed, err %d",  errno);
+			client->callback(client, DOWNLOAD_CLIENT_EVT_ERROR,
+					ECONNRESET);
+			return -1;
+		}
+	}
+
+	memset(client->req_buf, 0, CONFIG_NRF_DOWNLOAD_MAX_REQUEST_SIZE);
+
+	int request_len = snprintf(client->req_buf,
+				CONFIG_NRF_DOWNLOAD_MAX_REQUEST_SIZE,
+				REQUEST_TEMPLATE, client->resource,
+				client->host, client->download_size,
+				(client->download_size +
+				CONFIG_NRF_DOWNLOAD_MAX_FRAGMENT_SIZE - 1));
+
+	LOG_INF("request(), request length %d, state = %d\n",
+		request_len, client->status);
+
+	if ((request_len > 0) &&
+		(request_len < CONFIG_NRF_DOWNLOAD_MAX_REQUEST_SIZE)) {
+
+		client->status = DOWNLOAD_CLIENT_STATUS_DOWNLOAD_INPROGRESS;
+		LOG_INF("Request: %s", client->req_buf);
+
+		int written = 0;
+
+		while ((written != request_len)) {
+			written = send(client->fd, &client->req_buf[written],
+						 (request_len - written), 0);
+			if (written <= 0) {
+				/** Could not send the whole of request.
+				 *  Cannot continue.
+				 */
+				return -1;
+			}
+		}
+
+	} else {
+		LOG_ERR("Cannot create request, buffer too small!");
+		return -1;
+	}
+
+	return 0;
+}
+
+static void request_and_notify(struct download_client * const client,
+				bool flush, bool connnection_close)
+{
+
+	if (-1 == fragment_request(client, flush, connnection_close)) {
+		client->status = DOWNLOAD_CLIENT_ERROR;
+		client->callback(client, DOWNLOAD_CLIENT_EVT_ERROR,
+					ECONNRESET);
+	}
+}
+
+int download_client_init(struct download_client * const client)
+{
+	LOG_INF("init()\n");
+
+	if (client == NULL || client->host == NULL ||
+		client->callback == NULL ||
+		client->resource == NULL) {
+		LOG_ERR("init(): Invalid client object!");
+		return -1;
+	}
+
+	client->fd = -1;
+	client->status = DOWNLOAD_CLIENT_STATUS_IDLE;
+
+	return 0;
+}
+
+int download_client_connect(struct download_client * const client)
+{
+	int fd;
+
+	if (client == NULL || client->host == NULL ||
+	    client->callback == NULL) {
+		LOG_ERR("connect(): Invalid client object!");
+		return -1;
+	}
+
+	if ((client->fd != -1) &&
+		(client->status == DOWNLOAD_CLIENT_STATUS_CONNECTED)) {
+
+		LOG_ERR("connect(): already connected, fd %d",
+			client->fd);
+		return 0;
+	}
+
+	/* TODO: Parse the post for name, port and protocol. */
+	fd = resolve_and_connect(client->host, NULL, AF_INET, IPPROTO_TCP);
+	if (fd < 0) {
+		LOG_ERR("connect(): resolve_and_connect() failed, err %d",
+			errno);
+		return -1;
+	}
+
+
+	client->fd = fd;
+	client->status = DOWNLOAD_CLIENT_STATUS_CONNECTED;
+
+	LOG_INF("connect(): Success! State %d, fd %d",
+		client->status, client->fd);
+
+	return 0;
+}
+
+void download_client_disconnect(struct download_client * const client)
+{
+	if (client == NULL || client->fd < 0) {
+		LOG_ERR("disconnect(): Invalid client object!");
+		return;
+	}
+
+	close(client->fd);
+	client->fd = -1;
+	client->status = DOWNLOAD_CLIENT_STATUS_IDLE;
+}
+
+int download_client_start(struct download_client * const client)
+{
+	if (client == NULL || client->fd < 0 ||
+		(client->status != DOWNLOAD_CLIENT_STATUS_CONNECTED)) {
+		LOG_ERR("download(): Invalid client object/state!");
+		return -1;
+	}
+
+	client->object_size = -1;
+	return fragment_request(client, false, false);
+}
+
+void download_client_process(struct download_client * const client)
+{
+	int len;
+
+	if (client == NULL || client->fd < 0 ||
+		client->status != DOWNLOAD_CLIENT_STATUS_DOWNLOAD_INPROGRESS) {
+		LOG_ERR("process(): Invalid client object/state!");
+		return;
+	}
+
+	memset(client->resp_buf, 0, sizeof(client->resp_buf));
+
+	len = recv(client->fd, client->resp_buf, sizeof(client->resp_buf),
+			MSG_PEEK);
+	LOG_DBG("process(), fd = %d, state = %d, length = %d, "
+		"errno %d\n", client->fd, client->status, len, errno);
+
+	if (len == -1) {
+		if (errno != EAGAIN) {
+			LOG_ERR("recv err errno %d!", errno);
+			client->status = DOWNLOAD_CLIENT_ERROR;
+			client->callback(client, DOWNLOAD_CLIENT_EVT_ERROR,
+				ENOTCONN);
+		}
+		return;
+	}
+	if (len == 0) {
+		LOG_ERR("recv returned 0, peer closed connection!");
+		client->status = DOWNLOAD_CLIENT_ERROR;
+		client->callback(client, DOWNLOAD_CLIENT_EVT_ERROR, ECONNRESET);
+		return;
+	}
+
+	LOG_INF("Received response of size %d", len);
+
+	int payload_size = 0;
+	int total_size = 0;
+
+	char *content_range_header = strstr(client->resp_buf,
+		"Content-Range: bytes");
+
+	if (content_range_header == NULL) {
+		/* Return and wait for the header to arrive. */
+		LOG_DBG("Wait for Content-Range header.");
+		return;
+	}
+
+	content_range_header += strlen("Content-Range: bytes");
+	char *range_str = strstr(content_range_header, " ");
+
+	if (range_str == NULL) {
+		/* Return and wait for the header to arrive. */
+		LOG_DBG("Wait for Content-Range header value.");
+		return;
+	}
+
+	int download_offest = atoi(range_str+1);
+
+	if (download_offest != client->download_size) {
+		LOG_DBG("Start download_size %d, expected %d",
+		download_offest, client->download_size);
+		/* Returned range not as expected, cannot continue. */
+		client->status = DOWNLOAD_CLIENT_ERROR;
+		client->callback(client, DOWNLOAD_CLIENT_EVT_ERROR, EFAULT);
+		return;
+	}
+
+	char *totalsize_str = strstr(content_range_header, "/");
+
+	if (totalsize_str == NULL) {
+		/* Return and wait for size to arrive. */
+		LOG_DBG("Wait for Total length.");
+		return;
+	}
+
+	total_size = atoi(totalsize_str + 1);
+	LOG_DBG("Total size %d", total_size);
+
+	char *content_length_header = strstr(client->resp_buf,
+						"Content-Length: ");
+
+	if (content_length_header == NULL) {
+		/* Return and wait for the header to arrive. */
+		LOG_DBG("Wait for Content-Length header.");
+		return;
+	}
+
+	content_length_header += strlen("Content-Length: ");
+	payload_size = atoi(content_length_header);
+
+	if (total_size)	{
+		if (client->object_size == -1) {
+			client->object_size = total_size;
+		} else  if (client->object_size != total_size) {
+			LOG_ERR("Firmware size changed from %d to %d during "
+				"download!", client->object_size, total_size);
+			client->status = DOWNLOAD_CLIENT_ERROR;
+			client->callback(client, DOWNLOAD_CLIENT_EVT_ERROR,
+			EFAULT);
+		}
+	}
+
+	/** Allow a full sized fragment, except the last one. The last one can
+	 *  be smaller.
+	 */
+	if ((payload_size != CONFIG_NRF_DOWNLOAD_MAX_FRAGMENT_SIZE) &&
+		(client->download_size + payload_size != client->object_size)) {
+		LOG_DBG("Wait for payload.");
+		return;
+	}
+
+	char *payload = strstr(client->resp_buf, "\r\n\r\n");
+	bool connection_resume = false;
+
+	if (payload == NULL) {
+		LOG_DBG("Wait for payload.");
+		return;
+	}
+	payload += strlen("\r\n\r\n");
+	int expected_payload_size = len - (int)(payload - client->resp_buf);
+
+	if (payload_size != expected_payload_size) {
+		/* Wait for entire payload. */
+		LOG_DBG("Expected payload %d, received %d\n", payload_size,
+			expected_payload_size);
+		return;
+	}
+
+	char *connnection_header = strstr(client->resp_buf, "Connection: ");
+
+	if (connnection_header != NULL) {
+		connnection_header += strlen("Connection: ");
+		char *connnection_close = strstr(connnection_header, "close");
+
+		if (connnection_close != NULL) {
+			LOG_INF("Resume TCP connection\n");
+			connection_resume = true;
+		}
+	}
+
+	/** Parse the response, send the firmware to the modem.
+	 *  And generate the right events.
+	 */
+	client->fragment = payload;
+	client->fragment_size = payload_size;
+
+	/** Continue download if application returns success,
+	 *  else, halt.
+	 */
+	if (0 ==
+	client->callback(client, DOWNLOAD_CLIENT_EVT_DOWNLOAD_FRAG, 0)) {
+
+		client->download_size += payload_size;
+
+		if (client->download_size == client->object_size) {
+			client->status =
+				DOWNLOAD_CLIENT_STATUS_DOWNLOAD_COMPLETE;
+			client->callback(client,
+				DOWNLOAD_CLIENT_EVT_DOWNLOAD_DONE,
+				0);
+			rxdata_flush(client);
+		} else {
+			request_and_notify(client, true, connection_resume);
+		}
+	} else {
+		client->download_size -= payload_size;
+		client->status = DOWNLOAD_CLIENT_STATUS_HALTED;
+	}
+}


### PR DESCRIPTION
Library to download firmware objects from a server.
The library is intended to detect the application layer protocol from the uri.
However, currently, HTTP is assumed and used for download.

Signed-off-by: Krishna Shingala <krishna.shingala@nordicsemi.no>