### PR TITLE
nrf_desktop: Fix set_conf_file warning

### DIFF
--- a/samples/nrf_desktop/CMakeLists.txt
+++ b/samples/nrf_desktop/CMakeLists.txt
@@ -40,9 +40,7 @@ endif()
 include(../../cmake/boilerplate.cmake)
 
 # Define configuration files.
-macro(set_conf_file)
-  set(CONF_FILE "configuration/${BOARD}/app_${CMAKE_BUILD_TYPE}.conf")
-endmacro()
+set(CONF_FILE "configuration/${BOARD}/app_${CMAKE_BUILD_TYPE}.conf")
 
 ################################################################################
 


### PR DESCRIPTION
Fix the 'set_conf_file' deprecation warning by setting CONF_FILE
instead of using set_conf_file.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>