### PR TITLE
doc: build: add information about Python requirements

### DIFF
--- a/doc/nrf/doc_build.rst
+++ b/doc/nrf/doc_build.rst
@@ -15,6 +15,8 @@ Before you start
 ****************
 
 Before you can build the documentation, install the |NCS| as described in :ref:`gs_installing`.
+Make sure that you have installed the required :ref:`Python dependencies <additional_deps_win>`.
+
 See the *Installing the documentation processors* section in the :ref:`zephyr:zephyr_doc` developer guide for information about installing the required tools to build the documentation and their supported versions.
 
 .. note::


### PR DESCRIPTION
Point out that Python requirements need to be up to date when
building the documentation.

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>