### PR TITLE
subsys: spm: fix wrong comment

### DIFF
--- a/subsys/spm/spm.c
+++ b/subsys/spm/spm.c
@@ -10,7 +10,7 @@
 #include <gpio.h>
 
 #if !defined(CONFIG_ARM_SECURE_FIRMWARE)
-#error "Sample requires compiling for Secure ARM Firmware"
+#error "Module requires compiling for Secure ARM Firmware"
 #endif
 
 /* Include required APIs for TrustZone-M */


### PR DESCRIPTION
SPM is now a sub-system (module) instead of a sample,
therfore, update a related comment in spm.c.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>