### PR TITLE
doc: libraries: add header and source file information

### DIFF
--- a/doc/nrf/templates/customservice_README.rst
+++ b/doc/nrf/templates/customservice_README.rst
@@ -50,6 +50,13 @@ API documentation
 *****************
 
 .. note::
+   If all source files are in one specific folder, add the folder name (even if there is only one source file).
+   If there are unrelated source files in the same folder, add the file name.
+
+| Header file: :file:`include/.h`
+| Source files: :file:`/`
+
+.. note::
    Remove the code block and replace with the name of the doxygen group that contains the API.
 
 .. code-block:: python

--- a/include/at_cmd_parser.rst
+++ b/include/at_cmd_parser.rst
@@ -17,6 +17,9 @@ Then, to parse a string, simply pass the returned AT command string to the libra
 API documentation
 *****************
 
+| Header file: :file:`include/at_cmd_parser.h`
+| Source file: :file:`lib/at_cmd_parser/src/at_cmd_parser.c`
+
 .. doxygengroup:: at_cmd_parser
    :project: nrf
    :members:

--- a/include/at_params.rst
+++ b/include/at_params.rst
@@ -21,6 +21,9 @@ Getter and setter methods are available to read parameter values.
 API documentation
 *****************
 
+| Header file: :file:`include/at_params.h`
+| Source file: :file:`lib/at_cmd_parser/src/at_params.c`
+
 .. doxygengroup:: at_params
    :project: nrf
    :members:

--- a/include/bluetooth/conn_ctx.rst
+++ b/include/bluetooth/conn_ctx.rst
@@ -14,6 +14,9 @@ The following Bluetooth LE service shows how to use this library: :ref:`hids_rea
 API documentation
 *****************
 
+| Header file: :file:`include/bluetooth/conn_ctx.h`
+| Source file: :file:`subsys/bluetooth/conn_ctx.c`
+
 .. doxygengroup:: bt_conn_ctx
    :project: nrf
    :members:

--- a/include/bluetooth/gatt_dm.rst
+++ b/include/bluetooth/gatt_dm.rst
@@ -21,6 +21,9 @@ Limitations
 API documentation
 *****************
 
+| Header file: :file:`include/bluetooth/gatt_dm.h`
+| Source file: :file:`subsys/bluetooth/gatt_dm.c`
+
 .. doxygengroup:: bt_gatt_dm
    :project: nrf
    :members:

--- a/include/bluetooth/gatt_pool.rst
+++ b/include/bluetooth/gatt_pool.rst
@@ -25,6 +25,9 @@ If you are unsure about the proper values, print the module's statistics to see 
 API documentation
 *****************
 
+| Header file: :file:`include/bluetooth/gatt_pool.h`
+| Source file: :file:`subsys/bluetooth/gatt_pool.c`
+
 .. doxygengroup:: bt_gatt_pool
    :project: nrf
    :members:

--- a/include/bluetooth/scan.rst
+++ b/include/bluetooth/scan.rst
@@ -84,6 +84,9 @@ Filter modes
 API documentation
 *****************
 
+| Header file: :file:`include/bluetooth/scan.h`
+| Source file: :file:`subsys/bluetooth/scan.c`
+
 .. doxygengroup:: nrf_bt_scan
    :project: nrf
    :members:

--- a/include/bluetooth/services/bas_c.rst
+++ b/include/bluetooth/services/bas_c.rst
@@ -44,6 +44,9 @@ Getting the last known value
 API documentation
 *****************
 
+| Header file: :file:`include/bas_c.h`
+| Source file: :file:`subsys/bluetooth/services/bas_c.c`
+
 .. doxygengroup:: bt_gatt_bas_c
    :project: nrf
    :members:

--- a/include/bluetooth/services/dfu_smp_c.rst
+++ b/include/bluetooth/services/dfu_smp_c.rst
@@ -73,6 +73,9 @@ The offset size of the current part and the total size are available in fields o
 API documentation
 *****************
 
+| Header file: :file:`include/dfu_smp_c.h`
+| Source file: :file:`subsys/bluetooth/services/dfu_smp_c.c`
+
 .. doxygengroup:: bt_gatt_dfu_smp_c
    :project: nrf
    :members:

--- a/include/bluetooth/services/hids.rst
+++ b/include/bluetooth/services/hids.rst
@@ -59,6 +59,9 @@ part of the report is not to be stored as a characteristic value.
 API documentation
 *****************
 
+| Header file: :file:`include/hids.h`
+| Source file: :file:`subsys/bluetooth/services/hids.c`
+
 .. doxygengroup:: bt_gatt_hids
    :project: nrf
    :members:

--- a/include/bluetooth/services/hids_c.rst
+++ b/include/bluetooth/services/hids_c.rst
@@ -117,6 +117,9 @@ To resume, call :cpp:func:`bt_gatt_hids_c_exit_suspend`.
 API documentation
 *****************
 
+| Header file: :file:`include/hids_c.h`
+| Source file: :file:`subsys/bluetooth/services/hids_c.c`
+
 .. doxygengroup:: bt_gatt_hids_c
    :project: nrf
    :members:

--- a/include/bluetooth/services/lbs.rst
+++ b/include/bluetooth/services/lbs.rst
@@ -35,6 +35,9 @@ Write:
 API documentation
 *****************
 
+| Header file: :file:`include/lbs.h`
+| Source file: :file:`subsys/bluetooth/services/lbs.c`
+
 .. doxygengroup:: bt_gatt_lbs
    :project: nrf
    :members:

--- a/include/bluetooth/services/nus.rst
+++ b/include/bluetooth/services/nus.rst
@@ -34,6 +34,9 @@ Notify
 API documentation
 *****************
 
+| Header file: :file:`include/nus.h`
+| Source file: :file:`subsys/bluetooth/services/nus.c`
+
 .. doxygengroup:: bt_gatt_nus
    :project: nrf
    :members:

--- a/include/bluetooth/services/nus_c.rst
+++ b/include/bluetooth/services/nus_c.rst
@@ -25,6 +25,9 @@ Another dedicated callback is triggered when your request has been completed, to
 API documentation
 *****************
 
+| Header file: :file:`include/nus_c.h`
+| Source file: :file:`subsys/bluetooth/services/nus_c.c`
+
 .. doxygengroup:: bt_gatt_nus_c
    :project: nrf
    :members:

--- a/include/bluetooth/services/throughput.rst
+++ b/include/bluetooth/services/throughput.rst
@@ -38,6 +38,9 @@ Read
 API documentation
 *****************
 
+| Header file: :file:`include/throughput.h`
+| Source file: :file:`subsys/bluetooth/services/throughput.c`
+
 .. doxygengroup::  bt_gatt_throughput
    :project: nrf
    :members:

--- a/include/dk_buttons_and_leds.rst
+++ b/include/dk_buttons_and_leds.rst
@@ -16,6 +16,9 @@ You can then set the value of a single LED, or set all of them to a state specif
 API documentation
 *****************
 
+| Header file: :file:`include/dk_buttons_and_leds.h`
+| Source files: :file:`lib/dk_buttons_and_leds/`
+
 .. doxygengroup:: dk_buttons_and_leds
    :project: nrf
    :members:

--- a/include/download_client.rst
+++ b/include/download_client.rst
@@ -51,6 +51,9 @@ If the server response contains "Connection: close", the library automatically r
 API documentation
 *****************
 
+| Header file: :file:`include/download_client.h`
+| Source files: :file:`subsys/net/lib/download_client/src/`
+
 .. doxygengroup:: dl_client
    :project: nrf
    :members:

--- a/include/drivers/st25r3911b_nfc.rst
+++ b/include/drivers/st25r3911b_nfc.rst
@@ -53,6 +53,9 @@ The driver requires calling its specific function periodically.
 API documentation
 *****************
 
+| Header file: :file:`include/st25r3911b_nfca.h`
+| Source files: :file:`drivers/st25r3911b/`
+
 .. doxygengroup:: st25r3911b_nfca
    :project: nrf
    :members:

--- a/include/event_manager.rst
+++ b/include/event_manager.rst
@@ -281,6 +281,9 @@ This subcommand set contains the following commands:
 API documentation
 *****************
 
+| Header file: :file:`include/event_manager.h`
+| Source files: :file:`subsys/event_manager/`
+
 .. doxygengroup:: event_manager
    :project: nrf
    :members:

--- a/include/modem_info.rst
+++ b/include/modem_info.rst
@@ -29,6 +29,9 @@ Note, however, that signal strength data (RSRP) is only available by registering
 API documentation
 *****************
 
+| Header file: :file:`include/modem_info.h`
+| Source files: :file:`lib/modem_info/`
+
 .. doxygengroup:: modem_info
    :project: nrf
    :members:

--- a/include/nfc/ndef/nfc_ndef.rst
+++ b/include/nfc/ndef/nfc_ndef.rst
@@ -162,6 +162,9 @@ API documentation
 Custom NDEF messages
 ====================
 
+| Header file: :file:`include/nfc_ndef_msg.h`
+| Source file: :file:`subsys/nfc/ndef/nfc_ndef_msg.c`
+
 .. doxygengroup:: nfc_ndef_msg
    :project: nrf
    :members:
@@ -170,6 +173,9 @@ Custom NDEF messages
 
 Custom NDEF records
 ===================
+
+| Header file: :file:`include/nfc_ndef_record.h`
+| Source file: :file:`subsys/nfc/ndef/nfc_ndef_record.c`
 
 .. doxygengroup:: nfc_ndef_record
    :project: nrf

--- a/include/nfc/ndef/nfc_text.rst
+++ b/include/nfc/ndef/nfc_text.rst
@@ -70,6 +70,9 @@ API documentation
 
 .. _nfc_text_record:
 
+| Header file: :file:`include/nfc_text_rec.h`
+| Source file: :file:`subsys/nfc/ndef/nfc_text_rec.c`
+
 .. doxygengroup:: nfc_text_rec
    :project: nrf
    :members:

--- a/include/nfc/ndef/nfc_uri.rst
+++ b/include/nfc/ndef/nfc_uri.rst
@@ -49,6 +49,9 @@ API documentation
 URI messages
 ============
 
+| Header file: :file:`include/nfc_uri_msg.h`
+| Source file: :file:`subsys/nfc/ndef/nfc_uri_msg.c`
+
 .. doxygengroup:: nfc_uri_msg
    :project: nrf
    :members:
@@ -57,6 +60,9 @@ URI messages
 
 URI records
 ===========
+
+| Header file: :file:`include/nfc_uri_rec.h`
+| Source file: :file:`subsys/nfc/ndef/nfc_uri_rec.c`
 
 .. doxygengroup:: nfc_uri_rec
    :project: nrf

--- a/include/nrf_cloud.rst
+++ b/include/nrf_cloud.rst
@@ -138,6 +138,9 @@ When a user disassociates a device, the library disallows any further sensor dat
 API documentation
 *****************
 
+| Header file: :file:`include/nrf_cloud.h`
+| Source files: :file:`subsys/net/lib/nrf_cloud/src/`
+
 .. doxygengroup:: nrf_cloud
    :project: nrf
    :members:

--- a/include/nrf_esb.rst
+++ b/include/nrf_esb.rst
@@ -11,6 +11,9 @@ Also, check out the :ref:`esb_prx_ptx` sample.
 API documentation
 *****************
 
+| Header file: :file:`include/nrf_esb.h`
+| Source files: :file:`subsys/enhanced_shockburst/`
+
 .. doxygengroup:: nrf_esb
    :project: nrf
    :members:

--- a/include/profiler.rst
+++ b/include/profiler.rst
@@ -154,6 +154,9 @@ This subcommand set contains the following commands:
 API documentation
 *****************
 
+| Header file: :file:`include/profiler.h`
+| Source files: :file:`subsys/profiler/`
+
 .. doxygengroup:: profiler
    :project: nrf
    :members:

--- a/include/spm.rst
+++ b/include/spm.rst
@@ -42,6 +42,9 @@ Peripherals configured as Non-Secure
 API documentation
 *****************
 
+| Header file: :file:`include/spm.h`
+| Source files: :file:`subsys/spm/`
+
 .. doxygengroup:: secure_partition_manager
    :project: nrf
    :members:


### PR DESCRIPTION
For the nRF5 SDK, customers frequently requested information
about where an API could be found. With RST, we have the
possibility to add this information, so we should. :)

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>