### PR TITLE
Add support for Nordic proprietary BLE Controller v0.2.0-4.prealpha

### DIFF
--- a/doc/nrf/ug_bt_ll_nrfxlib.rst
+++ b/doc/nrf/ug_bt_ll_nrfxlib.rst
@@ -1,0 +1,40 @@
+.. _ug_bt_ll_nrfxlib:
+
+nRF BLE Controller (experimental)
+#################################
+
+The |NCS| provides a *Bluetooth* LE Controller that is targeted at nRF devices.
+This controller is designed to be robust and compatible to other link layers, similar to Nordic Semiconductor's SoftDevices.
+See :ref:`nrfxlib:ble_controller` for more information about the controller.
+
+The nRF BLE Controller is distributed as a set of precompiled linkable libraries that can be found in the `nrfxlib`_ repository.
+Note that the nRF BLE Controller described in this document is different from the open source BLE Controller that is included in the Zephyr project.
+
+This user guide describes how to use the nRF BLE Controller in the |NCS| and points out how it integrates with Zephyr.
+
+.. _ug_bt_ll_nrfxlib_usage:
+
+Using the nRF BLE Controller
+****************************
+
+The nRF BLE Controller can be used with any Bluetooth sample.
+To enable it, set :option:`CONFIG_BT_LL_NRFXLIB` to ``y`` in the sample's :file:`prj.conf` file.
+
+.. _ug_bt_ll_nrfxlib_drivers:
+
+nRF BLE Controller driver support
+*********************************
+
+The nRF BLE Controller provides built-in drivers for flash, clock control, and random number generation (entropy).
+When you enable the nRF BLE Controller, shims for these drivers are automatically selected and used instead of Zephyr's default drivers.
+
+Thread safety
+=============
+
+The nRF BLE Controller is not re-entrant by default.
+This means that to ensure thread safety, a multi-threading lock is required around calls to the controller's APIs.
+The lock is implemented as a single shared semaphore that is taken and given before and after calling into the nRF BLE Controller.
+This way, the nRF BLE Controller can alter how certain drivers and Bluetooth LE API calls behave.
+
+In particular, the entropy driver locks the nRF BLE Controller API, even in the :cpp:func:`entropy_get_entropy_isr()` API that can be called from interrupts.
+This means that a low priority interrupt calling the :cpp:func:`entropy_get_entropy_isr()` in a busy-wait manner can potentially block a higher priority interrupt.

--- a/doc/nrf/user_guides.rst
+++ b/doc/nrf/user_guides.rst
@@ -10,6 +10,7 @@ They introduce you to important concepts and guide you through developing your a
    :maxdepth: 2
 
    ug_nrf9160
+   ug_bt_ll_nrfxlib
    ug_esb
    ug_multi_image
    ug_bootloader

--- a/drivers/CMakeLists.txt
+++ b/drivers/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Nordic Semiconductor ASA
+# Copyright (c) 2018-2019 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
@@ -10,3 +10,4 @@ add_subdirectory_ifdef(CONFIG_SENSOR sensor)
 add_subdirectory_ifdef(CONFIG_NETWORKING net)
 add_subdirectory_ifdef(CONFIG_ADP536X adp536x)
 add_subdirectory_ifdef(CONFIG_ST25R3911B_LIB st25r3911b)
+add_subdirectory_ifdef(CONFIG_BT_LL_NRFXLIB bt_ll_nrfxlib)

--- a/drivers/Kconfig
+++ b/drivers/Kconfig
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018 Nordic Semiconductor ASA
+# Copyright (c) 2018-2019 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
@@ -11,7 +11,10 @@ rsource "gps_sim/Kconfig"
 rsource "lte_link_control/Kconfig"
 rsource "net/Kconfig"
 rsource "sensor/Kconfig"
-
 rsource "st25r3911b/Kconfig"
+
+if BT_LL_NRFXLIB
+rsource "bt_ll_nrfxlib/Kconfig"
+endif
 
 endmenu

--- a/drivers/bt_ll_nrfxlib/CMakeLists.txt
+++ b/drivers/bt_ll_nrfxlib/CMakeLists.txt
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2019 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+add_subdirectory_ifdef(CONFIG_SOC_FLASH_NRF_LL_NRFXLIB flash)
+add_subdirectory_ifdef(CONFIG_CLOCK_CONTROL_NRF_LL_NRFXLIB clock_control)
+add_subdirectory_ifdef(CONFIG_ENTROPY_NRF_LL_NRFXLIB entropy)

--- a/drivers/bt_ll_nrfxlib/Kconfig
+++ b/drivers/bt_ll_nrfxlib/Kconfig
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2019 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+rsource "clock_control/Kconfig"
+rsource "entropy/Kconfig"
+rsource "flash/Kconfig"

--- a/drivers/bt_ll_nrfxlib/clock_control/CMakeLists.txt
+++ b/drivers/bt_ll_nrfxlib/clock_control/CMakeLists.txt
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2019 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+zephyr_library()
+zephyr_library_sources(clock_control_ll_nrfxlib.c)

--- a/drivers/bt_ll_nrfxlib/clock_control/Kconfig
+++ b/drivers/bt_ll_nrfxlib/clock_control/Kconfig
@@ -1,0 +1,77 @@
+#
+# Copyright (c) 2018 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+config CLOCK_CONTROL_NRF_LL_NRFXLIB
+	bool "nRF BLE Controller clock control driver"
+	default y
+	select CLOCK_CONTROL_NRF_FORCE_ALT
+
+choice CLOCK_CONTROL_NRF_SOURCE
+	prompt "32 KHz clock source"
+	default CLOCK_CONTROL_NRF_K32SRC_XTAL
+
+config CLOCK_CONTROL_NRF_K32SRC_RC
+	bool "RC Oscillator"
+
+config CLOCK_CONTROL_NRF_K32SRC_XTAL
+	bool "Crystal Oscillator"
+
+config CLOCK_CONTROL_NRF_K32SRC_SYNTH
+	bool "Synthesized from HFCLK"
+
+endchoice
+
+config CLOCK_CONTROL_NRF_K32SRC_BLOCKING
+	bool "Blocking 32 KHz crystal oscillator startup"
+	depends on CLOCK_CONTROL_NRF_K32SRC_XTAL
+	help
+	  Clock control driver will spin wait in CPU sleep until 32 KHz
+	  crystal oscillator starts up. If not enabled, RC oscillator will
+	  initially start running and automatically switch to crystal when
+	  ready.
+
+choice CLOCK_CONTROL_NRF_ACCURACY
+	prompt "32 KHz clock accuracy"
+	default CLOCK_CONTROL_NRF_K32SRC_500PPM if CLOCK_CONTROL_NRF_K32SRC_RC
+	default CLOCK_CONTROL_NRF_K32SRC_20PPM
+
+config CLOCK_CONTROL_NRF_K32SRC_500PPM
+	bool "251 ppm to 500 ppm"
+
+config CLOCK_CONTROL_NRF_K32SRC_250PPM
+	bool "151 ppm to 250 ppm"
+
+config CLOCK_CONTROL_NRF_K32SRC_150PPM
+	bool "101 ppm to 150 ppm"
+
+config CLOCK_CONTROL_NRF_K32SRC_100PPM
+	bool "76 ppm to 100 ppm"
+
+config CLOCK_CONTROL_NRF_K32SRC_75PPM
+	bool "51 ppm to 75 ppm"
+
+config CLOCK_CONTROL_NRF_K32SRC_50PPM
+	bool "31 ppm to 50 ppm"
+
+config CLOCK_CONTROL_NRF_K32SRC_30PPM
+	bool "21 ppm to 30 ppm"
+
+config CLOCK_CONTROL_NRF_K32SRC_20PPM
+	bool "0 ppm to 20 ppm"
+
+config CLOCK_CONTROL_NRF_K32SRC_10PPM
+	bool "6 ppm to 10 ppm"
+
+config CLOCK_CONTROL_NRF_K32SRC_5PPM
+	bool "3 ppm to 5 ppm"
+
+config CLOCK_CONTROL_NRF_K32SRC_2PPM
+	bool "2 ppm"
+
+config CLOCK_CONTROL_NRF_K32SRC_1PPM
+	bool "1 ppm"
+
+endchoice

--- a/drivers/bt_ll_nrfxlib/clock_control/clock_control_ll_nrfxlib.c
+++ b/drivers/bt_ll_nrfxlib/clock_control/clock_control_ll_nrfxlib.c
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#include <soc.h>
+#include <errno.h>
+#include <device.h>
+#include <kernel_includes.h>
+#include <clock_control.h>
+#include <ble_controller.h>
+#include <ble_controller_soc.h>
+#include <multithreading_lock.h>
+#if IS_ENABLED(CONFIG_USB_NRF52840)
+#include <nrf_power.h>
+#endif
+
+static int hf_clock_start(struct device *dev, clock_control_subsys_t sub_system)
+{
+	ARG_UNUSED(dev);
+
+	int errcode = MULTITHREADING_LOCK_ACQUIRE();
+
+	if (errcode == 0) {
+		errcode = ble_controller_hf_clock_request(NULL);
+		MULTITHREADING_LOCK_RELEASE();
+	}
+	if (errcode != 0) {
+		return -EFAULT;
+	}
+
+	bool blocking = POINTER_TO_UINT(sub_system);
+
+	if (blocking) {
+		bool is_running = false;
+
+		while (!is_running) {
+			errcode = MULTITHREADING_LOCK_ACQUIRE();
+			if (errcode == 0) {
+				errcode = ble_controller_hf_clock_is_running(
+					&is_running);
+				MULTITHREADING_LOCK_RELEASE();
+			}
+			if (errcode != 0) {
+				return -EFAULT;
+			}
+		}
+	}
+
+	return 0;
+}
+
+static int hf_clock_stop(struct device *dev, clock_control_subsys_t sub_system)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(sub_system);
+
+	int errcode = MULTITHREADING_LOCK_ACQUIRE();
+
+	if (errcode == 0) {
+		errcode = ble_controller_hf_clock_release();
+		MULTITHREADING_LOCK_RELEASE();
+	}
+	if (errcode != 0) {
+		return -EFAULT;
+	}
+
+	return 0;
+}
+
+static int hf_clock_get_rate(struct device *dev,
+			     clock_control_subsys_t sub_system, u32_t *rate)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(sub_system);
+
+	if (rate == NULL) {
+		return -EINVAL;
+	}
+
+	*rate = MHZ(16);
+	return 0;
+}
+
+static int lf_clock_start(struct device *dev, clock_control_subsys_t sub_system)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(sub_system);
+
+	/* No-op. LFCLK is started by default by ble_controller_init(). */
+
+	return 0;
+}
+
+static int lf_clock_get_rate(struct device *dev,
+			     clock_control_subsys_t sub_system, u32_t *rate)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(sub_system);
+
+	if (rate == NULL) {
+		return -EINVAL;
+	}
+
+	*rate = 32768;
+	return 0;
+}
+
+#if IS_ENABLED(CONFIG_USB_NRF52840)
+static inline void power_event_cb(nrf_power_event_t event)
+{
+	extern void usb_dc_nrfx_power_event_callback(nrf_power_event_t event);
+
+	usb_dc_nrfx_power_event_callback(event);
+}
+#endif
+
+void nrf_power_clock_isr(void)
+{
+#if IS_ENABLED(CONFIG_USB_NRF52840)
+	bool usb_detected, usb_pwr_rdy, usb_removed;
+
+	usb_detected = nrf_power_event_check(NRF_POWER_EVENT_USBDETECTED);
+	usb_pwr_rdy = nrf_power_event_check(NRF_POWER_EVENT_USBPWRRDY);
+	usb_removed = nrf_power_event_check(NRF_POWER_EVENT_USBREMOVED);
+
+	if (usb_detected) {
+		nrf_power_event_clear(NRF_POWER_EVENT_USBDETECTED);
+		power_event_cb(NRF_POWER_EVENT_USBDETECTED);
+	}
+
+	if (usb_pwr_rdy) {
+		nrf_power_event_clear(NRF_POWER_EVENT_USBPWRRDY);
+		power_event_cb(NRF_POWER_EVENT_USBPWRRDY);
+	}
+
+	if (usb_removed) {
+		nrf_power_event_clear(NRF_POWER_EVENT_USBREMOVED);
+		power_event_cb(NRF_POWER_EVENT_USBREMOVED);
+	}
+#endif
+	/* FIXME/NOTE: This handler is called _after_ the USB registers are
+	 * checked. The reason is that the BLE controller also checks these
+	 * registsers _and clears them_, but there is currently no event
+	 * propagated from the controller.
+	 */
+	ble_controller_POWER_CLOCK_IRQHandler();
+}
+
+static int clock_control_init(struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	/* No-op. Initialized in subsys/bluetooth/controller/hci_driver.c by
+	 * ble_init() at PRE_KERNEL_1. ble_init() will call
+	 * ble_controller_init() that in turn will start the LFCLK.
+	 */
+	IRQ_CONNECT(DT_NORDIC_NRF_CLOCK_0_IRQ_0,
+		    DT_NORDIC_NRF_CLOCK_0_IRQ_0_PRIORITY,
+		    nrf_power_clock_isr, 0, 0);
+	return 0;
+}
+
+static const struct clock_control_driver_api hf_clock_control_api = {
+	.on = hf_clock_start,
+	.off = hf_clock_stop,
+	.get_rate = hf_clock_get_rate,
+};
+
+DEVICE_AND_API_INIT(hf_clock,
+		    DT_NORDIC_NRF_CLOCK_0_LABEL "_16M",
+		    clock_control_init, NULL, NULL, PRE_KERNEL_1,
+		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &hf_clock_control_api);
+
+/* LFCLK doesn't have stop function to replicate the nRF5 Power Clock driver
+ * behavior.
+ */
+static const struct clock_control_driver_api lf_clock_control_api = {
+	.on = lf_clock_start,
+	.off = NULL,
+	.get_rate = lf_clock_get_rate,
+};
+
+DEVICE_AND_API_INIT(lf_clock,
+		    DT_NORDIC_NRF_CLOCK_0_LABEL "_32K",
+		    clock_control_init, NULL, NULL, PRE_KERNEL_1,
+		    CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &lf_clock_control_api);
+
+#if IS_ENABLED(CONFIG_USB_NRF52840)
+
+void nrf5_power_usb_power_int_enable(bool enable)
+{
+	u32_t mask;
+
+
+	mask = NRF_POWER_INT_USBDETECTED_MASK |
+	       NRF_POWER_INT_USBREMOVED_MASK |
+	       NRF_POWER_INT_USBPWRRDY_MASK;
+
+	if (enable) {
+		nrf_power_int_enable(mask);
+		irq_enable(DT_NORDIC_NRF_CLOCK_0_IRQ_0);
+	} else {
+		nrf_power_int_disable(mask);
+	}
+}
+
+#endif

--- a/drivers/bt_ll_nrfxlib/entropy/CMakeLists.txt
+++ b/drivers/bt_ll_nrfxlib/entropy/CMakeLists.txt
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2018 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+target_sources(drivers__entropy PRIVATE ${CMAKE_CURRENT_LIST_DIR}/entropy_ll_nrfxlib.c)

--- a/drivers/bt_ll_nrfxlib/entropy/Kconfig
+++ b/drivers/bt_ll_nrfxlib/entropy/Kconfig
@@ -1,0 +1,28 @@
+#
+# Copyright (c) 2018 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+if ENTROPY_GENERATOR
+
+config ENTROPY_NRF_LL_NRFXLIB
+	bool "nRF BLE Controller entropy driver"
+	default y
+	select ENTROPY_NRF_FORCE_ALT
+	select ENTROPY_HAS_DRIVER
+	help
+	  This option enables the RNG peripheral, which is a random number
+	  generator, based on internal thermal noise, that provides a
+	  random 8-bit value to the host when read.
+
+config ENTROPY_NRF_PRI
+	int "RNG interrupt priority"
+	range 0 2 if SOC_SERIES_NRF51X
+	range 0 5 if SOC_COMPATIBLE_NRF52X
+	default 2 if SOC_SERIES_NRF51X
+	default 5 if SOC_COMPATIBLE_NRF52X
+	help
+	  nRF5X RNG IRQ priority.
+
+endif # ENTROPY_GENERATOR

--- a/drivers/bt_ll_nrfxlib/entropy/entropy_ll_nrfxlib.c
+++ b/drivers/bt_ll_nrfxlib/entropy/entropy_ll_nrfxlib.c
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#include <entropy.h>
+#include <soc.h>
+#include <device.h>
+#include <irq.h>
+#include <kernel.h>
+#include <kernel_includes.h>
+#include <ble_controller.h>
+#include <ble_controller_soc.h>
+
+#include <multithreading_lock.h>
+
+/* The RNG driver data. */
+struct rng_driver_data {
+	/* Used to fill the pending client buffer with new random values after
+	 * RNG IRQ is triggered.
+	 */
+	struct k_sem sem_sync;
+};
+
+static struct rng_driver_data rng_data;
+
+static inline struct rng_driver_data *rng_driver_data_get(struct device *dev)
+{
+	__ASSERT_NO_MSG(dev != NULL);
+	__ASSERT_NO_MSG((intptr_t) dev->driver_data == (intptr_t) &rng_data);
+
+	return dev->driver_data;
+}
+
+static int rng_driver_get_entropy(struct device *dev, u8_t *buf, u16_t len)
+{
+	struct rng_driver_data *rng_dev = rng_driver_data_get(dev);
+	u8_t *p_dst = buf;
+	u32_t bytes_left = len;
+
+	while (bytes_left > 0) {
+		u32_t bytes_read = 0;
+
+		while (bytes_read == 0) {
+			int errcode = MULTITHREADING_LOCK_ACQUIRE();
+
+			if (errcode) {
+				return errcode;
+			}
+			bytes_read = ble_controller_rand_vector_get(p_dst,
+								    bytes_left);
+			MULTITHREADING_LOCK_RELEASE();
+
+			if (!bytes_read) {
+				/* Put the thread on wait until next interrupt
+				 * to get more random values.
+				 */
+				k_sem_take(&rng_dev->sem_sync, K_FOREVER);
+			}
+		}
+
+		p_dst += bytes_read;
+		bytes_left -= bytes_read;
+	}
+
+	return 0;
+}
+
+static int rng_driver_get_entropy_isr(struct device *dev, u8_t *buf, u16_t len,
+				      u32_t flags)
+{
+
+	int errcode = 0;
+
+	if (likely((flags & ENTROPY_BUSYWAIT) == 0)) {
+		errcode = MULTITHREADING_LOCK_ACQUIRE_NO_WAIT();
+		if (!errcode) {
+			errcode = ble_controller_rand_vector_get(buf, len);
+			MULTITHREADING_LOCK_RELEASE();
+		}
+	} else {
+		errcode = MULTITHREADING_LOCK_ACQUIRE_FOREVER_WAIT();
+		if (!errcode) {
+			ble_controller_rand_vector_get_blocking(buf, len);
+			MULTITHREADING_LOCK_RELEASE();
+		}
+	}
+
+	if (!errcode) {
+		return len;
+	} else {
+		return errcode;
+	}
+}
+
+static void rng_driver_isr(void *param)
+{
+	ARG_UNUSED(param);
+
+	ble_controller_RNG_IRQHandler();
+
+	/* This sema wakes up the pending client buffer to fill it with new
+	 * random values.
+	 */
+	k_sem_give(&rng_data.sem_sync);
+}
+
+static int rng_driver_init(struct device *dev)
+{
+	struct rng_driver_data *rng_dev = rng_driver_data_get(dev);
+
+	k_sem_init(&rng_dev->sem_sync, 0, 1);
+
+	IRQ_CONNECT(RNG_IRQn,
+		    CONFIG_ENTROPY_NRF_PRI,
+		    rng_driver_isr,
+		    NULL,
+		    0);
+
+	return 0;
+}
+
+static const struct entropy_driver_api rng_driver_api_funcs = {
+	.get_entropy = rng_driver_get_entropy,
+	.get_entropy_isr = rng_driver_get_entropy_isr
+};
+
+DEVICE_AND_API_INIT(rng_driver, CONFIG_ENTROPY_NAME,
+		    rng_driver_init, &rng_data, NULL,
+		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		    &rng_driver_api_funcs);

--- a/drivers/bt_ll_nrfxlib/flash/CMakeLists.txt
+++ b/drivers/bt_ll_nrfxlib/flash/CMakeLists.txt
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2019 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+target_sources(drivers__flash PRIVATE ${CMAKE_CURRENT_LIST_DIR}/flash_ll_nrfxlib.c)

--- a/drivers/bt_ll_nrfxlib/flash/Kconfig
+++ b/drivers/bt_ll_nrfxlib/flash/Kconfig
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2018 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+if FLASH
+
+config SOC_FLASH_NRF_LL_NRFXLIB
+	bool "nRF BLE Controller flash driver"
+	default y
+	select FLASH_NRF_FORCE_ALT
+	select FLASH_HAS_PAGE_LAYOUT
+	select FLASH_HAS_DRIVER_ENABLED
+	select NRFX_NVMC
+	select MPU_ALLOW_FLASH_WRITE if CPU_HAS_MPU
+	help
+	  Enables nRF BLE Controller flash driver.
+
+endif # FLASH

--- a/drivers/bt_ll_nrfxlib/flash/flash_ll_nrfxlib.c
+++ b/drivers/bt_ll_nrfxlib/flash/flash_ll_nrfxlib.c
@@ -1,0 +1,362 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#include <string.h>
+#include <errno.h>
+#include <zephyr.h>
+#include <device.h>
+#include <soc.h>
+#include <flash.h>
+#include <misc/util.h>
+
+#include <nrfx_nvmc.h>
+
+#include "ble_controller_soc.h"
+#include "multithreading_lock.h"
+
+/* NOTE: The driver supports unligned writes, but some file systems (like FCB)
+ * may use the driver sub-optimally as a result. Word aligned writes are faster
+ * and require less overhead. This value can be changed to 4 to minimize this
+ * overhead.
+ */
+#define FLASH_DRIVER_WRITE_BLOCK_SIZE 1
+
+static struct {
+	/** Used to ensure a single ongoing operation at any time.  */
+	struct k_mutex lock;
+	/** Used to wait for the asynchronous operation to complete */
+	struct k_sem sync;
+	const void *data;
+	off_t addr;
+	u16_t len;
+	u16_t prev_len;
+	u32_t tmp_word;      /**< Used for unalinged writes. */
+	/* NOTE: Read is not async, so not a part of this enum. */
+	enum {
+		FLASH_OP_NONE,
+		FLASH_OP_WRITE,
+		FLASH_OP_ERASE
+	} op;
+} flash_state;
+
+/* Forward declarations */
+static int btctlr_flash_read(struct device *dev,
+			     off_t offset,
+			     void *data,
+			     size_t len);
+static int btctlr_flash_write(struct device *dev,
+			      off_t offset,
+			      const void *data,
+			      size_t len);
+static int btctlr_flash_erase(struct device *dev,
+			      off_t offset,
+			      size_t size);
+static int btctlr_flash_write_protection_set(struct device *dev,
+					     bool enable);
+
+static int flash_op_execute(void);
+
+#if defined(CONFIG_FLASH_PAGE_LAYOUT)
+static void btctlr_flash_page_layout_get(
+	struct device *dev,
+	const struct flash_pages_layout **layout,
+	size_t *layout_size);
+#endif /* defined(CONFIG_FLASH_PAGE_LAYOUT) */
+
+static const struct flash_driver_api btctrl_flash_api = {
+	.read = btctlr_flash_read,
+	.write = btctlr_flash_write,
+	.erase = btctlr_flash_erase,
+	.write_protection = btctlr_flash_write_protection_set,
+#if defined(CONFIG_FLASH_PAGE_LAYOUT)
+	.page_layout = btctlr_flash_page_layout_get,
+#endif  /* CONFIG_FLASH_PAGE_LAYOUT */
+	.write_block_size = FLASH_DRIVER_WRITE_BLOCK_SIZE
+};
+
+
+/* Utility functions */
+static inline bool is_addr_valid(off_t addr, size_t len)
+{
+	if ((addr < 0) ||
+	    (len > nrfx_nvmc_flash_size_get()) ||
+	    (addr >  nrfx_nvmc_flash_size_get() - len)) {
+		return false;
+	}
+
+	return true;
+}
+
+static inline bool is_aligned_32(off_t addr)
+{
+	return ((addr & 0x3) == 0);
+}
+
+static inline off_t align_32(off_t addr)
+{
+	return (addr & ~0x3);
+}
+
+static inline size_t bytes_to_words(size_t bytes)
+{
+	return bytes / sizeof(u32_t);
+}
+
+static inline bool is_page_aligned(off_t addr)
+{
+	return (addr & (nrfx_nvmc_flash_page_size_get() - 1)) == 0;
+}
+
+static void flash_operation_complete_callback(u32_t status)
+{
+	__ASSERT_NO_MSG(flash_state.op == FLASH_OP_WRITE ||
+			flash_state.op == FLASH_OP_ERASE);
+
+	int err;
+
+	flash_state.addr += flash_state.prev_len;
+	flash_state.data = (const void *) ((intptr_t) flash_state.data +
+					   flash_state.prev_len);
+	flash_state.len -= flash_state.prev_len;
+
+	if (flash_state.len > 0) {
+		err = flash_op_execute();
+		/* All inputs should have been validated on the first call. */
+		__ASSERT(err == 0, "Continued flash operation failed");
+	} else {
+		flash_state.op = FLASH_OP_NONE;
+		k_sem_give(&flash_state.sync);
+	}
+}
+
+static size_t offset_32(const void *addr)
+{
+	return (size_t) addr & 0x3;
+}
+
+/**
+ * Copies unaligned data into a word (u32_t).
+ *
+ * This function is used when either @p src or @p dst is an non-word aligned
+ * pointer.
+ *
+ * If the length exceeds the number of remaining in the word, the data is
+ * truncated. Example: Attempting to copy 4 bytes into `0x0000 0001` will only
+ * copy the first 3 bytes of the input data and return 3.
+ *
+ * @param[in,out] word_dst Pointer to 32-bit word that will be appropriately
+ *                         filled with as much of data from @p src as possible.
+ * @param[in]     dst      Destination address pointer (flash). Used to calcuate
+ *                         offset into @p word_dst. This is where the data
+ *                         should eventually be copied into.
+ * @param[in]     src      Source data pointer where data is copied from.
+ * @param[in]     len      Length of the data pointed to by @p src.
+ *
+ *
+ * @returns the number of bytes copied into @p word_dst.
+ */
+static size_t unaligned_word_copy(u32_t *word_dst,
+				  const void *dst,
+				  const void *src,
+				  size_t len)
+{
+	/* Example: Writing one byte from src to dst via word_dst.
+	 *
+	 * |    |<----- src (len = 1)
+	 * |  |<------- dst
+	 * | 0 1 2 3 |
+	 * | address |
+	 *
+	 * max_offset             : max(1, 2) => 2
+	 * remaining_bytes_in_word: 4 - 2     => 2
+	 * bytes_to_copy          : MIN(1, 2) => 1
+	 */
+	size_t max_offset = MAX(offset_32(dst), offset_32(src));
+	size_t remaining_bytes_in_word = sizeof(u32_t) - max_offset;
+	size_t bytes_to_copy = MIN(len, remaining_bytes_in_word);
+
+	/* nRF52832 Product specification:
+	 *  Only full 32-bit words can be written to Flash using the
+	 *  NVMC interface. To write less than 32 bits to Flash, write
+	 *  the data as a word, and set all the bits that should remain
+	 *  unchanged in the word to '1'.
+	 */
+	*word_dst = ~0;
+	memcpy(&((u8_t *)word_dst)[offset_32(dst)], src, bytes_to_copy);
+	return bytes_to_copy;
+}
+
+static int flash_op_write(void)
+{
+	if (is_aligned_32(flash_state.addr) &&
+	    is_aligned_32((off_t) flash_state.data) &&
+	    flash_state.len >= sizeof(u32_t)) {
+		flash_state.prev_len = MIN(align_32(flash_state.len),
+					   nrfx_nvmc_flash_page_size_get());
+		return ble_controller_flash_write(
+			(u32_t) flash_state.addr,
+			flash_state.data,
+			bytes_to_words(flash_state.prev_len),
+			flash_operation_complete_callback);
+	} else {
+		flash_state.prev_len = unaligned_word_copy(
+			&flash_state.tmp_word,
+			(void *)flash_state.addr,
+			flash_state.data,
+			flash_state.len);
+		return ble_controller_flash_write(
+			(u32_t)align_32(flash_state.addr),
+			&flash_state.tmp_word,
+			1,
+			flash_operation_complete_callback);
+	}
+}
+
+static int flash_op_execute(void)
+{
+	int err;
+
+	err = MULTITHREADING_LOCK_ACQUIRE();
+	if (!err) {
+		if (flash_state.op == FLASH_OP_WRITE) {
+			err = flash_op_write();
+		} else if (flash_state.op == FLASH_OP_ERASE) {
+			flash_state.prev_len = nrfx_nvmc_flash_page_size_get();
+			err = ble_controller_flash_page_erase(
+				(u32_t)flash_state.addr,
+				flash_operation_complete_callback);
+		} else {
+			__ASSERT(0, "Unsupported operation");
+			err = -EINVAL;
+		}
+		MULTITHREADING_LOCK_RELEASE();
+	}
+	return err;
+}
+
+/* Driver API. */
+
+static int btctlr_flash_read(struct device *dev,
+			     off_t offset,
+			     void *data,
+			     size_t len)
+{
+	int err;
+
+	if (!is_addr_valid(offset, len)) {
+		return -EINVAL;
+	}
+
+	if (len == 0) {
+		return 0;
+	}
+
+	/* Don't read flash while another flash operation is ongoing. */
+	err = k_mutex_lock(&flash_state.lock, K_FOREVER);
+	__ASSERT_NO_MSG(err == 0);
+	memcpy(data, (void *)offset, len);
+	k_mutex_unlock(&flash_state.lock);
+
+	return 0;
+}
+
+static int btctlr_flash_write(struct device *dev,
+			      off_t offset,
+			      const void *data,
+			      size_t len)
+{
+	int err;
+
+	if (!is_addr_valid(offset, len)) {
+		return -EINVAL;
+	}
+
+	err = k_mutex_lock(&flash_state.lock, K_FOREVER);
+	__ASSERT_NO_MSG(err == 0);
+	__ASSERT_NO_MSG(flash_state.op == FLASH_OP_NONE);
+	flash_state.op = FLASH_OP_WRITE;
+	flash_state.data = data;
+	flash_state.addr = offset;
+	flash_state.len = len;
+
+	err = flash_op_execute();
+	if (!err) {
+		err = k_sem_take(&flash_state.sync, K_FOREVER);
+		__ASSERT_NO_MSG(err == 0);
+	}
+
+	k_mutex_unlock(&flash_state.lock);
+	return err;
+}
+
+static int btctlr_flash_erase(struct device *dev, off_t offset, size_t len)
+{
+	int err;
+
+	/* Follows the behavior of soc_flash_nrf.c */
+	if (!(is_page_aligned(offset) && is_page_aligned(len)) ||
+	    !is_addr_valid(offset, len)) {
+		return -EINVAL;
+	}
+
+	size_t page_count = len / nrfx_nvmc_flash_page_size_get();
+
+	if (page_count == 0) {
+		return 0;
+	}
+
+	err = k_mutex_lock(&flash_state.lock, K_FOREVER);
+	__ASSERT_NO_MSG(err == 0);
+	__ASSERT_NO_MSG(flash_state.op == FLASH_OP_NONE);
+	flash_state.op = FLASH_OP_ERASE;
+	flash_state.addr = offset;
+	flash_state.len = len;
+
+	err = flash_op_execute();
+	if (!err) {
+		err = k_sem_take(&flash_state.sync, K_FOREVER);
+		__ASSERT_NO_MSG(err == 0);
+	}
+
+	k_mutex_unlock(&flash_state.lock);
+	return err;
+}
+
+static int btctlr_flash_write_protection_set(struct device *dev, bool enable)
+{
+	/* The BLE controller handles the write protection automatically. */
+	return 0;
+}
+
+#if defined(CONFIG_FLASH_PAGE_LAYOUT)
+static struct flash_pages_layout dev_layout;
+
+static void btctlr_flash_page_layout_get(
+	struct device *dev,
+	const struct flash_pages_layout **layout,
+	size_t *layout_size)
+{
+	*layout = &dev_layout;
+	*layout_size = 1;
+}
+#endif /* defined(CONFIG_FLASH_PAGE_LAYOUT) */
+
+static int nrf_btctrl_flash_init(struct device *dev)
+{
+	dev->driver_api = &btctrl_flash_api;
+	k_sem_init(&flash_state.sync, 0, 1);
+	k_mutex_init(&flash_state.lock);
+
+#if defined(CONFIG_FLASH_PAGE_LAYOUT)
+	dev_layout.pages_count = nrfx_nvmc_flash_page_count_get();
+	dev_layout.pages_size = nrfx_nvmc_flash_page_size_get();
+#endif
+
+	return 0;
+}
+
+DEVICE_INIT(nrf_btctrl_flash, DT_FLASH_DEV_NAME, nrf_btctrl_flash_init,
+	    NULL, NULL, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);

--- a/subsys/CMakeLists.txt
+++ b/subsys/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-if (CONFIG_BT OR CONFIG_BT_LL_NRFXLIB)
+if (CONFIG_BT)
   add_subdirectory(bluetooth)
 endif()
 

--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -6,11 +6,11 @@
 
 menu "Bluetooth Low Energy"
 
+if BT
+
 if BT_LL_NRFXLIB
 rsource "controller/Kconfig"
 endif # CONFIG_BT_LL_NRFXLIB
-
-if BT
 
 comment "BLE Libraries"
 rsource "Kconfig.pool"

--- a/subsys/bluetooth/controller/CMakeLists.txt
+++ b/subsys/bluetooth/controller/CMakeLists.txt
@@ -7,6 +7,7 @@
 zephyr_library()
 
 zephyr_library_sources(
+  multithreading_lock.c
   hci_driver.c
   )
 
@@ -16,3 +17,5 @@ zephyr_library_sources_ifdef(
 )
 
 zephyr_library_link_libraries(subsys__bluetooth)
+
+zephyr_include_directories(.)

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -19,7 +19,6 @@ config BLECTLR_SIGNAL_STACK_SIZE
 	help
 	  Size of the signal handler thread stack, used to process lower
 	  priority signals in the controller.
-
 # The BLE controller library variants are defined in nrfxlib, here we redefine
 # the choice to 'import' them, so they appear in the same menu as the rest.
 

--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -9,14 +9,18 @@
 #include <irq.h>
 #include <kernel.h>
 #include <soc.h>
+#include <misc/byteorder.h>
 
-#include <blectlr.h>
-#include <blectlr_hci.h>
-#include <blectlr_util.h>
+#include <ble_controller.h>
+#include <ble_controller_hci.h>
+#include "multithreading_lock.h"
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_hci_driver
 #include "common/log.h"
+
+#define BLE_CONTROLLER_IRQ_PRIO_LOW  4
+#define BLE_CONTROLLER_IRQ_PRIO_HIGH 0
 
 static K_SEM_DEFINE(sem_recv, 0, UINT_MAX);
 static K_SEM_DEFINE(sem_signal, 0, UINT_MAX);
@@ -24,7 +28,10 @@ static K_SEM_DEFINE(sem_signal, 0, UINT_MAX);
 static struct k_thread recv_thread_data;
 static struct k_thread signal_thread_data;
 static K_THREAD_STACK_DEFINE(recv_thread_stack, CONFIG_BLECTLR_RX_STACK_SIZE);
-static K_THREAD_STACK_DEFINE(signal_thread_stack, CONFIG_BLECTLR_SIGNAL_STACK_SIZE);
+static K_THREAD_STACK_DEFINE(signal_thread_stack,
+			     CONFIG_BLECTLR_SIGNAL_STACK_SIZE);
+
+static u8_t ble_controller_mempool[0x6000];
 
 void blectlr_assertion_handler(const char *const file, const u32_t line)
 {
@@ -38,10 +45,14 @@ void blectlr_assertion_handler(const char *const file, const u32_t line)
 
 static int cmd_handle(struct net_buf *cmd)
 {
-	const bool pkt_put = hci_cmd_packet_put(cmd->data);
+	int errcode = MULTITHREADING_LOCK_ACQUIRE();
 
-	if (!pkt_put) {
-		return -ENOBUFS;
+	if (!errcode) {
+		errcode = hci_cmd_put(cmd->data);
+		MULTITHREADING_LOCK_RELEASE();
+	}
+	if (errcode) {
+		return errcode;
 	}
 
 	k_sem_give(&sem_recv);
@@ -49,18 +60,24 @@ static int cmd_handle(struct net_buf *cmd)
 	return 0;
 }
 
+#if defined(CONFIG_BT_CONN)
 static int acl_handle(struct net_buf *acl)
 {
-	const bool pkt_put = hci_data_packet_put(acl->data);
+	int errcode = MULTITHREADING_LOCK_ACQUIRE();
 
-	if (!pkt_put) {
-		/* Likely buffer overflow event */
-		k_sem_give(&sem_recv);
-		return -ENOBUFS;
+	if (!errcode) {
+		errcode = hci_data_put(acl->data);
+		MULTITHREADING_LOCK_RELEASE();
+
+		if (errcode) {
+			/* Likely buffer overflow event */
+			k_sem_give(&sem_recv);
+		}
 	}
 
-	return 0;
+	return errcode;
 }
+#endif
 
 static int hci_driver_send(struct net_buf *buf)
 {
@@ -81,7 +98,7 @@ static int hci_driver_send(struct net_buf *buf)
 		BT_DBG("ACL_OUT");
 		err = acl_handle(buf);
 		break;
-#endif /* CONFIG_BT_CONN */
+#endif          /* CONFIG_BT_CONN */
 	case BT_BUF_CMD:
 		BT_DBG("CMD");
 		err = cmd_handle(buf);
@@ -128,14 +145,6 @@ static void event_packet_process(u8_t *hci_buf)
 
 	if (hdr->evt == BT_HCI_EVT_CMD_COMPLETE ||
 	    hdr->evt == BT_HCI_EVT_CMD_STATUS) {
-		u16_t opcode = hci_buf[3] | hci_buf[4] << 8;
-
-		if (opcode == 0xC03) {
-			BT_DBG("Reset command complete");
-			cal_init();
-			blectlr_set_default_evt_length();
-		}
-
 		evt_buf = bt_buf_get_cmd_complete(K_FOREVER);
 	} else {
 		evt_buf = bt_buf_get_rx(BT_BUF_EVT, K_FOREVER);
@@ -151,9 +160,14 @@ static void event_packet_process(u8_t *hci_buf)
 		       "(%02x), length (%d)",
 		       hci_buf[2], hci_buf[1]);
 	} else {
-		BT_DBG("Event: event code (%02x), "
-		       "length (%d)",
-		       hci_buf[0], hci_buf[1]);
+		u16_t opcode = sys_get_be16(&hci_buf[2]);
+
+		BT_DBG("Event: event code (0x%02x), "
+		       "length (%d), "
+		       "num_complete (%d), "
+		       "opcode (%d)"
+		       "status (%d)\n",
+		       hci_buf[0], hci_buf[1], hci_buf[2], opcode, hci_buf[5]);
 	}
 
 	net_buf_add_mem(evt_buf, &hci_buf[0], hdr->len + 2);
@@ -171,20 +185,35 @@ static void recv_thread(void *p1, void *p2, void *p3)
 	ARG_UNUSED(p3);
 
 	static u8_t hci_buffer[256 + 4];
-	bool pkt;
+	int errcode;
 
 	BT_DBG("Started");
-	while (1) {
+	while (true) {
 		k_sem_take(&sem_recv, K_FOREVER);
-
-		pkt = hci_data_packet_get(hci_buffer);
-		if (pkt) {
-			data_packet_process(hci_buffer);
+		while (true) {
+			errcode = MULTITHREADING_LOCK_ACQUIRE();
+			if (!errcode) {
+				errcode = hci_evt_get(hci_buffer);
+				MULTITHREADING_LOCK_RELEASE();
+			}
+			if (!errcode) {
+				event_packet_process(hci_buffer);
+			} else {
+				break;
+			}
 		}
 
-		pkt = hci_event_packet_get(hci_buffer);
-		if (pkt) {
-			event_packet_process(hci_buffer);
+		while (true) {
+			errcode = MULTITHREADING_LOCK_ACQUIRE();
+			if (!errcode) {
+				errcode = hci_data_get(hci_buffer);
+				MULTITHREADING_LOCK_RELEASE();
+			}
+			if (!errcode) {
+				data_packet_process(hci_buffer);
+			} else {
+				break;
+			}
 		}
 
 		/* Let other threads of same priority run in between. */
@@ -205,7 +234,7 @@ static void signal_thread(void *p1, void *p2, void *p3)
 
 	while (true) {
 		k_sem_take(&sem_signal, K_FOREVER);
-		blectlr_signal();
+		ble_controller_low_prio_tasks_process();
 	}
 }
 
@@ -218,10 +247,11 @@ static int hci_driver_open(void)
 			NULL, NULL, NULL, K_PRIO_COOP(CONFIG_BLECTLR_PRIO), 0,
 			K_NO_WAIT);
 
-	k_thread_create(&signal_thread_data, signal_thread_stack,
-			K_THREAD_STACK_SIZEOF(signal_thread_stack),
-			signal_thread, NULL, NULL, NULL,
-			K_PRIO_COOP(CONFIG_BLECTLR_PRIO), 0, K_NO_WAIT);
+	u8_t build_revision[BLE_CONTROLLER_BUILD_REVISION_SIZE];
+
+	ble_controller_build_revision_get(build_revision);
+	LOG_HEXDUMP_INF(build_revision, sizeof(build_revision),
+			"BLE controller build revision: ");
 
 	return 0;
 }
@@ -244,38 +274,172 @@ void SIGNALLING_Handler(void)
 	k_sem_give(&sem_signal);
 }
 
+u8_t bt_read_static_addr(bt_addr_le_t *addr)
+{
+	if (((NRF_FICR->DEVICEADDR[0] != UINT32_MAX) ||
+	     ((NRF_FICR->DEVICEADDR[1] & UINT16_MAX) != UINT16_MAX)) &&
+	    (NRF_FICR->DEVICEADDRTYPE & 0x01)) {
+		sys_put_le32(NRF_FICR->DEVICEADDR[0], &addr->a.val[0]);
+		sys_put_le16(NRF_FICR->DEVICEADDR[1], &addr->a.val[4]);
+
+		/* The FICR value is a just a random number, with no knowledge
+		 * of the Bluetooth Specification requirements for random
+		 * static addresses.
+		 */
+		BT_ADDR_SET_STATIC(&addr->a);
+
+		addr->type = BT_ADDR_LE_RANDOM;
+		return 1;
+	}
+	return 0;
+}
+
+static int ble_init(struct device *unused)
+{
+	int err = 0;
+	nrf_lf_clock_cfg_t clock_cfg;
+
+#ifdef CONFIG_CLOCK_CONTROL_NRF_K32SRC_RC
+	clock_cfg.lf_clk_source = NRF_LF_CLOCK_SRC_RC;
+#elif CONFIG_CLOCK_CONTROL_NRF_K32SRC_XTAL
+	clock_cfg.lf_clk_source = NRF_LF_CLOCK_SRC_XTAL;
+#elif CLOCK_CONTROL_NRF_K32SRC_SYNTH
+	clock_cfg.lf_clk_source = NRF_LF_CLOCK_SRC_SYNTH;
+#else
+#error "Clock source is not defined"
+#endif
+
+#ifdef CONFIG_CLOCK_CONTROL_NRF_K32SRC_500PPM
+	clock_cfg.accuracy = NRF_LF_CLOCK_ACCURACY_500_PPM;
+#elif CONFIG_CLOCK_CONTROL_NRF_K32SRC_250PPM
+	clock_cfg.accuracy = NRF_LF_CLOCK_ACCURACY_250_PPM;
+#elif CONFIG_CLOCK_CONTROL_NRF_K32SRC_150PPM
+	clock_cfg.accuracy = NRF_LF_CLOCK_ACCURACY_150_PPM;
+#elif CONFIG_CLOCK_CONTROL_NRF_K32SRC_100PPM
+	clock_cfg.accuracy = NRF_LF_CLOCK_ACCURACY_100_PPM;
+#elif CONFIG_CLOCK_CONTROL_NRF_K32SRC_75PPM
+	clock_cfg.accuracy = NRF_LF_CLOCK_ACCURACY_75_PPM;
+#elif CONFIG_CLOCK_CONTROL_NRF_K32SRC_50PPM
+	clock_cfg.accuracy = NRF_LF_CLOCK_ACCURACY_50_PPM;
+#elif CONFIG_CLOCK_CONTROL_NRF_K32SRC_30PPM
+	clock_cfg.accuracy = NRF_LF_CLOCK_ACCURACY_30_PPM;
+#elif CONFIG_CLOCK_CONTROL_NRF_K32SRC_20PPM
+	clock_cfg.accuracy = NRF_LF_CLOCK_ACCURACY_20_PPM;
+#elif CLOCK_CONTROL_NRF_K32SRC_10PPM
+	clock_cfg.accuracy = NRF_LF_CLOCK_ACCURACY_10_PPM;
+#elif CLOCK_CONTROL_NRF_K32SRC_5PPM
+	clock_cfg.accuracy = NRF_LF_CLOCK_ACCURACY_5_PPM;
+#elif CLOCK_CONTROL_NRF_K32SRC_2PPM
+	clock_cfg.accuracy = NRF_LF_CLOCK_ACCURACY_2_PPM;
+#elif CLOCK_CONTROL_NRF_K32SRC_1PPM
+	clock_cfg.accuracy = NRF_LF_CLOCK_ACCURACY_1_PPM;
+#else
+#error "Clock accuracy is not defined"
+#endif
+	clock_cfg.rc_ctiv = BLE_CONTROLLER_RECOMMENDED_RC_CTIV;
+	clock_cfg.rc_temp_ctiv = BLE_CONTROLLER_RECOMMENDED_RC_TEMP_CTIV;
+
+	err = ble_controller_init(blectlr_assertion_handler,
+				  &clock_cfg,
+				  SWI5_IRQn);
+	return err;
+}
+
+static int ble_enable(void)
+{
+	int err;
+	ble_controller_cfg_t cfg;
+
+	cfg.master_count.count = 1;
+
+	err = ble_controller_cfg_set(BLE_CONTROLLER_DEFAULT_RESOURCE_CFG_TAG,
+				     BLE_CONTROLLER_CFG_TYPE_MASTER_COUNT,
+				     &cfg);
+	if (err < 0 || err > sizeof(ble_controller_mempool)) {
+		return err;
+	}
+
+	cfg.slave_count.count = 1;
+
+	err = ble_controller_cfg_set(BLE_CONTROLLER_DEFAULT_RESOURCE_CFG_TAG,
+				     BLE_CONTROLLER_CFG_TYPE_SLAVE_COUNT,
+				     &cfg);
+	if (err < 0 || err > sizeof(ble_controller_mempool)) {
+		return err;
+	}
+
+	cfg.buffer_cfg.rx_packet_size = 251;
+	cfg.buffer_cfg.tx_packet_size = 251;
+	cfg.buffer_cfg.rx_packet_count = 10;
+	cfg.buffer_cfg.tx_packet_count = 10;
+
+	err = ble_controller_cfg_set(BLE_CONTROLLER_DEFAULT_RESOURCE_CFG_TAG,
+				     BLE_CONTROLLER_CFG_TYPE_BUFFER_CFG,
+				     &cfg);
+	if (err < 0 || err > sizeof(ble_controller_mempool)) {
+		return err;
+	}
+
+	cfg.event_length.event_length_us = 7500;
+	err = ble_controller_cfg_set(BLE_CONTROLLER_DEFAULT_RESOURCE_CFG_TAG,
+				     BLE_CONTROLLER_CFG_TYPE_EVENT_LENGTH,
+				     &cfg);
+	if (err < 0 || err > sizeof(ble_controller_mempool)) {
+		return err;
+	}
+
+	err = MULTITHREADING_LOCK_ACQUIRE();
+	if (!err) {
+		err = ble_controller_enable(host_signal,
+					    ble_controller_mempool);
+		MULTITHREADING_LOCK_RELEASE();
+	}
+	if (err < 0) {
+		return err;
+	}
+
+	/* Start processing software interrupts. This enables, e.g., the flash
+	 * API to work without having to call bt_enable(), which in turn calls
+	 * hci_driver_open().
+	 *
+	 * FIXME: Here we possibly start dynamic behavior during initialization,
+	 * which in general is a bad thing.
+	 */
+	k_thread_create(&signal_thread_data, signal_thread_stack,
+			K_THREAD_STACK_SIZEOF(signal_thread_stack),
+			signal_thread, NULL, NULL, NULL,
+			K_PRIO_COOP(CONFIG_BLECTLR_PRIO), 0, K_NO_WAIT);
+
+	return 0;
+}
+
 static int hci_driver_init(struct device *unused)
 {
 	ARG_UNUSED(unused);
 
-	u32_t err = blectlr_init(host_signal);
-
-	if (err) {
-		/* Probably memory */
-		return -ENOMEM;
-	}
-
 	bt_hci_driver_register(&drv);
 
-	IRQ_DIRECT_CONNECT(NRF5_IRQ_RADIO_IRQn, 0,
-			   C_RADIO_Handler, IRQ_ZERO_LATENCY);
-	IRQ_DIRECT_CONNECT(NRF5_IRQ_RTC0_IRQn, 0,
-			   C_RTC0_Handler, IRQ_ZERO_LATENCY);
-	IRQ_DIRECT_CONNECT(NRF5_IRQ_TIMER0_IRQn, 0,
-			   C_TIMER0_Handler, IRQ_ZERO_LATENCY);
-	IRQ_CONNECT(NRF5_IRQ_SWI5_IRQn, 4, SIGNALLING_Handler, NULL, 0);
-	IRQ_DIRECT_CONNECT(NRF5_IRQ_RNG_IRQn, 4, C_RNG_Handler, 0);
-	IRQ_DIRECT_CONNECT(NRF5_IRQ_POWER_CLOCK_IRQn, 4,
-			   C_POWER_CLOCK_Handler, 0);
+	int err = 0;
 
-	irq_enable(NRF5_IRQ_RADIO_IRQn);
-	irq_enable(NRF5_IRQ_RTC0_IRQn);
-	irq_enable(NRF5_IRQ_TIMER0_IRQn);
-	irq_enable(NRF5_IRQ_SWI5_IRQn);
-	irq_enable(NRF5_IRQ_RNG_IRQn);
-	irq_enable(NRF5_IRQ_POWER_CLOCK_IRQn);
+	err = ble_enable();
+
+	if (err < 0) {
+		return err;
+	}
+
+	IRQ_DIRECT_CONNECT(RADIO_IRQn, BLE_CONTROLLER_IRQ_PRIO_HIGH,
+			   ble_controller_RADIO_IRQHandler, IRQ_ZERO_LATENCY);
+	IRQ_DIRECT_CONNECT(RTC0_IRQn, BLE_CONTROLLER_IRQ_PRIO_HIGH,
+			   ble_controller_RTC0_IRQHandler, IRQ_ZERO_LATENCY);
+	IRQ_DIRECT_CONNECT(TIMER0_IRQn, BLE_CONTROLLER_IRQ_PRIO_HIGH,
+			   ble_controller_TIMER0_IRQHandler, IRQ_ZERO_LATENCY);
+
+	IRQ_CONNECT(SWI5_IRQn, BLE_CONTROLLER_IRQ_PRIO_LOW,
+		    SIGNALLING_Handler, NULL, 0);
+
 
 	return 0;
 }
 
 SYS_INIT(hci_driver_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);
+SYS_INIT(ble_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/subsys/bluetooth/controller/multithreading_lock.c
+++ b/subsys/bluetooth/controller/multithreading_lock.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#include "multithreading_lock.h"
+
+static K_SEM_DEFINE(ble_controller_lock, 1, 1);
+
+int multithreading_lock_acquire(int32_t timeout)
+{
+	return k_sem_take(&ble_controller_lock,
+			  ((timeout == K_FOREVER || timeout == K_NO_WAIT) ?
+			   timeout : K_MSEC(timeout)));
+}
+
+void multithreading_lock_release(void)
+{
+	k_sem_give(&ble_controller_lock);
+}

--- a/subsys/bluetooth/controller/multithreading_lock.h
+++ b/subsys/bluetooth/controller/multithreading_lock.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/**
+ * @file multithreading_lock.h
+ *
+ * @brief APIs for ensuring BLE controller threadsafe operation.
+ */
+
+#ifndef MULTITHREADING_LOCK_H__
+#define MULTITHREADING_LOCK_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <zephyr.h>
+
+/** Macro for acquiring a lock */
+#define MULTITHREADING_LOCK_ACQUIRE() \
+	multithreading_lock_acquire(K_FOREVER)
+
+/** Macro for acquiring a lock without waiting. */
+#define MULTITHREADING_LOCK_ACQUIRE_NO_WAIT() \
+	multithreading_lock_acquire(K_NO_WAIT)
+
+/** Macro for acquiring a lock while waiting forever. */
+#define MULTITHREADING_LOCK_ACQUIRE_FOREVER_WAIT() \
+	multithreading_lock_acquire(K_FOREVER)
+
+/** Macro for releasing a lock */
+#define MULTITHREADING_LOCK_RELEASE() multithreading_lock_release()
+
+
+/** @brief Try to take the lock with the specified blocking behavior.
+ *
+ * This API call will be blocked for the time specified by @p timeout and then
+ * return error code.
+ *
+ * @param[in] timeout     Timeout value (in milliseconds) for the locking API.
+ *
+ * @retval 0              Success
+ * @retval - ::EBUSY      Returned without waiting.
+ * @retval - ::EAGAIN     Waiting period timed out.
+ */
+int multithreading_lock_acquire(int timeout);
+
+/** @brief Unlock the lock.
+ *
+ * @note This API is must be called only after lock is obtained.
+ */
+void multithreading_lock_release(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MULTITHREADING_LOCK_H__ */

--- a/west.yml
+++ b/west.yml
@@ -49,7 +49,7 @@ manifest:
       revision: ef1f9c3d87474ec3570b1f46e91fd4b54a4fb421
     - name: nrfxlib
       path: nrfxlib
-      revision: v0.4.0
+      revision: a87551ba2e131ff17e0e1c796b73f7c37bbea9ec
     - name: cmock
       path: test/cmock
       revision: c243b9a7a7b3c471023193992b46cf1bd1910450


### PR DESCRIPTION
This PR adds support for the BT_LL_NRFXLIB version 0.2.0-1.prealpha from nrfxlib. 

Summary of changes:
- a multithreading lock API for ensuring thread safe access to the BLE controller API
- glue drivers for flash, clock_control and entropy
  - these glue drivers MUST be used whenever the BT_LL_NRFXLIB is
    selected
- updates to the hci_driver as required by changed APIs when the
  BT_LL_NRFXLIB is selected
- updates to the controller crypto interface

To test the library, checkout thomasstenersen/fw-nrfconnect-nrf:ble-controller-0.2.0 and 
do `west update`. Next:

```
cd <path-to-fw-nrfconnect-nrf>/samples/bluetooth/throughput
mkdir -p build
cd build
cmake -GNinja -DBOARD=nrf52840_pca10056 ..
ninja menuconfig

# Search for ll_choice, select Nordic proprietary BLE Link Layer
# Save and exit
ninja
```
Flash two boards and follow the instructions in on the serial terminal to run the throughput example.

**Note**: The glue drivers have already been reviewed internally, but feel free to go through them.
**Note 2**: I've updated the west.yml manifest to point to my fork of nrfxlib so it is easier to test. I will rebase when the PR for nrfxlib has been merged.