### PR TITLE
manifest: update fw-nrfconnect-mcuboot reference

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -41,7 +41,7 @@ manifest:
       revision: a288e8b8ab54c667c6ed9776042200411710a9cf
     - name: fw-nrfconnect-mcuboot
       path: mcuboot
-      revision: 1b930a96210edd2991cd16af4a8d659462b9c282
+      revision: a4db98dff803e17b06908419341577b14ce16107
     - name: fw-nrfconnect-tinycbor
       path: modules/lib/tinycbor
       revision: ef1f9c3d87474ec3570b1f46e91fd4b54a4fb421


### PR DESCRIPTION
Updated reference to include multi-image support when TINYCBOR is
enabled.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>