### PR TITLE
manifest: Update nrfxlib reference

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -40,7 +40,7 @@ manifest:
       revision: 59fde9c792bfaa36887c860fb8cd0ca1f1bc4db5
     - name: nrfxlib
       path: nrfxlib
-      revision: f1c37d3c78062ec517c2db303cad5a2a2d98c347
+      revision: cb70ca85c86a61edc55d4faeaf48d6874dfd553c
 
   self:
     path: nrf


### PR DESCRIPTION
Update nrfxlib commit hash, to include recently merged bsdlib
upgrade.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>