### PR TITLE
net: Clear `hints` structure before use in `getaddrinfo`

### DIFF
--- a/samples/nrf9160/coap_client/src/main.c
+++ b/samples/nrf9160/coap_client/src/main.c
@@ -52,12 +52,10 @@ static int server_resolve(void)
 {
 	int err;
 	struct addrinfo *result;
-	struct addrinfo hints;
-
-	hints.ai_flags = 0;
-	hints.ai_family = AF_INET;
-	hints.ai_socktype = SOCK_DGRAM;
-	hints.ai_protocol = 0;
+	struct addrinfo hints = {
+		.ai_family = AF_INET,
+		.ai_socktype = SOCK_DGRAM
+	};
 
 	err = getaddrinfo(CONFIG_COAP_SERVER_HOSTNAME, NULL, &hints, &result);
 	if (err != 0) {

--- a/samples/nrf9160/mqtt_simple/src/main.c
+++ b/samples/nrf9160/mqtt_simple/src/main.c
@@ -219,12 +219,10 @@ static void broker_init(void)
 	int err;
 	struct addrinfo *result;
 	struct addrinfo *addr;
-	struct addrinfo hints;
-
-	hints.ai_flags = 0;
-	hints.ai_family = AF_INET;
-	hints.ai_socktype = SOCK_STREAM;
-	hints.ai_protocol = 0;
+	struct addrinfo hints = {
+		.ai_family = AF_INET,
+		.ai_socktype = SOCK_STREAM
+	};
 
 	err = getaddrinfo(CONFIG_MQTT_BROKER_HOSTNAME, NULL, &hints, &result);
 	if (err) {

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
@@ -640,12 +640,10 @@ int nct_connect(void)
 	int err;
 	struct addrinfo *result;
 	struct addrinfo *addr;
-	struct addrinfo hints;
-
-	hints.ai_flags = 0;
-	hints.ai_family = NRF_CLOUD_AF_FAMILY;
-	hints.ai_socktype = SOCK_STREAM;
-	hints.ai_protocol = 0;
+	struct addrinfo hints = {
+		.ai_family = NRF_CLOUD_AF_FAMILY,
+		.ai_socktype = SOCK_STREAM
+	};
 
 	err = getaddrinfo(NRF_CLOUD_HOSTNAME, NULL, &hints, &result);
 	if (err) {


### PR DESCRIPTION
Unused fields of the `hints` structure for `getaddrinfo` function should be either 0 or NULL according to the man pages.

This became especially important, as bsdlib now verifies one of the non-standard fields (ai_next). Not having it cleared results in a crash.
