### PR TITLE
lib: bsdlib: prevent compilation if firmware is not non-secure

### DIFF
--- a/lib/bsdlib/CMakeLists.txt
+++ b/lib/bsdlib/CMakeLists.txt
@@ -5,5 +5,6 @@
 #
 zephyr_library()
 zephyr_library_sources(bsd_os.c)
+zephyr_library_sources(bsd_sanity.c)
 zephyr_library_sources(nrf91_sockets.c)
 zephyr_library_include_directories(.)

--- a/lib/bsdlib/Kconfig
+++ b/lib/bsdlib/Kconfig
@@ -10,7 +10,7 @@ config BSD_LIBRARY
 	prompt "Use BSD Socket library for IP/TLS/DTLS"
 	select FLOAT
 	select NET_RAW_MODE
-	depends on CPU_CORTEX_M33
+	depends on TRUSTED_EXECUTION_NONSECURE
 	help
 	  Use Nordic BSD Socket library.
 

--- a/lib/bsdlib/bsd_sanity.c
+++ b/lib/bsdlib/bsd_sanity.c
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#ifndef CONFIG_TRUSTED_EXECUTION_NONSECURE
+#error  bsdlib must be run as non-secure firmware.\
+	Are you building for the correct board ?
+#endif

--- a/samples/nrf9160/mqtt_simple/sample.yaml
+++ b/samples/nrf9160/mqtt_simple/sample.yaml
@@ -4,5 +4,5 @@ tests:
   test_build:
     build_only: true
     build_on_all: true
-    platform_whitelist: nrf9160_pca10090
+    platform_whitelist: nrf9160_pca10090ns
     tags: ci_build


### PR DESCRIPTION
bsdlib requires to be run from non-secure firmware.
Emit a very clear error message and abort compilation if a project
that does not define CONFIG_TRUSTED_EXECUTION_NONSECURE tries to
compile bsdlib glue files.

The rationale for this change is to make it easy to prevent
the situation where a project that uses bsdlib is compiled for
the wrong board, e.g. nrf9160_pca10090 instead of the non-secure
variant nrf9160_pca10090ns. The project would compile just fine
and run into a hard-fault at runtime, or emit a cryptic or
seemingly unrelated error during compilation.