### PR TITLE
samples: nrf_desktop: Connect USB subscriber only if absent

### DIFF
--- a/samples/nrf_desktop/src/modules/hid_state.c
+++ b/samples/nrf_desktop/src/modules/hid_state.c
@@ -978,7 +978,9 @@ static bool event_handler(const struct event_header *eh)
 
 			switch (event->state) {
 			case USB_STATE_POWERED:
-				connect_subscriber(event->id, true);
+				if (!get_subscriber_by_type(true)) {
+					connect_subscriber(event->id, true);
+				}
 				break;
 			case USB_STATE_DISCONNECTED:
 				disconnect_subscriber(event->id);


### PR DESCRIPTION
Jira:DESK-478

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>