### PR TITLE
bluetooth: services: nus: Fix on_sent callback not being called

### DIFF
--- a/include/bluetooth/services/nus.h
+++ b/include/bluetooth/services/nus.h
@@ -39,8 +39,7 @@ typedef void (*nus_received_cb_t)(struct bt_conn *conn,
 				  const u8_t *const data, u16_t len);
 
 /** @brief Callback type for data sent. */
-typedef void (*nus_sent_cb_t)(struct bt_conn *conn,
-			      const u8_t *data, u16_t len);
+typedef void (*nus_sent_cb_t)(struct bt_conn *conn);
 
 /** @brief Pointers to the callback functions for service events. */
 struct bt_gatt_nus_cb {


### PR DESCRIPTION
Sent_cb was never called because it was wrongly used inside
the service. Change triggered change of api since callback
prototype has changed.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>