### PR TITLE
manifest: update zephyr reference

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -40,7 +40,7 @@ manifest:
     - name: fw-nrfconnect-zephyr
       path: zephyr
       west-commands: scripts/west-commands.yml
-      revision: 518b504ce760c2308aee332ee26feb2e8b7fd19a
+      revision: a494544d6e5b42c3606d6617dca27eccb92918e6
     - name: nffs
       revision: bc62a2fa9d98ddb5d633c932ea199bc68e10f194
       path: modules/fs/nffs


### PR DESCRIPTION
Updated zephyr reference to one with bugfix
dfu/image_util: take trustzone and PM into account

https://github.com/NordicPlayground/fw-nrfconnect-zephyr/pull/145

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>