### PR TITLE
manifest: update mcuboot

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -51,7 +51,7 @@ manifest:
       revision: 900c7eea92e45adba1067e044ec705d4541c84a5
     - name: mcuboot
       repo-path: fw-nrfconnect-mcuboot
-      revision: 0cf7965a146bad1becb1e260481d0e32e853d38e
+      revision: 034c0485a0754f87b947d2043d6cfdac48282836
     - name: mcumgr
       repo-path: fw-nrfconnect-mcumgr
       revision: f663988d35da559a37f263d369842dbce309d1fa


### PR DESCRIPTION
Update to image-ify DTC_OVERLAY_FILE.

See https://github.com/NordicPlayground/fw-nrfconnect-mcuboot/pull/35

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>