### PR TITLE
samples: nrf9160: coap_client: check for poll events

### DIFF
--- a/samples/nrf9160/coap_client/src/main.c
+++ b/samples/nrf9160/coap_client/src/main.c
@@ -264,8 +264,8 @@ void main(void)
 
 		s64_t remaining = next_tick_time - k_uptime_get();
 
-		if (remaining <= 0) {
-			remaining = 1;
+		if (remaining < 0) {
+			remaining = 0;
 		}
 
 		if (wait(remaining) > 0) {


### PR DESCRIPTION
Some improvements in `poll` handling for `coap_client`.