### PR TITLE
lib: bsdlib: Remove k_sleep hacks used with AT sockets

### DIFF
--- a/drivers/lte_link_control/lte_lc.c
+++ b/drivers/lte_link_control/lte_lc.c
@@ -149,7 +149,6 @@ static int w_lte_lc_init_and_connect(struct device *unused)
 				break;
 			}
 		}
-		k_sleep(K_MSEC(10));
 	}
 
 	close(at_socket_fd);

--- a/lib/modem_info/modem_info.c
+++ b/lib/modem_info/modem_info.c
@@ -437,10 +437,6 @@ static void modem_info_rsrp_subscribe_thread(void *arg1, void *arg2, void *arg3)
 		if (err < 0) {
 			LOG_ERR("Poll error: %d\n", err);
 			continue;
-		} else if (err == 0) {
-			LOG_DBG("Timeout");
-			k_sleep(200);
-			continue;
 		}
 
 		k_mutex_lock(&socket_mutex, K_FOREVER);
@@ -493,4 +489,3 @@ int modem_info_init(void)
 
 	return err;
 }
-


### PR DESCRIPTION
As an implementation of `bsd_os_timedwait` is now available, we can get
rid of k_sleep hacks around the code, which were introduced to mitigate
the problems caused by lack of this implementation.

For now, remove hacks from code that uses AT sockets. Other types
(STREAM/DGRAM) of sockets have to wait until internal bsdlib issues are
resolved.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>