### PR TITLE
[DNM] samples: nrf_desktop: Pass MCUBoot overlay file to cmake explicitly

### DIFF
--- a/samples/nrf_desktop/CMakeLists.txt
+++ b/samples/nrf_desktop/CMakeLists.txt
@@ -136,7 +136,7 @@ if (${CONFIG_BOOTLOADER_MCUBOOT})
     -G${CMAKE_GENERATOR}
     -DBOARD=${BOARD}
     -DBOARD_ROOT="${BOARD_ROOT_STR}"
-    -DDTC_OVERLAY_FILE="${CMAKE_CURRENT_SOURCE_DIR}/configuration/${BOARD}/flash.overlay"
+    -DDTC_OVERLAY_FILE="${CMAKE_CURRENT_SOURCE_DIR}/configuration/${BOARD}/flash.overlay ${MCUBOOT_DIR}/boot/zephyr/dts.overlay"
     -DCONF_FILE="${CMAKE_CURRENT_SOURCE_DIR}/configuration/${BOARD}/mcuboot_${CMAKE_BUILD_TYPE}.conf"
     COMMENT
     "Generating bootloader for application in mcuboot folder"


### PR DESCRIPTION
This is a temporary workaround which prevents linking bootloader to
slot0 partition until
https://github.com/zephyrproject-rtos/zephyr/issues/15083 will be fixed.

Signed-off-by: Filip Kubicz <filip.kubicz@nordicsemi.no>