### PR TITLE
tests: unity: Fix mock include path not added to all files

### DIFF
--- a/tests/unity/CMakeLists.txt
+++ b/tests/unity/CMakeLists.txt
@@ -166,6 +166,6 @@ function(cmock_handle header_file)
 
   cmock_linker_wrap_trick(${mod_header_path})
 
-  target_include_directories(app PRIVATE ${CMOCK_PRODUCTS_DIR})
+  target_include_directories(zephyr_interface BEFORE INTERFACE ${CMOCK_PRODUCTS_DIR})
   message(STATUS "Generating cmock for header ${header_file}")
 endfunction()


### PR DESCRIPTION
Unity/Cmock framework generates customized version of mocked
headers which should be used instead of original one in the
test. Custom include path was only added to app library. That
resulted in error when mocked module was not part of app library.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>