### PR TITLE
build: Switch to using Zephyr modules to include the repo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,14 +4,12 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
+# Point to NCS root directory.
+set(NRF_DIR ${CMAKE_CURRENT_LIST_DIR})
+
 zephyr_include_directories(include)
 
 add_subdirectory(ext)
 add_subdirectory(lib)
 add_subdirectory(subsys)
 add_subdirectory(drivers)
-
-# Add the mandatory nrfxlib repository
-set(               NRFXLIB_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../nrfxlib)
-assert_exists(     NRFXLIB_DIR)
-add_subdirectory(${NRFXLIB_DIR} ${PROJECT_BINARY_DIR}/nrfxlib)

--- a/Kconfig.nrf
+++ b/Kconfig.nrf
@@ -11,6 +11,4 @@ rsource "lib/Kconfig"
 rsource "drivers/Kconfig"
 rsource "ext/Kconfig"
 
-orsource "../nrfxlib/Kconfig.nrfxlib"
-
 endmenu

--- a/cmake/boilerplate.cmake
+++ b/cmake/boilerplate.cmake
@@ -4,6 +4,9 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
+# Point to NCS root directory.
+set(NRF_DIR ${CMAKE_CURRENT_LIST_DIR}/..)
+
 if(NOT BOARD)
         set(BOARD $ENV{BOARD})
 endif()
@@ -21,9 +24,6 @@ if(DEFINED NRF_SUPPORTED_BUILD_TYPES)
                 message(FATAL_ERROR "${CMAKE_BUILD_TYPE} variant is not supported")
         endif()
 endif()
-
-# Point to NCS root directory.
-set(NRF_DIR ${CMAKE_CURRENT_LIST_DIR}/..)
 
 # Set BOARD_ROOT if board definition exists out of tree.
 find_path(_BOARD_DIR NAMES "${BOARD}_defconfig" PATHS ${NRF_DIR}/boards/*/*

--- a/west.yml
+++ b/west.yml
@@ -34,13 +34,13 @@ manifest:
     - name: fw-nrfconnect-zephyr
       path: zephyr
       west-commands: scripts/west-commands.yml
-      revision: 745326266d9c32ba3aa67d5af1f727059d9a88e3
+      revision: 578dac80f7c3bafb3d0e98c0c31b072139251395
     - name: fw-nrfconnect-mcuboot
       path: mcuboot
       revision: 59fde9c792bfaa36887c860fb8cd0ca1f1bc4db5
     - name: nrfxlib
       path: nrfxlib
-      revision: cb70ca85c86a61edc55d4faeaf48d6874dfd553c
+      revision: d98b59bdff2b533f5afb7bdad229eaeb4a931882
 
   self:
     path: nrf

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,3 @@
+build:
+  cmake: .
+  kconfig: Kconfig.nrf


### PR DESCRIPTION
In order to include the repository in the Zephyr build, we used to rely
on a custom hook in the zephyr repository's root CMakeLists.txt and
Kconfig.zephyr files. Now that Zephyr natively supports external
modules, use this mechanism to include nrf in the Zephyr build.
This implies that we no longer need to include nrfxlib from the nrf
repository, since that is done automatically by Zephyr's build system
through a separate commit in nrfxlib.

Includes the corresponding update to west.yml in order to switch to the
correct zephyr and nrfxlib revisions.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>