### PR TITLE
kconfig: Refer to feature flag instead of board name

### DIFF
--- a/subsys/spm/Kconfig
+++ b/subsys/spm/Kconfig
@@ -8,7 +8,7 @@ menu "SPM"
 
 config SPM
 	bool "Use Secure Partition Manager"
-	default y if BOARD_NRF9160_PCA10090NS
+	default y if TRUSTED_EXECUTION_NONSECURE
 
 if SPM
 choice


### PR DESCRIPTION
Instead of refering to BOARD_NRF9160_PCA10090NS we refer to
TRUSTED_EXECUTION_NONSECURE, this is more portable for future boards.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>