### PR TITLE
manifest: update zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -40,7 +40,7 @@ manifest:
     - name: fw-nrfconnect-zephyr
       path: zephyr
       west-commands: scripts/west-commands.yml
-      revision: 1378a1c7ac89d13fa08bd45b1272a70060d90663
+      revision: 33c06133c197dbf423d36ffc6f582c736dda92d7
     - name: fw-nrfconnect-mcuboot
       path: mcuboot
       revision: a4db98dff803e17b06908419341577b14ce16107


### PR DESCRIPTION
Update zephyr to include fix needed for building multi image on SES.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>