### PR TITLE
subsys: net: lib: nrf_cloud: Missing semicolon

### DIFF
--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
@@ -610,7 +610,7 @@ int af_inet_addr_pton(sa_family_t family, const char *src, void *dst)
 
 			src = ++endptr;
 		}
-	else {
+	} else {
 		return -ENOTSUP;
 	}
 


### PR DESCRIPTION
Add a missing semicolon to make it possible
to compile nrf_cloud_transport.c

Signed-off-by: Martin Lesund <martin.lesund@nordicsemi.no>