### PR TITLE
subsys: event_manager: Log before notification

### DIFF
--- a/subsys/event_manager/event_manager.c
+++ b/subsys/event_manager/event_manager.c
@@ -69,8 +69,7 @@ static void log_event(const struct event_header *eh)
 }
 
 static void log_event_progress(const struct event_type *et,
-			       const struct event_listener *el,
-			       bool consumed)
+			       const struct event_listener *el)
 {
 	if (!IS_ENABLED(CONFIG_DESKTOP_EVENT_MANAGER_SHOW_EVENTS) ||
 	    !IS_ENABLED(CONFIG_DESKTOP_EVENT_MANAGER_SHOW_EVENT_HANDLERS) ||
@@ -78,8 +77,18 @@ static void log_event_progress(const struct event_type *et,
 		return;
 	}
 
-	LOG_INF("|\t%s notified%s", el->name,
-		(consumed)?(" (event consumed)"):(""));
+	LOG_INF("|\tnotifying %s", el->name);
+}
+
+static void log_event_consumed(const struct event_type *et)
+{
+	if (!IS_ENABLED(CONFIG_DESKTOP_EVENT_MANAGER_SHOW_EVENTS) ||
+	    !IS_ENABLED(CONFIG_DESKTOP_EVENT_MANAGER_SHOW_EVENT_HANDLERS) ||
+	    !log_is_event_displayed(et)) {
+		return;
+	}
+
+	LOG_INF("|\tevent consumed");
 }
 
 static void log_event_init(void)
@@ -256,9 +265,13 @@ static void event_processor_fn(struct k_work *work)
 				__ASSERT_NO_MSG(el != NULL);
 				__ASSERT_NO_MSG(el->notification != NULL);
 
+				log_event_progress(et, el);
+
 				consumed = el->notification(eh);
 
-				log_event_progress(et, el, consumed);
+				if (consumed) {
+					log_event_consumed(et);
+				}
 			}
 		}
 


### PR DESCRIPTION
Moved logging before notifying module - it makes debugging easier.