### PR TITLE
applications: asset_tracker: modem_info & device info string improvements

### DIFF
--- a/applications/asset_tracker/src/main.c
+++ b/applications/asset_tracker/src/main.c
@@ -1061,7 +1061,7 @@ static void modem_data_init(void)
 	device_cloud_data.type = NRF_CLOUD_DEVICE_INFO;
 	device_cloud_data.tag = 0x1;
 
-	k_work_submit(&device_status_work);
+	device_status_send(NULL);
 
 	modem_info_rsrp_register(modem_rsrp_handler);
 }


### PR DESCRIPTION
The device status is initiated outside of system work queue in order to ensure that the device info string is sent before RSRP subscription is initiated. 

The RSRP subscription thread is using blocking receive instead of polling to obtain data. 

Signed-off-by: Henrik Malvik Halvorsen <henrik.halvorsen@nordicsemi.no>
Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no
