### PR TITLE
Partition manager: File handling improvements

### DIFF
--- a/doc/nrf/ug_partition_manager.rst
+++ b/doc/nrf/ug_partition_manager.rst
@@ -254,6 +254,49 @@ C code usage
       #else
       ...
 
+Hex files
+   Partition Manager associates 0 or 1 hex file with each partition.
+   A hex file can be assigned to a partition implicitly or explicitly.
+   Explicitly assigned hex files override implicitly assigned hex files.
+   Image partitions and phony partitions get a hex file assigned implicitly, while placeholder partitions do not.
+
+   Explicitly assigning a hex file to a partition is done by setting global properties in CMake.
+   The names of these properties must match a specific pattern, as shown below.
+
+   .. code-block:: cmake
+      :caption: Telling Partition manager about hex files.
+
+      set_property(
+         GLOBAL PROPERTY
+         app_PM_HEX_FILE # Has to match "*_PM_HEX_FILE"
+         ${PROJECT_BINARY_DIR}/signed.hex
+      )
+
+      set_property(
+         GLOBAL PROPERTY
+         app_PM_TARGET # Has to match "*_PM_TARGET
+         sign_target
+      )
+
+   Image partitions are implicitly assigned the compiled hex file, i.e. the hex file generated when building its corresponding image.
+   Phony partitions are implicitly assigned the result of merging the hex files assigned to its underlying partitions.
+
+   For example, if a bootloader needs an image partition to be cryptographically signed,
+   it must explicitly assign the signed hex file to that partition.
+   This is shown in the example below
+
+   Partition Manager creates a hex file called :file:`merged.hex`.
+   :file:`merged.hex` is flashed to the board when calling ``ninja flash``.
+   When creating :file:`merged.hex`, all assigned hex files are included in the merge operation.
+   When the hex files overlap the conflict will be resolved as follows:
+
+      * Hex files assigned to phony partitions overwrite hex files assigned to its underlying partitions.
+      * Hex files assigned to larger partitions overwrite hex files assigned to smaller partitions.
+      * Explcitly assigned hex files overwrite implicitly assigned hex files.
+
+   This effectively allows overwriting a partition's hex file by wrapping that partition in another partition,
+   and reporting a hex file for the new partition.
+
 rom_report
    When using the Partition Manager, run ``ninja rom_report`` to see the addresses and sizes of flash partitions.
 

--- a/samples/bootloader/CMakeLists.txt
+++ b/samples/bootloader/CMakeLists.txt
@@ -9,22 +9,5 @@ cmake_minimum_required(VERSION 3.8.2)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(bootloader)
 
-# This allows the bootloader sample to be built as a separate image in
-# a multi-image build context.
-
-if (IMAGE)
-  set(KERNEL_ELF ${logical_target_for_zephyr_elf})
-  set_property(
-    GLOBAL APPEND PROPERTY
-    HEX_FILES_TO_MERGE
-    ${PROJECT_BINARY_DIR}/zephyr/${KERNEL_HEX_NAME}
-    )
-  set_property(
-    GLOBAL APPEND PROPERTY
-    HEX_FILES_TO_MERGE_TARGET
-    ${KERNEL_ELF}
-    )
-endif()
-
 zephyr_library_sources(src/main.c)
 

--- a/subsys/bootloader/image/CMakeLists.txt
+++ b/subsys/bootloader/image/CMakeLists.txt
@@ -13,19 +13,6 @@ set(PROVISION_HEX_NAME     provision_data.hex)
 set(PROVISION_HEX          ${PROJECT_BINARY_DIR}/${PROVISION_HEX_NAME})
 set(SIGNED_KERNEL_HEX      ${PROJECT_BINARY_DIR}/signed_by_b0_${KERNEL_HEX_NAME})
 
-set_property(
-  GLOBAL APPEND PROPERTY
-  HEX_FILES_TO_MERGE
-  ${SIGNED_KERNEL_HEX}
-  ${PROVISION_HEX}
-)
-set_property(
-  GLOBAL APPEND PROPERTY
-  HEX_FILES_TO_MERGE_TARGET
-  signed_kernel_hex_target
-  provision_target
-)
-
 include(${CMAKE_CURRENT_LIST_DIR}/../cmake/debug_keys.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/../cmake/sign.cmake)
 

--- a/subsys/partition_manager/CMakeLists.txt
+++ b/subsys/partition_manager/CMakeLists.txt
@@ -12,12 +12,6 @@ set_property(GLOBAL APPEND PROPERTY
   -DUSE_PARTITION_MANAGER=$<TARGET_EXISTS:partition_manager>
   )
 
-# Safeguard to make sure folder naming does not break building on Windows
-if(${PROJECT_BINARY_DIR} MATCHES "[|]")
-  message(FATAL_ERROR "The character \"|\" is not allowed as filename or"
-          " folder name.\nThe offending path is: $${PROJECT_BINARY_DIR}")
-endif()
-
 if((EXISTS ${APPLICATION_SOURCE_DIR}/pm.yml) AND IMAGE)
   # Only run partition manager when being built as sub image.
 
@@ -36,13 +30,11 @@ if((EXISTS ${APPLICATION_SOURCE_DIR}/pm.yml) AND IMAGE)
   if(NOT "${ret}" STREQUAL "0")
     message(FATAL_ERROR "command failed with return code: ${ret}")
   endif()
-  string(LENGTH ${IMAGE} len)
-  MATH(EXPR len "${len}-1")
-  string(SUBSTRING ${IMAGE} 0 ${len} image_name)
+
   set_property(
     GLOBAL APPEND PROPERTY
-    PARTITION_MANAGER_CONFIG_FILES
-    "${image_name}|${PROJECT_BINARY_DIR}/include/generated/pm.yml|${PROJECT_BINARY_DIR}|${PROJECT_BINARY_DIR}/include/generated"
+    PM_IMAGES
+    ${IMAGE}
     )
   set_property(
     GLOBAL APPEND PROPERTY

--- a/subsys/partition_manager/CMakeLists.txt
+++ b/subsys/partition_manager/CMakeLists.txt
@@ -36,14 +36,4 @@ if((EXISTS ${APPLICATION_SOURCE_DIR}/pm.yml) AND IMAGE)
     PM_IMAGES
     ${IMAGE}
     )
-  set_property(
-    GLOBAL APPEND PROPERTY
-    PM_HEX_FILES_TO_MERGE
-    ${PROJECT_BINARY_DIR}/${KERNEL_HEX_NAME}
-    )
-  set_property(
-    GLOBAL APPEND PROPERTY
-    PM_HEX_FILES_TO_MERGE_TARGETS
-    ${IMAGE}zephyr_final
-    )
 endif()

--- a/west.yml
+++ b/west.yml
@@ -40,7 +40,7 @@ manifest:
     - name: fw-nrfconnect-zephyr
       path: zephyr
       west-commands: scripts/west-commands.yml
-      revision: 98c2d76ddd2903bbbd8ce72f4978942e51a283a4
+      revision: f3e79286d8f7812f159160d329485cd8f0cfae3a
     - name: fw-nrfconnect-mcuboot
       path: mcuboot
       revision: 4ef858c6781821248a3ac9e484a4b7697f831e1e

--- a/west.yml
+++ b/west.yml
@@ -40,10 +40,10 @@ manifest:
     - name: fw-nrfconnect-zephyr
       path: zephyr
       west-commands: scripts/west-commands.yml
-      revision: f3e79286d8f7812f159160d329485cd8f0cfae3a
+      revision: 0023611bbfabd0698a38a12e6f30d7a2a9108702
     - name: fw-nrfconnect-mcuboot
       path: mcuboot
-      revision: 4ef858c6781821248a3ac9e484a4b7697f831e1e
+      revision: 447495faa326082198c8e12493a2097f2ae20a99
     - name: fw-nrfconnect-tinycbor
       path: modules/lib/tinycbor
       revision: ef1f9c3d87474ec3570b1f46e91fd4b54a4fb421


### PR DESCRIPTION
Adapt to Partition Manager changes in fw-nrfconnect-zephyr:
 - Split partition_manager.py into two files
 - Port hex file merging to be based on Partition Manager

See commit messages and other PRs for more info.

Depends on https://github.com/NordicPlayground/fw-nrfconnect-zephyr/pull/146 and https://github.com/NordicPlayground/fw-nrfconnect-mcuboot/pull/36