### PR TITLE
samples: nrf9160: spm: fix overlay for lte_ble_gateway

### DIFF
--- a/samples/nrf9160/spm/nrf9160_pca10090.overlay
+++ b/samples/nrf9160/spm/nrf9160_pca10090.overlay
@@ -1,9 +1,4 @@
 /* needed to get the NRF_UARTE2 defined */
 &uart2 {
-	current-speed = <1000000>;
 	status = "ok";
-	tx-pin = <18>;
-	rx-pin = <17>;
-	rts-pin = <19>;
-	cts-pin = <21>;
 };


### PR DESCRIPTION
Correct the overlay file for `lte_ble_gateway`.