### PR TITLE
manifest: update nrfxlib

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -40,6 +40,16 @@ set(HTML_DIR ${CMAKE_BINARY_DIR}/html)
 # Create the combined HTML output folder
 file(MAKE_DIRECTORY ${HTML_DIR})
 
+# Create a mbedtls config file with all settings on
+file(STRINGS ${NRFXLIB_BASE}/nrf_security/configs/nrf-config.h.template MBEDTLS_TEMPLATE_CONFIG)
+string(REGEX REPLACE
+       "#cmakedefine ([-_A-Z0-9]*)"
+       "#define \\1\n#define CONFIG_GLUE_\\1\n#define CONFIG_CC310_\\1\n#define CONFIG_VANILLA_\\1"
+       MBEDTLS_CONFIG "${MBEDTLS_TEMPLATE_CONFIG}"
+)
+string(REGEX REPLACE ";" "\n" MBEDTLS_CONFIG "${MBEDTLS_CONFIG}")
+file(WRITE ${NRFXLIB_BINARY_DIR}/mbedtls_doxygen_config.h ${MBEDTLS_CONFIG})
+
 # Build Zephyr documentation
 set(SPHINXOPTS -c ${NRF_BASE}/doc/zephyr)
 # Place the generated HTML in the common Sphinx HTML output folder
@@ -268,6 +278,23 @@ add_custom_target(
 )
 
 
+add_custom_target(
+  nrfxlib-kconfig
+  COMMAND ${CMAKE_COMMAND} -E make_directory ${NRFXLIB_RST_OUT}/kconfig
+  COMMAND ${CMAKE_COMMAND} -E env
+  PYTHONPATH="${ZEPHYR_BASE}/scripts/kconfig${SEP}$ENV{PYTHONPATH}"
+  srctree=${NRFXLIB_BASE}
+  ENV_VAR_BOARD_DIR=boards/*/*/
+  ENV_VAR_ARCH=*
+  KERNELVERSION=${PROJECT_VERSION}
+  SRCARCH=x86
+  GENERATED_DTS_BOARD_CONF=not_applicable
+  CMAKE_BINARY_DIR=${CMAKE_BINARY_DIR}
+  KCONFIG_TURBO_MODE=${KCONFIG_TURBO_MODE}
+  KCONFIG_DOC_MODE=1
+  ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/doc/scripts/genrest.py ${NRFXLIB_BASE}/Kconfig.nrfxlib ${NRFXLIB_RST_OUT}/kconfig
+  WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+)
 
 set(EXTRACT_CONTENT ${ZEPHYR_BASE}/doc/scripts/extract_content.py)
 
@@ -278,6 +305,7 @@ set(NRFXLIB_EXTRACT_CONTENT_COMMAND
   ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/doc/scripts/extract_content.py
   --ignore ${CMAKE_CURRENT_BINARY_DIR}
   "*.rst:.:${NRFXLIB_RST_OUT}"
+  "*.rst:include:${NRFXLIB_RST_OUT}/kconfig"
 )
 
 
@@ -299,7 +327,7 @@ add_custom_target(
 
   WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
 )
-add_dependencies(nrfxlib-html nrfxlib-content nrfxlib-doxy)
+add_dependencies(nrfxlib-html nrfxlib-content nrfxlib-doxy nrfxlib-kconfig)
 
 add_custom_target(nrfxlib)
 add_dependencies(nrfxlib nrfxlib-html)

--- a/doc/nrfxlib/nrfxlib.doxyfile.in
+++ b/doc/nrfxlib/nrfxlib.doxyfile.in
@@ -1944,7 +1944,10 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = "CONFIG_SYS_CLOCK_EXISTS=y" \
+PREDEFINED             = "MBEDTLS_CONFIG_FILE=\"@NRFXLIB_BINARY_DIR@/mbedtls_doxygen_config.h\"" \
+                         "CONFIG_MBEDTLS_VANILLA_BACKEND=y" \
+                         "CONFIG_CC310_BACKEND=y" \
+                         "CONFIG_SYS_CLOCK_EXISTS=y" \
                          "CONFIG_THREAD_MONITOR=y" \
                          "CONFIG_THREAD_CUSTOM_DATA=y" \
                          "CONFIG_ERRNO=y" \

--- a/west.yml
+++ b/west.yml
@@ -49,7 +49,7 @@ manifest:
       revision: ef1f9c3d87474ec3570b1f46e91fd4b54a4fb421
     - name: nrfxlib
       path: nrfxlib
-      revision: 201142c8164e745fc31c8ed75b7623bbd106df01
+      revision: fb102e5f450e16a631540b2ce1cc7a7e9b651803
     - name: cmock
       path: test/cmock
       revision: c243b9a7a7b3c471023193992b46cf1bd1910450


### PR DESCRIPTION
Update nrfxlib revision to ~pull/50/head~ fb102e5f450e16a631540b2ce1cc7a7e9b651803 for latest documentation
updates from nrfxlib.

This commit also includes the usage of NCS mbed TLS configuration
template for correct dox generation of APIs.

Signed-off-by: Torsten Rasmussen <torsten.rasmussen@nordicsemi.no>