### PR TITLE
manifest: update fw-nrfconnect-zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -38,7 +38,7 @@ manifest:
     - name: fw-nrfconnect-zephyr
       path: zephyr
       west-commands: scripts/west-commands.yml
-      revision: 156cc434efb7e0d94a70887207fecc189e2b0c4f
+      revision: d70aa052bc4b333e97a36b4e5832a8509b4aa417
     - name: fw-nrfconnect-mcuboot
       path: mcuboot
       revision: 0341ae4f75e22e18aae9dfa42dd104e3352cf2b4


### PR DESCRIPTION
Update fw-nrfconnect-zephyr revision to the latest master to include
https://github.com/NordicPlayground/fw-nrfconnect-zephyr/pull/124

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>