### PR TITLE
samples: nrf9160: mqtt_simple: Add print of IPv4 address using ntop

### DIFF
--- a/samples/nrf9160/mqtt_simple/CMakeLists.txt
+++ b/samples/nrf9160/mqtt_simple/CMakeLists.txt
@@ -10,4 +10,6 @@ include(../../../cmake/boilerplate.cmake NO_POLICY_SCOPE)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(mqtt-simple)
 
-target_sources(app PRIVATE src/main.c)
+target_sources(app PRIVATE src/main.c
+                           ${ZEPHYR_BASE}/subsys/net/ip/utils.c
+              )

--- a/samples/nrf9160/mqtt_simple/src/main.c
+++ b/samples/nrf9160/mqtt_simple/src/main.c
@@ -259,8 +259,13 @@ static void broker_init(void)
 				->sin_addr.s_addr;
 			broker4->sin_family = AF_INET;
 			broker4->sin_port = htons(CONFIG_MQTT_BROKER_PORT);
-			printk("IPv4 Address found 0x%08x\n",
-				broker4->sin_addr.s_addr);
+			/* ntop returns a \0 terminated string */
+			char ipv4_addr[NET_IPV4_ADDR_LEN + 1];
+			net_addr_ntop(AF_INET,
+				      &broker4->sin_addr.s_addr,
+				      ipv4_addr,
+				      NET_IPV4_ADDR_LEN + 1);
+			printk("IPv4 Address found %s\n", ipv4_addr);
 			break;
 		} else {
 			printk("ai_addrlen = %u should be %u or %u\n",


### PR DESCRIPTION
Printing out the resolved IPv4 address isn't really helpful unless you
manually convert it afterwards. This change introduces the use of utils
from zephyr's `net` subsystem and uses the `ntop` function to convert
it from binary to an `\0` terminated string which is easier to read when
doing printout.

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>