### PR TITLE
Sensor and GPS simulator stack fix

### DIFF
--- a/drivers/gps_sim/gps_sim.c
+++ b/drivers/gps_sim/gps_sim.c
@@ -36,10 +36,11 @@ struct gps_sim_data {
 	gps_trigger_handler_t drdy_handler;
 	struct gps_trigger drdy_trigger;
 
-	K_THREAD_STACK_MEMBER(thread_stack, CONFIG_GPS_SIM_THREAD_STACK_SIZE);
 	struct k_thread thread;
 #endif /* CONFIG_GPS_SIM_TRIGGER */
 };
+
+static K_THREAD_STACK_DEFINE(thread_stack, CONFIG_GPS_SIM_THREAD_STACK_SIZE);
 
 static struct gps_data nmea_sample;
 static struct k_mutex trigger_mutex;
@@ -127,8 +128,8 @@ static int gps_sim_init_thread(struct device *dev)
 		k_sem_init(&drv_data->gpio_sem, 0, 1);
 	}
 
-	k_thread_create(&drv_data->thread, drv_data->thread_stack,
-			CONFIG_GPS_SIM_THREAD_STACK_SIZE,
+	k_thread_create(&drv_data->thread, thread_stack,
+			K_THREAD_STACK_SIZEOF(thread_stack),
 			(k_thread_entry_t)gps_sim_thread, dev, NULL, NULL,
 			K_PRIO_COOP(CONFIG_GPS_SIM_THREAD_PRIORITY), 0, 0);
 

--- a/drivers/sensor/sensor_sim/sensor_sim.c
+++ b/drivers/sensor/sensor_sim/sensor_sim.c
@@ -19,6 +19,8 @@
 
 LOG_MODULE_REGISTER(sensor_sim, CONFIG_SENSOR_SIM_LOG_LEVEL);
 
+static K_THREAD_STACK_DEFINE(thread_stack, CONFIG_SENSOR_SIM_THREAD_STACK_SIZE);
+
 static const double base_accel_samples[3] = {0.0, 0.0, 0.0};
 static double accel_samples[3];
 
@@ -128,8 +130,8 @@ static int sensor_sim_init_thread(struct device *dev)
 
 #endif   /* CONFIG_SENSOR_SIM_TRIGGER_USE_BUTTON */
 
-	k_thread_create(&drv_data->thread, drv_data->thread_stack,
-			CONFIG_SENSOR_SIM_THREAD_STACK_SIZE,
+	k_thread_create(&drv_data->thread, thread_stack,
+			K_THREAD_STACK_SIZEOF(thread_stack),
 			(k_thread_entry_t)sensor_sim_thread, dev,
 			NULL, NULL,
 			K_PRIO_COOP(CONFIG_SENSOR_SIM_THREAD_PRIORITY),

--- a/drivers/sensor/sensor_sim/sensor_sim.h
+++ b/drivers/sensor/sensor_sim/sensor_sim.h
@@ -21,8 +21,6 @@ struct sensor_sim_data {
 	sensor_trigger_handler_t drdy_handler;
 	struct sensor_trigger drdy_trigger;
 
-	K_THREAD_STACK_MEMBER(thread_stack,
-			      CONFIG_SENSOR_SIM_THREAD_STACK_SIZE);
 	struct k_thread thread;
 #endif  /* CONFIG_SENSOR_SIM_TRIGGER */
 };


### PR DESCRIPTION
The sensor and GPS simulators run threads which have stacks as members of a driver data struct. Generally, having stacks as members of structs is discouraged in Zephyr (though common practice in drivers). After recent, unidentified changes upstream the asset tracker and other apps using these simulators would hardfault because of accessing .

These two patches removes the stacks from the structs and set them as global statics.