### PR TITLE
Enable FP_SHARING for asset tracker and LTE BLE gateway

### DIFF
--- a/drivers/gps_sim/Kconfig
+++ b/drivers/gps_sim/Kconfig
@@ -7,6 +7,9 @@
 
 menuconfig GPS_SIM
 	bool "GPS simulator"
+	# FP_SHARING needs to be enabled if FLOAT is enabled, as other contexts
+	# might also use the FPU.
+	select FP_SHARING if FLOAT
 	help
 	  Enable GPS simulator.
 

--- a/drivers/sensor/sensor_sim/Kconfig
+++ b/drivers/sensor/sensor_sim/Kconfig
@@ -7,6 +7,9 @@
 
 menuconfig SENSOR_SIM
 	bool "Sensor simulator"
+	# FP_SHARING needs to be enabled if FLOAT is enabled, as other contexts
+	# might also use the FPU.
+	select FP_SHARING if FLOAT
 	help
 	  Enable sensor simulator.
 

--- a/lib/bsdlib/Kconfig
+++ b/lib/bsdlib/Kconfig
@@ -9,6 +9,7 @@ config BSD_LIBRARY
 	bool
 	prompt "Use BSD Socket library for IP/TLS/DTLS"
 	select FLOAT
+	select FP_SHARING
 	select NET_OFFLOAD
 	select NET_SOCKETS_OFFLOAD
 	depends on TRUSTED_EXECUTION_NONSECURE


### PR DESCRIPTION
Mulitple threads use floats, so CONFIG_FP_SHARING needs to be
enabled for the applications to run.