### PR TITLE
tests: unity: Fix ruby executable check

### DIFF
--- a/tests/unity/CMakeLists.txt
+++ b/tests/unity/CMakeLists.txt
@@ -13,7 +13,7 @@ find_program(
   RUBY_EXECUTABLE
   ruby
 )
-if(${RUBY_EXECUTABLE} STREQUAL RUBY-NOTFOUND)
+if(${RUBY_EXECUTABLE} STREQUAL RUBY_EXECUTABLE-NOTFOUND)
   message(FATAL_ERROR "Unable to find ruby")
 endif()
 


### PR DESCRIPTION
Lack of ruby executable was not detected.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>