### PR TITLE
manifest update fw-nrfconnect-mcuboot

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -41,7 +41,7 @@ manifest:
       revision: d70aa052bc4b333e97a36b4e5832a8509b4aa417
     - name: fw-nrfconnect-mcuboot
       path: mcuboot
-      revision: 0341ae4f75e22e18aae9dfa42dd104e3352cf2b4
+      revision: 6168414cb103f97b016160396ccc88d9ed45d457
     - name: nrfxlib
       path: nrfxlib
       revision: 45475200c1c89f31d0398574e4657db99dc89940


### PR DESCRIPTION
Include fix for setting default board.

See https://github.com/NordicPlayground/fw-nrfconnect-mcuboot/pull/23

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>