### PR TITLE
subsys: bootloader: Fix after renamings in Zephyr

### DIFF
--- a/subsys/bootloader/bootloader.c
+++ b/subsys/bootloader/bootloader.c
@@ -147,7 +147,7 @@ static void boot_from(u32_t *address)
 	CODE_UNREACHABLE;
 }
 
-void _Cstart(void) __attribute__((alias("main_bl")));
+void z_cstart(void) __attribute__((alias("main_bl")));
 void main_bl(void)
 {
 #if defined(CONFIG_SB_DEBUG_PORT_SEGGER_RTT)

--- a/subsys/bootloader/c_runtime_setup/CMakeLists.txt
+++ b/subsys/bootloader/c_runtime_setup/CMakeLists.txt
@@ -42,6 +42,6 @@ target_include_directories(
 
 add_library(kernel_init STATIC ${ZEPHYR_BASE}/kernel/init.c)
 target_link_libraries(kernel_init zephyr_interface libc)
-target_compile_definitions(kernel_init PRIVATE _Cstart=UNUSED_Cstart)
+target_compile_definitions(kernel_init PRIVATE z_cstart=UNUSED_z_cstart)
 add_dependencies(kernel_init offsets_h)
 target_link_libraries(c_runtime_setup PRIVATE kernel_init)

--- a/subsys/bootloader/fw_metadata/fw_metadata.c
+++ b/subsys/bootloader/fw_metadata/fw_metadata.c
@@ -10,7 +10,7 @@ extern const u32_t _image_rom_start;
 extern const u32_t _flash_used;
 
 const struct fw_firmware_info m_firmware_info
-_GENERIC_SECTION(.firmware_info)
+Z_GENERIC_SECTION(.firmware_info)
 __attribute__((used)) = {
 	.magic = {FIRMWARE_INFO_MAGIC},
 	.firmware_size = (u32_t)&_flash_used,


### PR DESCRIPTION
_GENERIC_SECTION -> Z_GENERIC_SECTION
_Cstart -> z_cstart

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>