### PR TITLE
lib: bsdlib: Trace disabled by default

### DIFF
--- a/lib/bsdlib/Kconfig
+++ b/lib/bsdlib/Kconfig
@@ -21,7 +21,6 @@ comment "Nordic BSD Socket library configuration"
 config BSD_LIBRARY_TRACE_ENABLED
 	bool
 	prompt "Enable proprietary traces over UART"
-	default y
 	# Modem tracing over UART use the UARTE1 as dedicated peripheral.
 	# This enable UARTE1 peripheral and includes nrfx UARTE driver.
 	select NRFX_UARTE1


### PR DESCRIPTION
Enabling trace increases the power consumption.
The bsdlib trace should therefore be disabled by default and
enabled when needed.

Signed-off-by: Joakim Andre Tønnesen <joakim.tonnesen@nordicsemi.no>