### PR TITLE
lib: bsdlib: Handle hints properly if input variable is NULL

### DIFF
--- a/lib/bsdlib/nrf91_sockets.c
+++ b/lib/bsdlib/nrf91_sockets.c
@@ -718,6 +718,7 @@ static int nrf91_socket_offload_getaddrinfo(const char *node,
 	struct nrf_addrinfo nrf_hints;
 	struct nrf_addrinfo nrf_hints_pdn;
 	struct nrf_addrinfo *nrf_res = NULL;
+	struct nrf_addrinfo *nrf_hints_ptr = NULL;
 
 	memset(&nrf_hints, 0, sizeof(struct nrf_addrinfo));
 
@@ -738,8 +739,9 @@ static int nrf91_socket_offload_getaddrinfo(const char *node,
 			}
 			nrf_hints.ai_next = &nrf_hints_pdn;
 		}
+		nrf_hints_ptr = &nrf_hints;
 	}
-	int retval = nrf_getaddrinfo(node, service, &nrf_hints, &nrf_res);
+	int retval = nrf_getaddrinfo(node, service, nrf_hints_ptr, &nrf_res);
 
 	struct nrf_addrinfo *next_nrf_res = nrf_res;
 	struct addrinfo *latest_z_res = NULL;


### PR DESCRIPTION
If the input variable "hints" is NULL, the input to nrf_getaddrinfo
would be a stacked variable, ie: not NULL. The latest bsdlib will return
an error if the hints input variable is present, and not have a
specified .ai_family set to either AF_INET6 or AF_INET.