### PR TITLE
subsys: bluetooth: gatt_dm: Properly process bad conn object error

### DIFF
--- a/subsys/bluetooth/gatt_dm.c
+++ b/subsys/bluetooth/gatt_dm.c
@@ -388,6 +388,7 @@ static u8_t discovery_callback(struct bt_conn *conn,
 
 	if (conn != bt_gatt_dm_inst.conn) {
 		LOG_ERR("Unexpected conn object. Aborting.");
+		discovery_complete_error(&bt_gatt_dm_inst, -EFAULT);
 		return BT_GATT_ITER_STOP;
 	}
 


### PR DESCRIPTION
If the invalid connection object response is received
the gatt_dm sholuld properly process this error to avoid
deadlock in the code in such situation.
This commit fixes the code for such situation.

Signed-off-by: Radoslaw Koppel <radoslaw.koppel@nordicsemi.no>