### PR TITLE
subsys: partition_manager: Fix delimiter for split on ':' to '|'

### DIFF
--- a/subsys/partition_manager/CMakeLists.txt
+++ b/subsys/partition_manager/CMakeLists.txt
@@ -12,6 +12,12 @@ set_property(GLOBAL APPEND PROPERTY
   -DUSE_PARTITION_MANAGER=$<TARGET_EXISTS:partition_manager>
   )
 
+# Safeguard to make sure folder naming does not break building on Windows
+if(${PROJECT_BINARY_DIR} MATCHES "[|]")
+  message(FATAL_ERROR "The character \"|\" is not allowed as filename or"
+          " folder name.\nThe offending path is: $${PROJECT_BINARY_DIR}")
+endif()
+
 if((EXISTS ${APPLICATION_SOURCE_DIR}/pm.yml) AND IMAGE)
   # Only run partition manager when being built as sub image.
 
@@ -36,7 +42,7 @@ if((EXISTS ${APPLICATION_SOURCE_DIR}/pm.yml) AND IMAGE)
   set_property(
     GLOBAL APPEND PROPERTY
     PARTITION_MANAGER_CONFIG_FILES
-    "${image_name}:${PROJECT_BINARY_DIR}/include/generated/pm.yml:${PROJECT_BINARY_DIR}:${PROJECT_BINARY_DIR}/include/generated"
+    "${image_name}|${PROJECT_BINARY_DIR}/include/generated/pm.yml|${PROJECT_BINARY_DIR}|${PROJECT_BINARY_DIR}/include/generated"
     )
   set_property(
     GLOBAL APPEND PROPERTY

--- a/west.yml
+++ b/west.yml
@@ -38,7 +38,7 @@ manifest:
     - name: fw-nrfconnect-zephyr
       path: zephyr
       west-commands: scripts/west-commands.yml
-      revision: f0f5dc49dff55594b916a41f51a0fa39b432991c
+      revision: 1ff159ab1fcfc88474d50d21c48a57026e88c318
     - name: fw-nrfconnect-mcuboot
       path: mcuboot
       revision: 289f108b6ce992dc3a0a4038ba2e10fb6ae5336a


### PR DESCRIPTION
The problem is that a split on `:` in windows would result in splitting
`c:\` on windows which would create invalid paths. Both windows and
linux does not allow naming a folder | hence this would be safe to
assume would not create the same problem.

Edit:  @stig-bjorlykke pointed out that you are allowed to do this on Linux and Mac. I forgot to add escape `""` when I tested it on linux.

I think we should put a limitation on the build system and say that we disallow folders with delimiters which are restricted in windows as it would break building on windows.

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>