### PR TITLE
boards: arm: nrf9160_pca20035: Increase charge current

### DIFF
--- a/boards/arm/nrf9160_pca20035/board_nonsecure.c
+++ b/boards/arm/nrf9160_pca20035/board_nonsecure.c
@@ -212,8 +212,14 @@ static int power_mgmt_init(void)
 		return err;
 	}
 
-	/* The value 0x09 corresponds to 100 mA charging current. */
-	err = adp536x_charger_current_set(0x09);
+	/* The value 0x1F corresponds to 320 mA charging current. */
+	err = adp536x_charger_current_set(0x1F);
+	if (err) {
+		return err;
+	}
+
+	/* The value 0x07 corresponds to a 400 mA peak charge current. */
+	err = adp536x_oc_chg_current_set(0x07);
 	if (err) {
 		return err;
 	}

--- a/drivers/adp536x/adp536x.c
+++ b/drivers/adp536x/adp536x.c
@@ -23,6 +23,7 @@
 #define ADP536X_CHG_STATUS_1				0x08
 #define ADP536X_CHG_STATUS_2				0x09
 #define ADP536X_BAT_PROTECT_CTRL			0x11
+#define ADP536X_BAT_OC_CHG				0x15
 #define ADP536X_BUCK_OUTPUT				0x2A
 #define ADP536X_BUCKBST_CFG				0x2B
 #define ADP536X_BUCKBST_OUTPUT				0x2C
@@ -105,6 +106,11 @@
 #define ADP536X_BAT_PROTECT_CTRL_EN_CHGLB(x)		(((x) & 0x01) << 1)
 #define ADP536X_BAT_PROTECT_CTRL_EN_BATPRO_MSK		BIT(0)
 #define ADP536X_BAT_PROTECT_CTRL_EN_BATPRO(x)		((x) & 0x01)
+
+#define ADP536X_BAT_OC_CHG_OC_CHG_MSK			GENMASK(7, 5)
+#define ADP536X_BAT_OC_CHG_OC_CHG(x)			(((x) & 0x07) << 5)
+#define ADP536X_BAT_OC_CHG_DGT_OC_CHG_MSK		GENMASK(4, 3)
+#define ADP536X_BAT_OC_CHG_DGT_OC_CHG(x)		(((x) & 0x03) << 3)
 
 /* Buck output voltage setting register. */
 #define ADP536X_BUCK_OUTPUT_VOUT_BUCK_MSK		GENMASK(5, 0)
@@ -214,6 +220,13 @@ int adp536x_oc_chg_hiccup_set(bool enable)
 	return adp536x_reg_write_mask(ADP536X_BAT_PROTECT_CTRL,
 				ADP536X_BAT_PROTECT_CTRL_OC_CHG_HICCUP_MSK,
 				ADP536X_BAT_PROTECT_CTRL_OC_CHG_HICCUP(enable));
+}
+
+int adp536x_oc_chg_current_set(u8_t value)
+{
+	return adp536x_reg_write_mask(ADP536X_BAT_OC_CHG,
+					ADP536X_BAT_OC_CHG_OC_CHG_MSK,
+					ADP536X_BAT_OC_CHG_OC_CHG(value));
 }
 
 int adp536x_buck_1v8_set(void)

--- a/include/drivers/adp536x.h
+++ b/include/drivers/adp536x.h
@@ -19,3 +19,4 @@ int adp536x_buckbst_enable(bool enable);
 int adp536x_buck_1v8_set(void);
 int adp536x_buckbst_3v3_set(void);
 int adp536x_factory_reset(void);
+int adp536x_oc_chg_current_set(u8_t value);


### PR DESCRIPTION
The ADP536X API is expanded to set the OC_CHG register.

The OC_CHG register is set to a maximum value of 400mA.
The charge current is increased to 320 mA.