### PR TITLE
docs: Links between docs

### DIFF
--- a/include/event_manager.rst
+++ b/include/event_manager.rst
@@ -16,7 +16,7 @@ Listeners can process events differently based on their type.
 You can easily define custom event types for your application.
 Currently, up to 32 event types can be used in an application.
 
-You can use the Profiler (see ``include/profiler.h``) to observe the propagation of an event in the system, view the data connected with the event, or create statistics.
+You can use the :ref:`profiler` to observe the propagation of an event in the system, view the data connected with the event, or create statistics.
 A shell integration is available to display additional information and to dynamically enable or disable logging for given event types.
 
 See the :ref:`event_manager_sample` sample for an example on how to use the Event Manager.
@@ -212,7 +212,7 @@ The following code example shows how to register an event listener with an event
 Profiling an event
 ******************
 
-Event Manager events can be profiled (see ``include/profiler.h``).
+Event Manager events can be profiled (see :ref:`profiler`).
 To profile a given Event Manager event, you must define an :cpp:class:`event_info` structure (with :c:macro:`EVENT_INFO_DEFINE`) and provide it as argument when defining the event type.
 This structure contains a profiling function and information about the data fields that are logged.
 

--- a/include/profiler.rst
+++ b/include/profiler.rst
@@ -11,6 +11,7 @@ The output is provided via RTT and can be visualized in `SEGGER SystemView`_ or 
 
 	Currently, you can register and profile up to 32 event types.
 
+See the :ref:`profiler_sample` sample for an example on how to use the Profiler.
 
 Configuration
 *************

--- a/samples/profiler/README.rst
+++ b/samples/profiler/README.rst
@@ -3,13 +3,13 @@
 Profiler
 ########
 
-The Profiler sample demonstrates the functionality of the Profiler subsystem.
+The Profiler sample demonstrates the functionality of the :ref:`profiler` subsystem.
 It shows how to use the Profiler to log and visualize data about custom events that are not part of the :ref:`event_manager`.
 
 Overview
 ********
 
-The sample initializes the Profiler, registers two event types, and profiles their occurrences periodically.
+The sample initializes the :ref:`profiler`, registers two event types, and profiles their occurrences periodically.
 
 Event without data (``no data event``):
   This event is used to signal the occurrence of an event only.
@@ -57,4 +57,4 @@ Dependencies
 
 This sample uses the following |NCS| subsystems:
 
-* profiler
+* :ref:`profiler`


### PR DESCRIPTION
Change adds missing links between docs for the Event Manager and Profiler.