### PR TITLE
include: modem_info: Increase expected response size

### DIFF
--- a/include/modem_info.h
+++ b/include/modem_info.h
@@ -16,7 +16,7 @@
  */
 
 /** Largest expected parameter response size. */
-#define MODEM_INFO_MAX_RESPONSE_SIZE 64
+#define MODEM_INFO_MAX_RESPONSE_SIZE 100
 
 /** Size of the JSON string. */
 #define MODEM_INFO_JSON_STRING_SIZE 256


### PR DESCRIPTION
Increase expected response size to support a
dual IPv4 and IPv6 response.

Signed-off-by: Henrik Malvik Halvorsen <henrik.halvorsen@nordicsemi.no>
Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>