### PR TITLE
samples: nrf9160: mqtt_simple: Check poll events

### DIFF
--- a/samples/nrf9160/mqtt_simple/CMakeLists.txt
+++ b/samples/nrf9160/mqtt_simple/CMakeLists.txt
@@ -6,6 +6,7 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
+include(../../../cmake/boilerplate.cmake NO_POLICY_SCOPE)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(mqtt-simple)
 


### PR DESCRIPTION
This patch adds checking of poll events to check if the socket
is ready for the next operation, either send or receive.
It's also checked for POLLERR and POLLNVAL flags to catch
error conditions.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>