### PR TITLE
doc: Remove use of VERSION in CMakeLists.txt

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.8.2)
-project(nrf-connect-sdk-doc VERSION ${PROJECT_VERSION} LANGUAGES)
+cmake_minimum_required(VERSION 3.13.1)
+project(nrf-connect-sdk-doc LANGUAGES)
 
 set(ZEPHYR_BASE $ENV{ZEPHYR_BASE})
 get_filename_component(NRF_BASE ${CMAKE_CURRENT_LIST_DIR}../ DIRECTORY)


### PR DESCRIPTION
This is obsolete and has no purpose, remove it to get rid of a warning.
Also bump up the CMake version requirement to match Zephyr's.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>