### PR TITLE
lib: at_host: Add  missing break statement

### DIFF
--- a/lib/at_host/at_host.c
+++ b/lib/at_host/at_host.c
@@ -253,6 +253,7 @@ static int at_host_init(struct device *arg)
 		break;
 	case UART_2:
 		uart_dev_name = CONFIG_UART_2_NAME;
+		break;
 	default:
 		LOG_ERR("Unknown UART instance %d", uart_id);
 		return -EINVAL;


### PR DESCRIPTION
`break` was missing in one of the `switch` cases.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>