### PR TITLE
nrf_desktop: Fixed a bug where overlays were missing

### DIFF
--- a/samples/nrf_desktop/CMakeLists.txt
+++ b/samples/nrf_desktop/CMakeLists.txt
@@ -24,11 +24,11 @@ if (NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE ZDebug)
 endif()
 
+include(../../cmake/boilerplate.cmake)
+
 if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/configuration/${BOARD}/dts.overlay")
   set(DTC_OVERLAY_FILE "${CMAKE_CURRENT_SOURCE_DIR}/configuration/${BOARD}/dts.overlay")
 endif()
-
-include(../../cmake/boilerplate.cmake)
 
 set(mcuboot_CONF_FILE
   ${CMAKE_CURRENT_SOURCE_DIR}/configuration/${BOARD}/mcuboot_${CMAKE_BUILD_TYPE}.conf


### PR DESCRIPTION
Fixed a bug where DT overlays were missing when the BOARD was
specified through an environment variable.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>