### PR TITLE
scripts: hid_configurator: Support BLE devices on Linux

### DIFF
--- a/scripts/hid_configurator/README.rst
+++ b/scripts/hid_configurator/README.rst
@@ -10,7 +10,7 @@ This application is an example of controlling nRF52 Desktop firmware parameters 
 
 It uses HID feature reports to communicate with firmware.
 
-Right now, it can be used to change following parameters:
+Right now, it can be used to perform DFU or change following parameters:
 
 * mouse optical sensor resolution (CPI)
 * optical sensor power saving modes:
@@ -21,16 +21,17 @@ Right now, it can be used to change following parameters:
 Supported transports:
 
 * USB
+* BLE (Windows 10, Linux)
 
 Usage
 *****
 On Windows:
 
-	py -3 configurator.py --cpi 12000
+	py -3 configurator.py config sensor cpi 12000
 
 On Linux:
 
-	python3 configurator.py --cpi 12000
+	python3 configurator.py config sensor cpi 12000
 
 To get a list of possible arguments, call with `--help` option.
 
@@ -44,11 +45,15 @@ On Windows:
 On Linux:
 
 	pip3 install --user -r requirements.txt
+        sudo apt install libhidapi-hidraw0
 
 This installs:
 
-* HIDAPI library - on Windows provided by `hidapi.dll` or `hidapi-x64.dll`
+* HIDAPI library - on Windows provided by `hidapi.dll` or `hidapi-x64.dll`, on Linux provided by `libhidapi-hidraw0`.
 * pyhidapi Python wrapper - installed from GitHub repository with additional patches included. The version on PyPI is obsolete and will not work.
+
+When using configuration channel for BLE devices on Linux, it recommended to use BlueZ version >= 5.44.
+In previous versions, the HID device attached by BlueZ may obtain wrong VID and PID values (ignoring values in Device Information Service), which will stop HIDAPI from opening the device.
 
 On Linux, to call the Python script without root rights,
 install the provided udev rule `99-hid.rules` by copying it to
@@ -56,7 +61,9 @@ install the provided udev rule `99-hid.rules` by copying it to
 
 Note:
 ************
-When using Python Launcher for Windows, `--user` installation option will not work, since DLL files will be copied to `user\AppData\Roaming\Python\PythonX` which is not searched for DLL libraries by default. You can either install without `--user` option or copy the DLL library next to the program being run. To uninstall all files, run
+When using Python Launcher for Windows, `--user` installation option will not work, since DLL files will be copied to `user\AppData\Roaming\Python\PythonX` which is not searched for DLL libraries by default.
+You can either install without `--user` option or copy the DLL library next to the program being run.
+To uninstall all files, run
 
 	py -3 -m pip uninstall hid
 


### PR DESCRIPTION
Use HIDAPI with hidraw in order to support Bluetooth Low Energy devices.
Added information about bug in BlueZ older than 5.44.

DESK-519

Signed-off-by: Filip Kubicz <filip.kubicz@nordicsemi.no>