### PR TITLE
samples: nrf9160: lte_ble_gateway: fix flow control settings in overlay

### DIFF
--- a/samples/nrf9160/lte_ble_gateway/nrf9160_pca10090ns.overlay
+++ b/samples/nrf9160/lte_ble_gateway/nrf9160_pca10090ns.overlay
@@ -9,6 +9,6 @@
 	status = "ok";
 	tx-pin = <18>;
 	rx-pin = <17>;
-	rts-pin = <19>;
-	cts-pin = <21>;
+	rts-pin = <21>;
+	cts-pin = <19>;
 };


### PR DESCRIPTION
Fix incorrect RTS/CTS pin assignment in overlay.
See [here](https://github.com/zephyrproject-rtos/zephyr/blob/master/samples/bluetooth/hci_uart/nrf52840_pca10090.overlay) for pin assignment in `hci_uart`.
See below for hardware routing.
```
 * | nRF9160 |				 | nRF52840 | nRF9160 DK |
 * | P0.17   | -- MCU Interface Pin 0 -- | P0.17    | Arduino 4  |
 * | P0.18   | -- MCU Interface Pin 1 -- | P0.20    | Arduino 5  |
 * | P0.19   | -- MCU Interface Pin 2 -- | P0.15    | Arduino 6  |
 * | P0.21   | -- MCU Interface Pin 3 -- | P0.22    | TRACECLK   |
 * | P0.22   | -- MCU Interface Pin 4 -- | P1.04    | TRACEDATA0 |
 * | P0.23   | -- MCU Interface Pin 5 -- | P1.02    | TRACEDATA1 |
 * | COEX0   | -- MCU Interface Pin 6 -- | P1.13    | COEX0_PH   |
 * | COEX1   | -- MCU Interface Pin 7 -- | P1.11    | COEX1_PH   |
 * | COEX2   | -- MCU Interface Pin 8 -- | P1.15    | COEX2_PH   |
```