### PR TITLE
scripts: hid_configurator: Add udev rule for BLE peripheral

### DIFF
--- a/scripts/hid_configurator/99-hid.rules
+++ b/scripts/hid_configurator/99-hid.rules
@@ -1,5 +1,8 @@
 # udev rules which allow using configuration channel for nRF52 Desktop without
 # root permissions on Linux. Adapted from HIDAPI project.
+#
+# Symbolic links are only used for identification of attached devices and
+# checking if the rule has been applied correctly. Can be removed if not needed.
 
 # To apply the rule, drop this file into `/etc/udev/rules.d` and unplug
 # and replug your device. These are the only steps necessary to see the new
@@ -8,13 +11,17 @@
 # Rules change the permissions to 0666 (world readable/writable) for specified
 # device on Linux systems.
 
-### Mouse
+### Mouse over USB
 # HIDAPI + libusb/hidraw
-ATTRS{idVendor}=="1915", ATTRS{idProduct}=="52de", MODE="0666", SYMLINK+="nrf52-desktop-mouse"
+ATTRS{idVendor}=="1915", ATTRS{idProduct}=="52de", MODE="0666", SYMLINK+="nrf52-desktop-mouse-usb"
 
-### Dongle
+### Dongle over USB
 # HIDAPI + libusb/hidraw
-ATTRS{idVendor}=="1915", ATTRS{idProduct}=="52dc", MODE="0666", SYMLINK+="nrf52-desktop-dongle"
-
+ATTRS{idVendor}=="1915", ATTRS{idProduct}=="52dc", MODE="0666", SYMLINK+="nrf52-desktop-dongle-usb"
+#
 # Note that the hexadecimal values for VID and PID are case sensitive and
 # must be lower case.
+
+### Mouse over BLE
+# HIDAPI + hidraw
+ATTRS{name}=="Mouse nRF52 Desktop", SUBSYSTEMS=="input", MODE="0666", SYMLINK+="nrf52-desktop-mouse-ble"


### PR DESCRIPTION
BLE mouse on Linux is added as HID device by BlueZ via uhid and needs
different udev rule than USB devices.

Signed-off-by: Filip Kubicz <filip.kubicz@nordicsemi.no>