### PR TITLE
lib: at_host: Increase the rx buffer

### DIFF
--- a/lib/at_host/Kconfig
+++ b/lib/at_host/Kconfig
@@ -72,7 +72,7 @@ config AT_HOST_THREAD_PRIO
 
 config AT_HOST_SOCKET_BUF_SIZE
 	int "AT socket Rx buffer size"
-	default 328
+	default 1024
 
 config AT_HOST_UART_BUF_SIZE
 	int "UART Rx buffer size"


### PR DESCRIPTION
This increases the AT socket Rx buffer
size to be able to print everything from
what the modem sends to the UART.

Before: When sending commands e.g
AT+CLAC, you would not get every
response printed out.

Signed-off-by: Martin Lesund <martin.lesund@nordicsemi.no>