### PR TITLE
esb: Fix statement always true

### DIFF
--- a/subsys/enhanced_shockburst/nrf_esb.c
+++ b/subsys/enhanced_shockburst/nrf_esb.c
@@ -1269,7 +1269,7 @@ int nrf_esb_start_rx(void)
 
 int nrf_esb_stop_rx(void)
 {
-	if (esb_state != ESB_STATE_PRX || esb_state != ESB_STATE_PRX_SEND_ACK) {
+	if (esb_state != ESB_STATE_PRX && esb_state != ESB_STATE_PRX_SEND_ACK) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
The statement can only be false if esb_state has both states at the same time.