### PR TITLE
secure_boot: add special handling when configuring NRF_GPIOTE

### DIFF
--- a/samples/nrf9160/secure_boot/src/main.c
+++ b/samples/nrf9160/secure_boot/src/main.c
@@ -263,9 +263,13 @@ static int secure_boot_config_peripheral(u8_t id, bool dma_present)
 	 *
 	 * Note: the function assumes that the peripheral ID matches
 	 * the IRQ line.
+	 *
+	 * Note2: NRF_GPIOTE1_NS needs special handling as its
+	 * peripheral ID for non-secure han incorrect properties
+	 * in the NRF_SPM->PERIPHID[id].perm register.
 	 */
-
-	if (!usel_or_split(id)) {
+	if (id != NRFX_PERIPHERAL_ID_GET(NRF_GPIOTE1_NS) &&
+	    !usel_or_split(id)) {
 		return -1;
 	}
 


### PR DESCRIPTION
The device ID for the _S and _NS version of NRF_GPIOTE
are different.  0x5000D000 for secure and 0x40031000 for
non-secure. Also, the values for NRF_SPM->PERIPHID[].PERM
are different for the two different IDs (0x0D and 0x31).
For non-secure all fields in register ID A, B, C, D and E are
set to 0. This results in an error when calling `usel_or_split`
with the non-secure ID.

This change works around this by adding special handling
for NRF_GPIOTE_NS.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>