### PR TITLE
manifest: update mcuboot reference

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -40,7 +40,7 @@ manifest:
       revision: 0bf5263b0522bb5cfac84eefdfdee86dc2c67e3e
     - name: fw-nrfconnect-mcuboot
       path: mcuboot
-      revision: 59fde9c792bfaa36887c860fb8cd0ca1f1bc4db5
+      revision: 73d4cd12928fb53930e7bcbe6c376b7c797317bf
     - name: nrfxlib
       path: nrfxlib
       revision: 9bcc77b27d12162adc31d8c8c70f4e499338fbdb


### PR DESCRIPTION
Updated mcuboot reference to new one.

[NordicPlayground/fw-nrfconnect-mcuboot#17](https://github.com/NordicPlayground/fw-nrfconnect-mcuboot/pull/17)

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>