### PR TITLE
doc: spm: update docs after multi image build changes

### DIFF
--- a/doc/nrf/ug_nrf9160.rst
+++ b/doc/nrf/ug_nrf9160.rst
@@ -39,9 +39,12 @@ Secure Partition Manager
 
 To use any of the nRF9160 samples, you must first compile and flash the
 **Secure Partition Manager** sample.
-It provides a reference implementation of a Secure Partition Manager firmware.
 This firmware is required to set up the nRF9160 DK so that it can run
 user applications in the non-secure domain.
+Note that the **Secure Partition Manager** sample is automatically included in
+the build for the nrf9160_pca10090ns board.
+To disable the automatic inclusion of the **Secure Partition Manager** sample,
+set the option ``CONFIG_SPM=n`` in the project configuration.
 
 For detailed documentation of the sample, see :ref:`secure_partition_manager`.
 

--- a/include/spm.rst
+++ b/include/spm.rst
@@ -14,13 +14,11 @@ Configuration
 *************
 
 Use Kconfig to configure the security attributions for the peripherals.
-Modify the source code of the SPM subsystem to configure the security attributions of flash or SRAM.
+Modify the source code of the SPM subsystem to configure the security attributions of SRAM.
+If Partition Manager is used, the security attributions of the flash regions are deduced from the generated file :file:`pm.config`.
+Otherwise, the security attributions of the flash regions are deduced from Device Tree information.
 
-The following security attribution configuration is applied:
-
-Flash (1 Mb)
-   * Lower 256 kB: Secure
-   * Upper 768 kB: Non-Secure
+For SRAM and peripherals, the following security attribution configuration is applied:
 
 SRAM (256 kB)
    * Lower 64 kB: Secure

--- a/samples/nrf9160/coap_client/README.rst
+++ b/samples/nrf9160/coap_client/README.rst
@@ -20,7 +20,6 @@ Requirements
 * :ref:`secure_partition_manager` must be programmed on the board.
 
   The sample is configured to compile and run as a non-secure application on nRF91's Cortex-M33.
-  Therefore, it requires the :ref:`secure_partition_manager` that prepares the required peripherals to be available for the application.
 
 Building and running
 ********************
@@ -28,7 +27,7 @@ Building and running
 This sample can be found under :file:`samples/nrf9160/coap_client` in the |NCS| folder structure.
 
 The sample is built as a non-secure firmware image for the nrf9160_pca10090ns board.
-It can be programmed independently from the Secure Partition Manager firmware.
+Because of this, the sample will automatically include the :ref:`SPM<secure_partition_manager>`.
 
 See :ref:`gs_programming` for information about how to build and program the application.
 Note that you must program two different applications as described in the following section.
@@ -39,7 +38,6 @@ Programming the sample
 When you connect the nRF9160 DK board to your computer, you must first make sure that the :ref:`secure_partition_manager` sample is programmed:
 
 1. Put the **SW5** switch (marked debug/prog) in the **NRF91** position to program the main controller.
-#. Build the :ref:`secure_partition_manager` sample and program it.
 #. Build the nRF CoAP Client sample (this sample) and program it.
 #. Verify that the sample was programmed successfully by connecting to the serial port with a terminal emulator (for example, PuTTY) and checking the output.
    See :ref:`putty` for the required settings.

--- a/samples/nrf9160/http_application_update/README.rst
+++ b/samples/nrf9160/http_application_update/README.rst
@@ -34,9 +34,9 @@ Building and running
 
 This sample can be found under :file:`samples/nrf9160/http_application_update` in the |NCS| folder structure.
 
-The sample is built as a non-secure firmware image for the nrf9160_pca10090ns board. Is uses MCUboot and SPM
-(Secure Partition Manager) and they will be automatically built and merged into the final hex-file when building
-the sample.
+The sample is built as a non-secure firmware image for the nrf9160_pca10090ns board.
+Because of this, the sample will automatically include the :ref:`SPM<secure_partition_manager>`.
+The sample also uses MCUboot which is automatically built and merged into the final hex file when building the sample.
 
 See :ref:`gs_programming` for information about how to build and program the application.
 

--- a/samples/nrf9160/lte_ble_gateway/README.rst
+++ b/samples/nrf9160/lte_ble_gateway/README.rst
@@ -31,7 +31,6 @@ Requirements
 * :ref:`secure_partition_manager` must be programmed on the board.
 
   The sample is configured to compile and run as a non-secure application on nRF91's Cortex-M33.
-  Therefore, it requires the :ref:`secure_partition_manager` that prepares the required peripherals to be available for the application.
 
 Building and running
 ********************
@@ -39,7 +38,7 @@ Building and running
 This sample can be found under :file:`samples/lte-gateway/` in the |NCS| folder structure.
 
 The sample is built as a non-secure firmware image for the nrf9160_pca10090ns board.
-It can be programmed independently from the Secure Partition Manager firmware.
+Because of this, the sample will automatically include the :ref:`SPM<secure_partition_manager>`.
 
 See :ref:`gs_programming` for information about how to build and program the application.
 Note that you must program two different applications as described in the following section.
@@ -60,7 +59,6 @@ Before you program the sample application onto the main controller, you must pro
 After programming the board controller, you must program the :ref:`secure_partition_manager` sample and the LTE Sensor Gateway sample to the main controller:
 
 1. Put the **SW5** switch (marked debug/prog) in the **NRF91** position to program the main controller.
-#. Build the :ref:`secure_partition_manager` sample for the nrf9160_pca10090 board and program it.
 #. Build the LTE Sensor Gateway sample (this sample) for the nrf9160_pca10090ns board and program it.
 #. Verify that the sample was programmed successfully by connecting to the first serial port with a terminal emulator (for example, PuTTY) and checking the output.
    See :ref:`putty` for the required settings.

--- a/samples/nrf9160/mqtt_simple/README.rst
+++ b/samples/nrf9160/mqtt_simple/README.rst
@@ -17,10 +17,9 @@ Requirements
 
   * nRF9160 DK board (PCA10090)
 
-* :ref:`secure_partition_manager` must be programmed on the board.
-
   The sample is configured to compile and run as a non-secure application on nRF91's Cortex-M33.
-  Therefore, it requires the :ref:`secure_partition_manager` that prepares the required peripherals to be available for the application.
+  Therefore, it automatically includes the :ref:`secure_partition_manager` that prepares the required peripherals to be available for the application.
+
 
 Building and running
 ********************
@@ -28,7 +27,7 @@ Building and running
 This sample can be found under :file:`samples/nrf9160/mqtt_simple` in the |NCS| folder structure.
 
 The sample is built as a non-secure firmware image for the nrf9160_pca10090ns board.
-It can be programmed independently from the Secure Partition Manager firmware.
+Because of this, the sample will automatically include the :ref:`SPM<secure_partition_manager>`.
 
 See :ref:`gs_programming` for information about how to build and program the application.
 Note that you must program two different applications as described in the following section.
@@ -39,7 +38,6 @@ Programming the sample
 When you connect the nRF9160 DK board to your computer, you must first make sure that the :ref:`secure_partition_manager` sample is programmed:
 
 1. Put the **SW5** switch (marked debug/prog) in the **NRF91** position to program the main controller.
-#. Build the :ref:`secure_partition_manager` sample and program it.
 #. Build the Simple MQTT sample (this sample) and program it.
 #. Verify that the sample was programmed successfully by connecting to the serial port with a terminal emulator (for example, PuTTY) and checking the output.
    See :ref:`putty` for the required settings.

--- a/samples/nrf9160/spm/README.rst
+++ b/samples/nrf9160/spm/README.rst
@@ -3,7 +3,7 @@
 nRF9160: Secure Partition Manager
 #################################
 
-The Secure Partition Manager sample provides a reference use of the Secure Partition Manager peripheral.
+The Secure Partition Manager sample provides a reference use of the System Protection Unit peripheral.
 This firmware is required to set up the nRF9160 DK so that it can run user applications in the non-secure domain.
 
 Overview
@@ -13,6 +13,20 @@ The sample uses the SPM to configure secure attributions for the nRF9160 SiP and
 
 The SPM utilizes the SPU peripheral to configure security attributions for the nRF9160 flash, SRAM, and peripherals.
 After the configuration setup is complete, the sample loads the application firmware that is located on the device.
+
+The sample is automatically built by non-secure applications, when the
+nrf9160_pca10090ns board is used.
+
+Disable automatic building of SPM
+*********************************
+It might be desirable to flash SPM or the non-secure application individually.
+This can be done by disabling the automatic building of SPM.
+To do this set the option ``CONFIG_SPM=n`` in the applications ``prj.conf`` file.
+
+If this results in a single image build, the start address of the non-secure application will change.
+
+The security attribution configuration for the flash will change when SPM is not built as a sub-image.
+
 
 Security attribution configuration
 ==================================


### PR DESCRIPTION
SPM is now included automatically, describe this in the docs.
Partition Manager or DT is used to deduce flash size,
describe this in the docs as well.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>