### PR TITLE
manifest: Updating manifest to latest nrfxlib for nrf_security changes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -49,7 +49,7 @@ manifest:
       revision: ef1f9c3d87474ec3570b1f46e91fd4b54a4fb421
     - name: nrfxlib
       path: nrfxlib
-      revision: 150cf3477061d560d43b19617f6cc7e246382794
+      revision: pull/58/head
     - name: cmock
       path: test/cmock
       revision: c243b9a7a7b3c471023193992b46cf1bd1910450


### PR DESCRIPTION
This commit updates the manifest file to include the nrf_security
changes related to correct symbol handling of mbedtls_platform_zeroize
and mbedtls_cipher_* functions from cipher.c.

Signed-off-by: Torsten Rasmussen <torsten.rasmussen@nordicsemi.no>