### PR TITLE
License fixes

### DIFF
--- a/applications/asset_tracker/src/certificates.h
+++ b/applications/asset_tracker/src/certificates.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: BSD-5-Clause-Nordic
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */
 
 #define NRF_CLOUD_CLIENT_ID "my-client-id"

--- a/samples/bluetooth/peripheral_hids_keyboard/src/main.c
+++ b/samples/bluetooth/peripheral_hids_keyboard/src/main.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: BSD-5-Clause-Nordic
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */
 
 #include <zephyr/types.h>

--- a/samples/nrf9160/gps/src/main.c
+++ b/samples/nrf9160/gps/src/main.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
 #include <zephyr.h>
 #include <bsd.h>
 #include <nrf_socket.h>

--- a/samples/nrf9160/lte_ble_gateway/src/certificates.h
+++ b/samples/nrf9160/lte_ble_gateway/src/certificates.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: BSD-5-Clause-Nordic
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */
 
 #ifndef _CERTIFICATES_H_

--- a/subsys/bootloader/include/bootloader.h
+++ b/subsys/bootloader/include/bootloader.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
 #ifndef BOOTLOADER_H__
 #define BOOTLOADER_H__
 

--- a/subsys/net/CMakeLists.txt
+++ b/subsys/net/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2018 Nordic Semiconductor
 #
-# SPDX-License-Identifier: BSD-5-Clause-Nordic
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
 add_subdirectory(lib)

--- a/subsys/net/Kconfig
+++ b/subsys/net/Kconfig
@@ -1,6 +1,6 @@
 # Copyright (c) 2018 Nordic Semiconductor
 #
-# SPDX-License-Identifier: BSD-5-Clause-Nordic
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
 menu "Networking"

--- a/subsys/net/lib/mqtt_socket/CMakeLists.txt
+++ b/subsys/net/lib/mqtt_socket/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2018 Nordic Semiconductor
 #
-# SPDX-License-Identifier: BSD-5-Clause-Nordic
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
 zephyr_library()

--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_mem.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_mem.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018 Nordic Semiconductor ASA
  *
- * SPDX-License-Identifier: BSD-5-Clause-Nordic
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */
 
 #ifndef NRF_CLOUD_MEM_H_

--- a/tests/subsys/event_manager/src/modules/test_config.h
+++ b/tests/subsys/event_manager/src/modules/test_config.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
 /* TEST_DATA */
 
 #define TEST_VAL1 -10

--- a/tests/subsys/event_manager/src/modules/test_multicontext_config.h
+++ b/tests/subsys/event_manager/src/modules/test_multicontext_config.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
 /* TEST_MULTICONTEXT */
 
 #include <zephyr.h>


### PR DESCRIPTION
Use LicenseRef- prefix since the Nordic license is not part of the SDPX
default set.

Add license to files that were missing it.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>