### PR TITLE
samples: nrf_desktop: Suppress suspend/resume state on startup

### DIFF
--- a/samples/nrf_desktop/src/modules/usb_state.c
+++ b/samples/nrf_desktop/src/modules/usb_state.c
@@ -254,14 +254,14 @@ static void device_status(enum usb_dc_status_code cb_status, const u8_t *param)
 		__ASSERT_NO_MSG(state != USB_STATE_DISCONNECTED);
 		new_state = USB_STATE_SUSPENDED;
 		/* Not supported yet */
-		__ASSERT_NO_MSG(false);
+		LOG_WRN("USB suspend");
 		break;
 
 	case USB_DC_RESUME:
 		__ASSERT_NO_MSG(state == USB_STATE_SUSPENDED);
 		new_state = USB_STATE_POWERED;
 		/* Not supported yet */
-		__ASSERT_NO_MSG(false);
+		LOG_WRN("USB resume");
 		break;
 
 	case USB_DC_SET_HALT:


### PR DESCRIPTION
For some reason driver is suspending and immediately resuming the
USB. Application must ignore it or it will die.

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>