### PR TITLE
eth_rtt: Fixing compilation

### DIFF
--- a/drivers/net/eth_rtt.c
+++ b/drivers/net/eth_rtt.c
@@ -312,7 +312,7 @@ static void recv_frame(struct eth_rtt_context *context, const u8_t *data,
 
 	LOG_DBG("Received %d byte(s) frame", (int)len);
 
-	pkt = net_pkt_get_reserve_rx(K_NO_WAIT);
+	pkt = net_pkt_rx_alloc(K_NO_WAIT);
 	if (!pkt) {
 		LOG_ERR("Could not allocate rx pkt");
 		return;


### PR DESCRIPTION
Fixing error due to restructuring of net APIs in 1.14 vs 1.13

Signed-off-by: Frank Audun Kvamtrø <frank.kvamtro@nordicsemi.no>
