### PR TITLE
samples: nrf_desktop: Handle multiple USB suspend/reset/resume

### DIFF
--- a/samples/nrf_desktop/src/events/usb_event.c
+++ b/samples/nrf_desktop/src/events/usb_event.c
@@ -14,6 +14,7 @@
 static const char * const state_name[] = {
 	[USB_STATE_DISCONNECTED] = "DISCONNECTED",
 	[USB_STATE_POWERED]      = "POWERED",
+	[USB_STATE_IDLE]	 = "IDLE",
 	[USB_STATE_ACTIVE]       = "ACTIVE",
 	[USB_STATE_SUSPENDED]    = "SUSPENDED"
 };

--- a/samples/nrf_desktop/src/events/usb_event.h
+++ b/samples/nrf_desktop/src/events/usb_event.h
@@ -30,6 +30,7 @@ extern "C" {
 enum usb_state {
 	USB_STATE_DISCONNECTED, /**< Cable is not attached. */
 	USB_STATE_POWERED,      /**< Cable attached but no communication. */
+	USB_STATE_IDLE,		/**< Cable attached but no communication. */
 	USB_STATE_ACTIVE,       /**< Cable attached and data is exchanged. */
 	USB_STATE_SUSPENDED,    /**< Cable attached but port is suspended. */
 

--- a/samples/nrf_desktop/src/modules/usb_state.c
+++ b/samples/nrf_desktop/src/modules/usb_state.c
@@ -239,15 +239,17 @@ static void device_status(enum usb_dc_status_code cb_status, const u8_t *param)
 		break;
 
 	case USB_DC_CONFIGURED:
-		__ASSERT_NO_MSG(state == USB_STATE_POWERED);
+		__ASSERT_NO_MSG(state != USB_STATE_DISCONNECTED);
 		new_state = USB_STATE_ACTIVE;
 		break;
 
 	case USB_DC_RESET:
-		if (state == USB_STATE_DISCONNECTED) {
-			LOG_WRN("USB_DC_RESET when USB is disconnected");
+		__ASSERT_NO_MSG(state != USB_STATE_DISCONNECTED);
+		if (state == USB_STATE_SUSPENDED) {
+			LOG_WRN("USB reset in suspended state, ignoring");
+		} else {
+			new_state = USB_STATE_IDLE;
 		}
-		new_state = USB_STATE_POWERED;
 		break;
 
 	case USB_DC_SUSPEND:
@@ -259,7 +261,7 @@ static void device_status(enum usb_dc_status_code cb_status, const u8_t *param)
 
 	case USB_DC_RESUME:
 		__ASSERT_NO_MSG(state == USB_STATE_SUSPENDED);
-		new_state = USB_STATE_POWERED;
+		new_state = USB_STATE_IDLE;
 		/* Not supported yet */
 		LOG_WRN("USB resume");
 		break;


### PR DESCRIPTION
USB stack can send excess suspend/resume state changes. In case of
suspend, we need to disconnect HID subscriber, or the subscriber will be
connected twice, breaking the HID communication.

Jira: DESK-478

Signed-off-by: Filip Kubicz <filip.kubicz@nordicsemi.no>