### PR TITLE
manifest: update zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -40,7 +40,7 @@ manifest:
     - name: fw-nrfconnect-zephyr
       path: zephyr
       west-commands: scripts/west-commands.yml
-      revision: 5820a41758d7f1a83f5d4483c621c4a2af32718e
+      revision: 7e3d27087d31c5d9d70fffbb8b7e2aa4db144788
     - name: fw-nrfconnect-mcuboot
       path: mcuboot
       revision: aebd4b96d2abbeea5a3392c623369dd61ddf40cb


### PR DESCRIPTION
Update for having a deafult fallback for `--west-path`.

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>