### PR TITLE
[DNM] manifest: update mcuboot reference

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -41,7 +41,7 @@ manifest:
       revision: 3757f8cfe6ffe2c2b537815bb9ca1ace85882df8
     - name: fw-nrfconnect-mcuboot
       path: mcuboot
-      revision: 0e68ab46461cfe62a6db342cbd69a08aac01d82d
+      revision: 40ab097e616bcd393fc7afccce7704c76f5c6c4e
     - name: nrfxlib
       path: nrfxlib
       revision: 9bcc77b27d12162adc31d8c8c70f4e499338fbdb


### PR DESCRIPTION
Updated mcuboot reference to new one.

counterpart to https://github.com/NordicPlayground/fw-nrfconnect-mcuboot/pull/21

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>