### PR TITLE
ci: Add nrf52840_pca20037 keyboard target to desktop CI artifacts.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,7 +86,7 @@ pipeline {
 
             script {
               /* Rename the nrf52 desktop samples */
-              desktop_platforms = ['nrf52840_pca20041', 'nrf52840_pca10056', 'nrf52840_pca10059']
+              desktop_platforms = ['nrf52840_pca20041', 'nrf52_pca20037', 'nrf52840_pca10059']
               for(int i=0; i<desktop_platforms.size(); i++) {
                 file_path = "zephyr/sanity-out/${desktop_platforms[i]}/nrf_desktop/test/zephyr/zephyr.hex"
                 check_and_store_sample("$file_path", "nrf_desktop_${desktop_platforms[i]}.hex")


### PR DESCRIPTION
Replace deprecated pca10056 artifact with pca20037.

Signed-off-by: Wiktor Miesok <wiktor.miesok@nordicsemi.no>