### PR TITLE
cmake: Simplify by always adding NRF_DIR to the BOARD_ROOTs

### DIFF
--- a/cmake/boilerplate.cmake
+++ b/cmake/boilerplate.cmake
@@ -25,10 +25,5 @@ if(DEFINED NRF_SUPPORTED_BUILD_TYPES)
         endif()
 endif()
 
-# Set BOARD_ROOT if board definition exists out of tree.
-find_path(_BOARD_DIR NAMES "${BOARD}_defconfig" PATHS ${NRF_DIR}/boards/*/*
-          NO_DEFAULT_PATH)
-
-if (_BOARD_DIR)
-        set(BOARD_ROOT ${NRF_DIR})
-endif()
+# Add NRF_DIR as a BOARD_ROOT in case the board is in NRF_DIR
+list(APPEND BOARD_ROOT ${NRF_DIR})


### PR DESCRIPTION
Simplify the build scripts by always adding NRF_DIR as a BOARD_ROOT
instead of first checking if we need to add NRF_DIR as a BOARD_ROOT.

The logic for determining if we need to add NRF_DIR is error-prone and
unnecessary.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>