### PR TITLE
event_manager: Use slist for chaining events

### DIFF
--- a/include/event_manager.h
+++ b/include/event_manager.h
@@ -61,7 +61,7 @@ extern "C" {
  */
 struct event_header {
 	/** Linked list node used to chain events. */
-	sys_dlist_t node;
+	sys_snode_t node;
 
 	/** Pointer to the event type object. */
 	const struct event_type *type_id;


### PR DESCRIPTION
Single linked list is enough to handle events chaining
as list is traversed in one direction only. This change
reduces the memory footprint of each event.

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>