### PR TITLE
Asset tracker: Add UI module and adapt app to use it

### DIFF
--- a/applications/asset_tracker/CMakeLists.txt
+++ b/applications/asset_tracker/CMakeLists.txt
@@ -16,7 +16,14 @@ target_sources(app PRIVATE src/main.c)
 # NORDIC SDK APP END
 zephyr_include_directories(src)
 
-include_directories(src/orientation_detector)
-target_sources(app PRIVATE src/orientation_detector/orientation_detector.c)
-include_directories(src/cloud_codec)
-target_sources(app PRIVATE src/cloud_codec/cloud_codec.c)
+# Include application events and configuration headers
+zephyr_library_include_directories(
+  src/orientation_detector
+  src/ui
+  src/cloud_codec
+  )
+
+# Application sources
+add_subdirectory(src/orientation_detector)
+add_subdirectory(src/ui)
+add_subdirectory(src/cloud_codec)

--- a/applications/asset_tracker/Kconfig
+++ b/applications/asset_tracker/Kconfig
@@ -6,6 +6,8 @@
 
 menu "Application sample"
 
+rsource "src/ui/Kconfig"
+
 config CLOUD_BUTTON
 	bool "Enable button sensor"
 	default y

--- a/applications/asset_tracker/src/cloud_codec/CMakeLists.txt
+++ b/applications/asset_tracker/src/cloud_codec/CMakeLists.txt
@@ -5,3 +5,4 @@
 #
 
 zephyr_include_directories(.)
+target_sources(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/cloud_codec.c)

--- a/applications/asset_tracker/src/orientation_detector/CMakeLists.txt
+++ b/applications/asset_tracker/src/orientation_detector/CMakeLists.txt
@@ -5,3 +5,4 @@
 #
 
 zephyr_include_directories(.)
+target_sources(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/orientation_detector.c)

--- a/applications/asset_tracker/src/ui/CMakeLists.txt
+++ b/applications/asset_tracker/src/ui/CMakeLists.txt
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2019 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+zephyr_include_directories(include)
+target_sources(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/ui.c)
+target_sources_ifdef(CONFIG_UI_BUZZER
+	app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/buzzer.c
+	)
+target_sources_ifdef(CONFIG_UI_NMOS
+	app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/nmos.c
+	)
+target_sources_ifdef(
+	CONFIG_UI_LED_USE_PWM
+	app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/led_pwm.c
+	)

--- a/applications/asset_tracker/src/ui/Kconfig
+++ b/applications/asset_tracker/src/ui/Kconfig
@@ -1,0 +1,95 @@
+#
+# Copyright (c) 2019 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+menu "User Interface"
+
+config UI_LED_USE_PWM
+	bool "Use PWM to control LEDs"
+	default y if BOARD_NRF9160_PCA20035NS
+	select PWM if BOARD_NRF9160_PCA20035NS
+	select PWM_0 if BOARD_NRF9160_PCA20035NS
+
+if UI_LED_USE_PWM
+
+config UI_LED_PWM_DEV_NAME
+	string "PWM device name for RGB LED"
+	default "$(dt_str_val,DT_NORDIC_NRF_PWM_PWM_0_LABEL)" if BOARD_NRF9160_PCA20035NS
+
+config UI_LED_RED_PIN
+	int "Red LED pin number"
+	default $(dt_int_val,DT_NORDIC_NRF_PWM_PWM_0_CH0_PIN)
+
+config UI_LED_GREEN_PIN
+	int "Green LED pin number"
+	default $(dt_int_val,DT_NORDIC_NRF_PWM_PWM_0_CH1_PIN)
+
+config UI_LED_BLUE_PIN
+	int "Blue LED pin number"
+	default $(dt_int_val,DT_NORDIC_NRF_PWM_PWM_0_CH2_PIN)
+
+endif # UI_LED_USE_PWM
+
+config UI_BUZZER
+	bool "Enable buzzer"
+	default y if BOARD_NRF9160_PCA20035NS
+	select PWM if BOARD_NRF9160_PCA20035NS
+	select PWM_1 if BOARD_NRF9160_PCA20035NS
+
+if UI_BUZZER
+
+config UI_BUZZER_PWM_DEV_NAME
+	string "PWM device name for buzzer"
+	default "$(dt_str_val,DT_NORDIC_NRF_PWM_PWM_1_LABEL)" if BOARD_NRF9160_PCA20035NS
+
+config UI_BUZZER_PIN
+	int "Buzzer pin number"
+	default $(dt_int_val,DT_NORDIC_NRF_PWM_PWM_1_CH0_PIN)
+
+config UI_BUZZER_MIN_FREQUENCY
+	int "Minimum buzzer frequency"
+	default 100
+
+config UI_BUZZER_MAX_FREQUENCY
+	int "Maximum buzzer frequency"
+	default 10000
+
+endif # UI_BUZZER
+
+config UI_NMOS
+	bool "Enable NMOS control"
+	default y if BOARD_NRF9160_PCA20035NS
+	select PWM if BOARD_NRF9160_PCA20035NS
+	select PWM_2 if BOARD_NRF9160_PCA20035NS
+
+if UI_NMOS
+
+config UI_NMOS_PWM_DEV_NAME
+	string "PWM device name for buzzer"
+	default "$(dt_str_val,DT_NORDIC_NRF_PWM_PWM_2_LABEL)" if BOARD_NRF9160_PCA20035NS
+
+config UI_NMOS_1_PIN
+	int "NMOS 1 pin"
+	default $(dt_int_val,DT_NORDIC_NRF_PWM_PWM_2_CH0_PIN)
+
+config UI_NMOS_2_PIN
+	int "NMOS 2 pin"
+	default $(dt_int_val,DT_NORDIC_NRF_PWM_PWM_2_CH1_PIN)
+
+config UI_NMOS_3_PIN
+	int "NMOS 3 pin"
+	default $(dt_int_val,DT_NORDIC_NRF_PWM_PWM_2_CH2_PIN)
+
+config UI_NMOS_4_PIN
+	int "NMOS 4 pin"
+	default $(dt_int_val,DT_NORDIC_NRF_PWM_PWM_2_CH3_PIN)
+
+endif # UI_NMOS
+
+endmenu
+
+module = UI
+module-str = User Interface
+source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"

--- a/applications/asset_tracker/src/ui/buzzer.c
+++ b/applications/asset_tracker/src/ui/buzzer.c
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#include <zephyr.h>
+#include <pwm.h>
+
+#include "ui.h"
+
+#include <logging/log.h>
+LOG_MODULE_REGISTER(buzzer, CONFIG_UI_LOG_LEVEL);
+
+#define BUZZER_MIN_FREQUENCY		CONFIG_UI_BUZZER_MIN_FREQUENCY
+#define BUZZER_MAX_FREQUENCY		CONFIG_UI_BUZZER_MAX_FREQUENCY
+#define BUZZER_MIN_INTENSITY		0
+#define BUZZER_MAX_INTENSITY		100
+#define BUZZER_MIN_DUTY_CYCLE_DIV	100
+#define BUZZER_MAX_DUTY_CYCLE_DIV	2
+
+struct device *pwm_dev;
+static atomic_t buzzer_enabled;
+
+static u32_t intensity_to_duty_cycle_divisor(u8_t intensity)
+{
+	return MIN(
+		MAX(((intensity - BUZZER_MIN_INTENSITY) *
+		    (BUZZER_MAX_DUTY_CYCLE_DIV - BUZZER_MIN_DUTY_CYCLE_DIV) /
+		    (BUZZER_MAX_INTENSITY - BUZZER_MIN_INTENSITY) +
+		    BUZZER_MIN_DUTY_CYCLE_DIV),
+		    BUZZER_MAX_DUTY_CYCLE_DIV),
+		BUZZER_MIN_DUTY_CYCLE_DIV);
+}
+
+static int pwm_out(u32_t frequency, u8_t intensity)
+{
+	static u32_t prev_period;
+	u32_t period = (frequency > 0) ? USEC_PER_SEC / frequency : 0;
+	u32_t duty_cycle = (intensity == 0) ? 0 :
+		period / intensity_to_duty_cycle_divisor(intensity);
+
+	/* Applying workaround due to limitations in PWM driver that doesn't
+	 * allow changing period while PWM is running. Setting pulse to 0
+	 * disables the PWM, but not before the current period is finished.
+	 */
+	if (prev_period) {
+		pwm_pin_set_usec(pwm_dev, CONFIG_UI_BUZZER_PIN, prev_period, 0);
+		k_sleep(MAX(K_MSEC(prev_period / USEC_PER_MSEC), K_MSEC(1)));
+	}
+
+	prev_period = period;
+
+	return pwm_pin_set_usec(pwm_dev, CONFIG_UI_BUZZER_PIN,
+				period, duty_cycle);
+}
+
+static void buzzer_disable(void)
+{
+	atomic_set(&buzzer_enabled, 0);
+
+	pwm_out(0, 0);
+
+#ifdef CONFIG_DEVICE_POWER_MANAGEMENT
+	int err = device_set_power_state(pwm_dev,
+					 DEVICE_PM_SUSPEND_STATE,
+					 NULL, NULL);
+	if (err) {
+		LOG_ERR("PWM disable failed");
+	}
+#endif
+}
+
+static int buzzer_enable(void)
+{
+	int err = 0;
+
+	atomic_set(&buzzer_enabled, 1);
+
+#ifdef CONFIG_DEVICE_POWER_MANAGEMENT
+	err = device_set_power_state(pwm_dev,
+					 DEVICE_PM_ACTIVE_STATE,
+					 NULL, NULL);
+	if (err) {
+		LOG_ERR("PWM enable failed");
+		return err;
+	}
+#endif
+
+	return err;
+}
+
+int ui_buzzer_init(void)
+{
+	const char *dev_name = CONFIG_UI_BUZZER_PWM_DEV_NAME;
+	int err = 0;
+
+	pwm_dev = device_get_binding(dev_name);
+	if (!pwm_dev) {
+		LOG_ERR("Could not bind to device %s", log_strdup(dev_name));
+		err = -ENODEV;
+	}
+
+	buzzer_enable();
+
+	return err;
+}
+
+int ui_buzzer_set_frequency(u32_t frequency, u8_t intensity)
+{
+	if (frequency == 0 || intensity == 0) {
+		LOG_DBG("Frequency set to 0, disabling PWM\n");
+		buzzer_disable();
+		return 0;
+	}
+
+	if ((frequency < BUZZER_MIN_FREQUENCY) ||
+	    (frequency > BUZZER_MAX_FREQUENCY)) {
+		return -EINVAL;
+	}
+
+	if ((intensity < BUZZER_MIN_INTENSITY) ||
+	    (intensity > BUZZER_MAX_INTENSITY)) {
+		return -EINVAL;
+	}
+
+	if (!atomic_get(&buzzer_enabled)) {
+		buzzer_enable();
+	}
+
+	return pwm_out(frequency, intensity);
+}

--- a/applications/asset_tracker/src/ui/include/buzzer.h
+++ b/applications/asset_tracker/src/ui/include/buzzer.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+/**@file
+ *
+ * @brief   Buzzer control for the User Interface module. The module uses PWM to
+ *	    control the buzzer output frequency.
+ */
+
+#ifndef UI_BUZZER_H__
+#define UI_BUZZER_H__
+
+#include <zephyr.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**@brief Initialize buzzer in the user interface module. */
+int ui_buzzer_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* UI_BUZZER_H__ */

--- a/applications/asset_tracker/src/ui/include/led_effect.h
+++ b/applications/asset_tracker/src/ui/include/led_effect.h
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#ifndef LED_EFFECT_H__
+#define LED_EFFECT_H__
+
+/**
+ * @brief LED Effect
+ * @defgroup led_effect LED Effect
+ * @{
+ */
+
+#include <zephyr/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct led_color {
+	u8_t c[3];
+};
+
+struct led_effect_step {
+	struct led_color color;
+	u16_t substep_count;
+	u16_t substep_time;
+};
+
+struct led_effect {
+	struct led_effect_step *steps;
+	u16_t step_count;
+	bool loop_forever;
+};
+
+#define LED_COLOR(_r, _g, _b) {		\
+		.c = {_r, _g, _b}	\
+}
+#define LED_NOCOLOR() {			\
+		.c = {0, 0, 0}		\
+}
+
+#define LED_EFFECT_LED_ON(_color)					       \
+	{								       \
+		.steps = ((const struct led_effect_step[]) {		       \
+			{						       \
+				.color = _color,			       \
+				.substep_count = 1,			       \
+				.substep_time = 0,			       \
+			},						       \
+		}),							       \
+		.step_count = 1,					       \
+		.loop_forever = false,					       \
+	}
+
+#define LED_EFFECT_LED_OFF() LED_EFFECT_LED_ON(LED_NOCOLOR())
+
+#define LED_EFFECT_LED_BLINK(_period, _color)				       \
+	{								       \
+		.steps = ((const struct led_effect_step[]) {		       \
+			{						       \
+				.color = _color,			       \
+				.substep_count = 1,			       \
+				.substep_time = (_period),		       \
+			},						       \
+			{						       \
+				.color = LED_NOCOLOR(),			       \
+				.substep_count = 1,			       \
+				.substep_time = (_period),		       \
+			},						       \
+		}),							       \
+		.step_count = 2,					       \
+		.loop_forever = true,					       \
+	}
+
+#define _BREATH_SUBSTEPS 15
+#define _BREATH_PAUSE_SUBSTEPS 1
+#define LED_EFFECT_LED_BREATHE(_period, _pause, _color)			       \
+	{								       \
+		.steps = ((struct led_effect_step[]) {			       \
+			{						       \
+				.color = _color,			       \
+				.substep_count = _BREATH_SUBSTEPS,	       \
+				.substep_time = ((_period +		       \
+					(_BREATH_SUBSTEPS - 1))		       \
+					/ _BREATH_SUBSTEPS),		       \
+			},						       \
+			{						       \
+				.color = _color,			       \
+				.substep_count = 1,			       \
+				.substep_time = _period,		       \
+			},						       \
+			{						       \
+				.color = LED_NOCOLOR(),			       \
+				.substep_count = _BREATH_SUBSTEPS,	       \
+				.substep_time = ((_period +		       \
+					(_BREATH_SUBSTEPS - 1))		       \
+					/ _BREATH_SUBSTEPS),		       \
+			},						       \
+			{						       \
+				.color = LED_NOCOLOR(),			       \
+				.substep_count = _BREATH_PAUSE_SUBSTEPS,       \
+				.substep_time = _pause,			       \
+			},						       \
+		}),							       \
+		.step_count = 4,					       \
+		.loop_forever = true,					       \
+	}
+
+#ifdef __cplusplus
+}
+#endif
+
+/**
+ * @}
+ */
+
+#endif /* LED_EFFECT_H_ */

--- a/applications/asset_tracker/src/ui/include/led_pwm.h
+++ b/applications/asset_tracker/src/ui/include/led_pwm.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+/**@file
+ *
+ * @brief   LED control for the User Interface module. The module uses PWM to
+ *	    control RGB colors and light intensity.
+ */
+
+#ifndef UI_LEDS_H__
+#define UI_LEDS_H__
+
+#include <zephyr.h>
+#include "ui.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**@brief Initializes LEDs in the user interface module. */
+int ui_leds_init(void);
+
+/**@brief Starts the PWM and handling of LED effects. */
+void ui_leds_start(void);
+
+/**@brief Stops the LED effects. */
+void ui_leds_stop(void);
+
+/**@brief Sets LED effect based in UI LED state. */
+void ui_led_set_effect(enum ui_led_pattern state);
+
+/**@brief Sets RGB and light intensity values, in 0 - 255 ranges. */
+int ui_led_set_rgb(u8_t red, u8_t green, u8_t blue);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* UI_LEDS_H__ */

--- a/applications/asset_tracker/src/ui/include/nmos.h
+++ b/applications/asset_tracker/src/ui/include/nmos.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/**@file
+ *
+ * @brief   NMOS control for the User Interface module.
+ */
+
+#ifndef UI_NMOS_H__
+#define UI_NMOS_H__
+
+#include <zephyr.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**@brief Initializes NMOS transistor control. */
+int ui_nmos_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* UI_NMOS_H__ */

--- a/applications/asset_tracker/src/ui/include/ui.h
+++ b/applications/asset_tracker/src/ui/include/ui.h
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/**@file
+ *
+ * @brief   User interface module.
+ *
+ * Module that handles user interaction through button, RGB LED and buzzer.
+ */
+
+#ifndef UI_H__
+#define UI_H__
+
+#include <zephyr.h>
+#include <dk_buttons_and_leds.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define UI_BUTTON_1			1
+#define UI_BUTTON_2			2
+#define UI_SWITCH_1			3
+#define UI_SWITCH_2			4
+
+#define UI_LED_1			1
+#define UI_LED_2			2
+#define UI_LED_3			3
+#define UI_LED_4			4
+
+#define UI_NMOS_1			0
+#define UI_NMOS_2			1
+#define UI_NMOS_3			2
+#define UI_NMOS_4			3
+
+#define UI_LED_ON(x)			(x)
+#define UI_LED_BLINK(x)			((x) << 8)
+#define UI_LED_GET_ON(x)		((x) & 0xFF)
+#define UI_LED_GET_BLINK(x)		(((x) >> 8) & 0xFF)
+
+#ifdef CONFIG_UI_LED_USE_PWM
+
+#define UI_LED_ON_PERIOD_NORMAL		500
+#define UI_LED_OFF_PERIOD_NORMAL	5000
+#define UI_LED_ON_PERIOD_ERROR		500
+#define UI_LED_OFF_PERIOD_ERROR		500
+
+#define UI_LED_MAX			50
+
+#define UI_LED_COLOR_OFF		LED_COLOR(0, 0, 0)
+#define UI_LED_COLOR_RED		LED_COLOR(UI_LED_MAX, 0, 0)
+#define UI_LED_COLOR_GREEN		LED_COLOR(0, UI_LED_MAX, 0)
+#define UI_LED_COLOR_BLUE		LED_COLOR(0, 0, UI_LED_MAX)
+#define UI_LED_COLOR_WHITE		LED_COLOR(UI_LED_MAX, UI_LED_MAX,      \
+						  UI_LED_MAX)
+#define UI_LED_COLOR_YELLOW		LED_COLOR(UI_LED_MAX, UI_LED_MAX, 0)
+#define UI_LED_COLOR_CYAN		LED_COLOR(0, UI_LED_MAX, UI_LED_MAX)
+#define UI_LED_COLOR_PURPLE		LED_COLOR(UI_LED_MAX, 0, UI_LED_MAX)
+
+#define UI_LTE_DISCONNECTED_COLOR	UI_LED_COLOR_OFF
+#define UI_LTE_CONNECTING_COLOR		UI_LED_COLOR_BLUE
+#define UI_LTE_CONNECTED_COLOR		UI_LED_COLOR_BLUE
+#define UI_CLOUD_CONNECTING_COLOR	UI_LED_COLOR_BLUE
+#define UI_CLOUD_CONNECTED_COLOR	UI_LED_COLOR_GREEN
+#define UI_CLOUD_PAIRING_COLOR		UI_LED_COLOR_YELLOW
+#define UI_ACCEL_CALIBRATING_COLOR	UI_LED_COLOR_PURPLE
+#define UI_LED_ERROR_CLOUD_COLOR	UI_LED_COLOR_RED
+#define UI_LED_ERROR_BSD_REC_COLOR	UI_LED_COLOR_RED
+#define UI_LED_ERROR_BSD_IRREC_COLOR	UI_LED_COLOR_RED
+#define UI_LED_ERROR_LTE_LC_COLOR	UI_LED_COLOR_RED
+#define UI_LED_ERROR_UNKNOWN_COLOR	UI_LED_COLOR_WHITE
+
+#else
+
+#define UI_LED_ON_PERIOD_NORMAL		500
+#define UI_LED_OFF_PERIOD_NORMAL	500
+
+#endif /* CONFIG_UI_LED_USE_PWM */
+
+/**@brief UI LED state pattern definitions. */
+enum ui_led_pattern {
+#ifdef CONFIG_UI_LED_USE_PWM
+	UI_LTE_DISCONNECTED,
+	UI_LTE_CONNECTING,
+	UI_LTE_CONNECTED,
+	UI_CLOUD_CONNECTING,
+	UI_CLOUD_CONNECTED,
+	UI_CLOUD_PAIRING,
+	UI_ACCEL_CALIBRATING,
+	UI_LED_ERROR_CLOUD,
+	UI_LED_ERROR_BSD_REC,
+	UI_LED_ERROR_BSD_IRREC,
+	UI_LED_ERROR_LTE_LC,
+	UI_LED_ERROR_UNKNOWN,
+#else /* LED patterns without using PWM. */
+	UI_LTE_DISCONNECTED	= UI_LED_ON(0),
+	UI_LTE_CONNECTING	= UI_LED_BLINK(DK_LED3_MSK),
+	UI_LTE_CONNECTED	= UI_LED_BLINK(DK_LED3_MSK),
+	UI_CLOUD_CONNECTING	= UI_LED_BLINK(DK_LED3_MSK | DK_LED4_MSK),
+	UI_CLOUD_CONNECTED	= UI_LED_ON(DK_LED4_MSK),
+	UI_CLOUD_PAIRING	= UI_LED_BLINK(DK_LED3_MSK | DK_LED4_MSK),
+	UI_ACCEL_CALIBRATING	= UI_LED_ON(DK_LED1_MSK | DK_LED3_MSK),
+	UI_LED_ERROR_CLOUD	= UI_LED_BLINK(DK_LED1_MSK | DK_LED4_MSK),
+	UI_LED_ERROR_BSD_REC	= UI_LED_BLINK(DK_LED1_MSK | DK_LED3_MSK),
+	UI_LED_ERROR_BSD_IRREC	= UI_LED_BLINK(DK_ALL_LEDS_MSK),
+	UI_LED_ERROR_LTE_LC	= UI_LED_BLINK(DK_LED1_MSK | DK_LED2_MSK),
+	UI_LED_ERROR_UNKNOWN	= UI_LED_ON(DK_ALL_LEDS_MSK)
+#endif /* CONFIG_UI_LED_USE_PWM */
+};
+
+/**@brief UI event types. */
+enum ui_evt_type {
+	UI_EVT_BUTTON_ACTIVE,
+	UI_EVT_BUTTON_INACTIVE
+};
+
+/**@brief UI event structure. */
+struct ui_evt {
+	enum ui_evt_type type;
+
+	union {
+		u32_t button;
+	};
+};
+
+/**
+ * @brief UI callback handler type definition.
+ *
+ * @param evt Pointer to event struct.
+ */
+typedef void (*ui_callback_t)(struct ui_evt evt);
+
+/**
+ * @brief Initializes the user interface module.
+ *
+ * @param cb UI callback handler. Can be NULL to disable callbacks.
+ *
+ * @return 0 on success or negative error value on failure.
+ */
+int ui_init(ui_callback_t cb);
+
+/**
+ * @brief Sets the LED pattern.
+ *
+ * @param pattern LED pattern.
+ */
+void ui_led_set_pattern(enum ui_led_pattern pattern);
+
+/**
+ * @brief Sets a LED's state. Only the one LED is affected, the rest of the
+ *	  LED pattern is preserved. Only has effect if the specified LED is not
+ *	  controlled by PWM.
+ *
+ * @param led LED number to be controlled.
+ * @param value 0 turns the LED off, a non-zero value turns the LED on.
+ */
+void ui_led_set_state(u32_t led, u8_t value);
+
+/**
+ * @brief Gets the LED pattern.
+ *
+ * @return Current LED pattern.
+ */
+enum ui_led_pattern ui_led_get_pattern(void);
+
+/**
+ * @brief Sets the LED RGB color.
+ *
+ * @param red Red, in range 0 - 255.
+ * @param green Green, in range 0 - 255.
+ * @param blue Blue, in range 0 - 255.
+ *
+ * @return 0 on success or negative error value on failure.
+ */
+int ui_led_set_color(u8_t red, u8_t green, u8_t blue);
+
+/**
+ * @brief Get the state of a button.
+ *
+ * @param button Button number.
+ *
+ * @return 1 if button is active, 0 if it's inactive.
+ */
+bool ui_button_is_active(u32_t button);
+
+/**
+ * @brief Set the buzzer frequency.
+ *
+ * @param frequency Frequency. If set to 0, the buzzer is disabled.
+ *		    The frequency is limited to the range 100 - 10 000 Hz.
+ * @param intensity Intensity of the buzzer output. If set to 0, the buzzer is
+ *		    disabled.
+ *		    The frequency is limited to the range 0 - 100 %.
+ *
+ * @return 0 on success or negative error value on failure.
+ */
+int ui_buzzer_set_frequency(u32_t frequency, u8_t intensity);
+
+/**
+ * @brief Write value to pin controlling NMOS transistor.
+ *
+ * @param nmos_idx	NMOS to control.
+ * @param value		1 sets high signal on NMOS gate, 0 sets it low.
+ *
+ * @return 0 on success or negative error value on failure.
+ */
+int ui_nmos_write(size_t nmos_idx, u8_t value);
+
+/**
+ * @brief Control NMOS with PWM signal.
+ *
+ * @param period	PWM signal period in microseconds.
+ * @param pulse	PWM signal Pulse in microseconds.
+ *
+ * @return 0 on success or negative error value on failure.
+ */
+int ui_nmos_pwm_set(size_t nmos_idx, u32_t period, u32_t pulse);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* UI_H__ */

--- a/applications/asset_tracker/src/ui/led_pwm.c
+++ b/applications/asset_tracker/src/ui/led_pwm.c
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#include <zephyr.h>
+#include <pwm.h>
+#include <string.h>
+
+#include "ui.h"
+#include "led_pwm.h"
+#include "led_effect.h"
+
+#include <logging/log.h>
+LOG_MODULE_REGISTER(ui_led_pwm, CONFIG_UI_LOG_LEVEL);
+
+struct led {
+	struct device *pwm_dev;
+
+	size_t id;
+	struct led_color color;
+	const struct led_effect *effect;
+	u16_t effect_step;
+	u16_t effect_substep;
+
+	struct k_delayed_work work;
+};
+
+static const struct led_effect effect[] = {
+	[UI_LTE_DISCONNECTED] = LED_EFFECT_LED_BREATHE(UI_LED_ON_PERIOD_NORMAL,
+					UI_LED_OFF_PERIOD_NORMAL,
+					UI_LTE_DISCONNECTED_COLOR),
+	[UI_LTE_CONNECTING] = LED_EFFECT_LED_BREATHE(UI_LED_ON_PERIOD_NORMAL,
+					UI_LED_OFF_PERIOD_NORMAL,
+					UI_LTE_CONNECTING_COLOR),
+	[UI_LTE_CONNECTED] = LED_EFFECT_LED_BREATHE(UI_LED_ON_PERIOD_NORMAL,
+					UI_LED_OFF_PERIOD_NORMAL,
+					UI_LTE_CONNECTED_COLOR),
+	[UI_CLOUD_CONNECTING] = LED_EFFECT_LED_BREATHE(UI_LED_ON_PERIOD_NORMAL,
+					UI_LED_OFF_PERIOD_NORMAL,
+					UI_CLOUD_CONNECTING_COLOR),
+	[UI_CLOUD_CONNECTED] = LED_EFFECT_LED_BREATHE(UI_LED_ON_PERIOD_NORMAL,
+					UI_LED_OFF_PERIOD_NORMAL,
+					UI_CLOUD_CONNECTED_COLOR),
+	[UI_CLOUD_PAIRING] = LED_EFFECT_LED_BREATHE(UI_LED_ON_PERIOD_NORMAL,
+					UI_LED_OFF_PERIOD_NORMAL,
+					UI_CLOUD_PAIRING_COLOR),
+	[UI_ACCEL_CALIBRATING] = LED_EFFECT_LED_BREATHE(UI_LED_ON_PERIOD_NORMAL,
+					UI_LED_OFF_PERIOD_NORMAL,
+					UI_ACCEL_CALIBRATING_COLOR),
+	[UI_LED_ERROR_CLOUD] = LED_EFFECT_LED_BREATHE(UI_LED_ON_PERIOD_ERROR,
+					UI_LED_OFF_PERIOD_ERROR,
+					UI_LED_ERROR_CLOUD_COLOR),
+	[UI_LED_ERROR_BSD_REC] = LED_EFFECT_LED_BREATHE(UI_LED_ON_PERIOD_ERROR,
+					UI_LED_OFF_PERIOD_ERROR,
+					UI_LED_ERROR_BSD_REC_COLOR),
+	[UI_LED_ERROR_BSD_IRREC] = LED_EFFECT_LED_BREATHE(UI_LED_ON_PERIOD_ERROR,
+					UI_LED_OFF_PERIOD_ERROR,
+					UI_LED_ERROR_BSD_IRREC_COLOR),
+	[UI_LED_ERROR_LTE_LC] = LED_EFFECT_LED_BREATHE(UI_LED_ON_PERIOD_ERROR,
+					UI_LED_OFF_PERIOD_ERROR,
+					UI_LED_ERROR_LTE_LC_COLOR),
+	[UI_LED_ERROR_UNKNOWN] = LED_EFFECT_LED_BREATHE(UI_LED_ON_PERIOD_ERROR,
+					UI_LED_OFF_PERIOD_ERROR,
+					UI_LED_ERROR_UNKNOWN_COLOR),
+};
+
+static struct led_effect custom_effect =
+	LED_EFFECT_LED_BREATHE(UI_LED_ON_PERIOD_NORMAL,
+		UI_LED_OFF_PERIOD_NORMAL,
+		LED_NOCOLOR());
+
+static struct led leds;
+static const size_t led_pins[3] = {
+	CONFIG_UI_LED_RED_PIN,
+	CONFIG_UI_LED_GREEN_PIN,
+	CONFIG_UI_LED_BLUE_PIN,
+};
+
+static void pwm_out(struct led *led, struct led_color *color)
+{
+	for (size_t i = 0; i < ARRAY_SIZE(color->c); i++) {
+		pwm_pin_set_usec(led->pwm_dev, led_pins[i], 255, color->c[i]);
+	}
+}
+
+static void pwm_off(struct led *led)
+{
+	struct led_color nocolor = {0};
+
+	pwm_out(led, &nocolor);
+}
+
+static void work_handler(struct k_work *work)
+{
+	struct led *led = CONTAINER_OF(work, struct led, work);
+	const struct led_effect_step *effect_step =
+		&leds.effect->steps[leds.effect_step];
+	int substeps_left = effect_step->substep_count - leds.effect_substep;
+
+	for (size_t i = 0; i < ARRAY_SIZE(leds.color.c); i++) {
+		int diff = (effect_step->color.c[i] - leds.color.c[i]) /
+			substeps_left;
+		leds.color.c[i] += diff;
+	}
+
+	pwm_out(led, &leds.color);
+
+	leds.effect_substep++;
+	if (leds.effect_substep == effect_step->substep_count) {
+		leds.effect_substep = 0;
+		leds.effect_step++;
+
+		if (leds.effect_step == leds.effect->step_count) {
+			if (leds.effect->loop_forever) {
+				leds.effect_step = 0;
+			}
+		} else {
+			__ASSERT_NO_MSG(leds.effect->steps[leds.effect_step].substep_count > 0);
+		}
+	}
+
+	if (leds.effect_step < leds.effect->step_count) {
+		s32_t next_delay =
+			leds.effect->steps[leds.effect_step].substep_time;
+
+		k_delayed_work_submit(&leds.work, next_delay);
+	}
+}
+
+static void led_update(struct led *led)
+{
+	k_delayed_work_cancel(&led->work);
+
+	led->effect_step = 0;
+	led->effect_substep = 0;
+
+	if (!led->effect) {
+		LOG_DBG("No effect set");
+		return;
+	}
+
+	__ASSERT_NO_MSG(led->effect->steps);
+
+	if (led->effect->step_count > 0) {
+		s32_t next_delay =
+			led->effect->steps[led->effect_step].substep_time;
+
+		k_delayed_work_submit(&led->work, next_delay);
+	} else {
+		LOG_DBG("LED effect with no effect");
+	}
+}
+
+int ui_leds_init(void)
+{
+	const char *dev_name = CONFIG_UI_LED_PWM_DEV_NAME;
+	int err = 0;
+
+	leds.pwm_dev = device_get_binding(dev_name);
+	leds.id = 0;
+	leds.effect = &effect[UI_LTE_DISCONNECTED];
+
+	if (!leds.pwm_dev) {
+		LOG_ERR("Could not bind to device %s", dev_name);
+		return -ENODEV;
+	}
+
+	k_delayed_work_init(&leds.work, work_handler);
+	led_update(&leds);
+
+	return err;
+}
+
+void ui_leds_start(void)
+{
+#ifdef CONFIG_DEVICE_POWER_MANAGEMENT
+	int err = device_set_power_state(leds.pwm_dev,
+						DEVICE_PM_ACTIVE_STATE,
+						NULL, NULL);
+	if (err) {
+		LOG_ERR("PWM enable failed");
+	}
+#endif
+	led_update(&leds);
+}
+
+void ui_leds_stop(void)
+{
+	k_delayed_work_cancel(&leds.work);
+#ifdef CONFIG_DEVICE_POWER_MANAGEMENT
+	int err = device_set_power_state(leds.pwm_dev,
+					 DEVICE_PM_SUSPEND_STATE,
+					 NULL, NULL);
+	if (err) {
+		LOG_ERR("PWM disable failed");
+	}
+#endif
+	pwm_off(&leds);
+}
+
+void ui_led_set_effect(enum ui_led_pattern state)
+{
+	leds.effect = &effect[state];
+	led_update(&leds);
+}
+
+int ui_led_set_rgb(u8_t red, u8_t green, u8_t blue)
+{
+	struct led_effect effect =
+		LED_EFFECT_LED_BREATHE(UI_LED_ON_PERIOD_NORMAL,
+			UI_LED_OFF_PERIOD_NORMAL,
+			LED_COLOR(red, green, blue));
+
+	memcpy((void *)custom_effect.steps, (void *)effect.steps,
+		effect.step_count * sizeof(struct led_effect_step));
+
+	leds.effect = &custom_effect;
+	led_update(&leds);
+
+	return 0;
+}

--- a/applications/asset_tracker/src/ui/nmos.c
+++ b/applications/asset_tracker/src/ui/nmos.c
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#include <zephyr.h>
+#include <misc/util.h>
+#include <gpio.h>
+#include <pwm.h>
+
+#include "ui.h"
+
+#include <logging/log.h>
+LOG_MODULE_REGISTER(ui_nmos, CONFIG_UI_LOG_LEVEL);
+
+#define NMOS_CONFIG_DEFAULT(_pin)	(.pin = _pin)
+#define NMOS_CONFIG_UNUSED		(.pin = -1)
+#define NMOS_CONFIG_PIN(_pin)		COND_CODE_0(_pin, NMOS_CONFIG_UNUSED,  \
+						NMOS_CONFIG_DEFAULT(_pin))
+#define NMOS_CONFIG(_pin)		{ NMOS_CONFIG_PIN(_pin),	       \
+						.mode = NMOS_MODE_GPIO }
+
+
+struct nmos_config {
+	int pin;
+	enum {
+		NMOS_MODE_GPIO,
+		NMOS_MODE_PWM
+	} mode;
+};
+
+static struct device *gpio_dev;
+static struct device *pwm_dev;
+
+static struct nmos_config nmos_pins[] = {
+	[UI_NMOS_1] = NMOS_CONFIG(CONFIG_UI_NMOS_1_PIN),
+	[UI_NMOS_2] = NMOS_CONFIG(CONFIG_UI_NMOS_2_PIN),
+	[UI_NMOS_3] = NMOS_CONFIG(CONFIG_UI_NMOS_3_PIN),
+	[UI_NMOS_4] = NMOS_CONFIG(CONFIG_UI_NMOS_4_PIN),
+};
+
+static int pwm_out(u32_t pin, u32_t period_us, u32_t duty_cycle_us)
+{
+	static u32_t prev_period;
+
+	/* Applying workaround due to limitations in PWM driver that doesn't
+	 * allow changing period while PWM is running. Setting pulse to 0
+	 * disables the PWM, but not before the current period is finished.
+	 */
+	if (prev_period) {
+		pwm_pin_set_usec(pwm_dev, pin, prev_period, 0);
+		k_sleep(MAX(K_MSEC(prev_period / USEC_PER_MSEC), K_MSEC(1)));
+	}
+
+	prev_period = period_us;
+
+	return pwm_pin_set_usec(pwm_dev, pin, period_us, duty_cycle_us);
+}
+
+#ifdef CONFIG_DEVICE_POWER_MANAGEMENT
+static bool pwm_is_in_use(void)
+{
+	for (size_t i = 0; i < ARRAY_SIZE(nmos_pins); i++) {
+		if (nmos_pins[i].mode == NMOS_MODE_PWM) {
+			return true;
+		}
+	}
+
+	return false;
+}
+#endif /* CONFIG_DEVICE_POWER_MANAGEMENT */
+
+static void nmos_pwm_disable(u32_t nmos_idx)
+{
+	pwm_out(nmos_pins[nmos_idx].pin, 0, 0);
+
+	nmos_pins[nmos_idx].mode = NMOS_MODE_GPIO;
+
+#ifdef CONFIG_DEVICE_POWER_MANAGEMENT
+	if (pwm_is_in_use()) {
+		return;
+	}
+
+	int err = device_set_power_state(pwm_dev,
+					 DEVICE_PM_SUSPEND_STATE,
+					 NULL, NULL);
+	if (err) {
+		LOG_WRN("PWM disable failed");
+	}
+#endif /* CONFIG_DEVICE_POWER_MANAGEMENT */
+}
+
+static int nmos_pwm_enable(size_t nmos_idx)
+{
+	int err = 0;
+
+	nmos_pins[nmos_idx].mode = NMOS_MODE_PWM;
+
+#ifdef CONFIG_DEVICE_POWER_MANAGEMENT
+	u32_t power_state;
+
+	device_get_power_state(pwm_dev, &power_state);
+
+	if (power_state == DEVICE_PM_ACTIVE_STATE) {
+		return 0;
+	}
+
+	err = device_set_power_state(pwm_dev,
+					 DEVICE_PM_ACTIVE_STATE,
+					 NULL, NULL);
+	if (err) {
+		LOG_ERR("PWM enable failed");
+		return err;
+	}
+#endif /* CONFIG_DEVICE_POWER_MANAGEMENT */
+
+	return err;
+}
+
+static int configure_gpio(u32_t pin)
+{
+	int err;
+
+	err = gpio_pin_configure(gpio_dev, pin, GPIO_DIR_OUT);
+	if (err) {
+		return err;
+	}
+
+	err = gpio_pin_write(gpio_dev, pin, 0);
+	if (err) {
+		return err;
+	}
+
+	return err;
+}
+
+static int nmos_gpio_enable(size_t nmos_idx)
+{
+	int err = 0;
+
+	if (nmos_pins[nmos_idx].mode == NMOS_MODE_PWM) {
+		nmos_pwm_disable(nmos_idx);
+
+		err = configure_gpio(nmos_pins[nmos_idx].pin);
+		if (err) {
+			LOG_ERR("Could not configure GPIO, error: %d", err);
+			return err;
+		}
+	}
+
+	return err;
+}
+
+int ui_nmos_init(void)
+{
+	int err = 0;
+
+	gpio_dev = device_get_binding(DT_NORDIC_NRF_GPIO_0_LABEL);
+	if (!gpio_dev) {
+		LOG_ERR("Could not bind to device %s",
+			log_strdup(DT_NORDIC_NRF_GPIO_0_LABEL));
+		return -ENODEV;
+	}
+
+	for (size_t i = 0; i < ARRAY_SIZE(nmos_pins); i++) {
+		if ((nmos_pins[i].pin < 0) ||
+		    (nmos_pins[i].mode != NMOS_MODE_GPIO)) {
+			continue;
+		}
+
+		err = configure_gpio(nmos_pins[i].pin);
+		if (err) {
+			LOG_ERR("Could not configure pin %d, error: %d",
+				nmos_pins[i].pin, err);
+			continue;
+		}
+	}
+
+	pwm_dev = device_get_binding(CONFIG_UI_NMOS_PWM_DEV_NAME);
+	if (!pwm_dev) {
+		LOG_ERR("Could not bind to device %s",
+			log_strdup(CONFIG_UI_NMOS_PWM_DEV_NAME));
+		return -ENODEV;
+	}
+
+	return err;
+}
+
+int ui_nmos_pwm_set(size_t nmos_idx, u32_t period, u32_t pulse)
+{
+	if ((pulse > period) || (period == 0)) {
+		LOG_ERR("Period has to be non-zero and period >= duty cycle");
+		return -EINVAL;
+	}
+
+	if (nmos_idx > (ARRAY_SIZE(nmos_pins) - 4)) {
+		LOG_ERR("Invalid NMOS instance: %d", nmos_idx);
+		return -EINVAL;
+	}
+
+	if (nmos_pins[nmos_idx].mode != NMOS_MODE_PWM) {
+		int err = nmos_pwm_enable(nmos_idx);
+
+		if (err) {
+			LOG_ERR("Could not enable PWM for pin %d, error: %d",
+				nmos_pins[nmos_idx].pin, err);
+			return err;
+		}
+	}
+
+	return pwm_out(nmos_pins[nmos_idx].pin, period, pulse);
+}
+
+int ui_nmos_write(size_t nmos_idx, u8_t value)
+{
+	int err;
+
+	if (nmos_idx > (ARRAY_SIZE(nmos_pins) - 1)) {
+		LOG_ERR("Invalid NMOS instance: %d", nmos_idx);
+		return -EINVAL;
+	}
+
+	nmos_gpio_enable(nmos_idx);
+	nmos_pwm_disable(nmos_idx);
+
+	value = (value == 0) ? 0 : 1;
+
+	err = gpio_pin_write(gpio_dev, nmos_pins[nmos_idx].pin, value);
+	if (err) {
+		LOG_ERR("Setting GPIO state failed, error: %d", err);
+		return err;
+	}
+
+	return err;
+}

--- a/applications/asset_tracker/src/ui/ui.c
+++ b/applications/asset_tracker/src/ui/ui.c
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#include <logging/log.h>
+
+#include "ui.h"
+#include "buzzer.h"
+#include "led_pwm.h"
+#include "nmos.h"
+
+LOG_MODULE_REGISTER(ui, CONFIG_UI_LOG_LEVEL);
+
+static enum ui_led_pattern current_led_state;
+static ui_callback_t callback;
+
+#if !defined(CONFIG_UI_LED_USE_PWM)
+static struct k_delayed_work leds_update_work;
+
+/**@brief Update LEDs state. */
+static void leds_update(struct k_work *work)
+{
+	static bool led_on;
+	static u8_t current_led_on_mask;
+	u8_t led_on_mask;
+
+	led_on_mask = UI_LED_GET_ON(current_led_state);
+	led_on = !led_on;
+
+	if (led_on) {
+		led_on_mask |= UI_LED_GET_BLINK(current_led_state);
+	} else {
+		led_on_mask &= ~UI_LED_GET_BLINK(current_led_state);
+	}
+
+	if (led_on_mask != current_led_on_mask) {
+#if defined(CONFIG_DK_LIBRARY)
+		dk_set_leds(led_on_mask);
+#endif
+		current_led_on_mask = led_on_mask;
+	}
+
+	if (work) {
+		if (led_on) {
+			k_delayed_work_submit(&leds_update_work,
+						UI_LED_ON_PERIOD_NORMAL);
+		} else {
+			k_delayed_work_submit(&leds_update_work,
+						UI_LED_OFF_PERIOD_NORMAL);
+		}
+	}
+}
+#endif /* CONFIG_UI_LED_USE_PWM */
+
+/**@brief Callback for button events from the DK buttons and LEDs library. */
+static void button_handler(u32_t button_states, u32_t has_changed)
+{
+	struct ui_evt evt;
+	u8_t btn_num;
+
+	while (has_changed) {
+		btn_num = 0;
+
+		/* Get bit position for next button that changed state. */
+		for (u8_t i = 0; i < 32; i++) {
+			if (has_changed & BIT(i)) {
+				btn_num = i + 1;
+				break;
+			}
+		}
+
+		/* Button number has been stored, remove from bitmask. */
+		has_changed &= ~(1UL << (btn_num - 1));
+
+		evt.button = btn_num;
+		evt.type = (button_states & BIT(btn_num - 1))
+				? UI_EVT_BUTTON_ACTIVE
+				: UI_EVT_BUTTON_INACTIVE;
+
+		callback(evt);
+	}
+}
+
+void ui_led_set_pattern(enum ui_led_pattern state)
+{
+	current_led_state = state;
+#ifdef CONFIG_UI_LED_USE_PWM
+	ui_led_set_effect(state);
+#else
+	current_led_state = state;
+#endif /* CONFIG_UI_LED_USE_PWM */
+}
+
+enum ui_led_pattern ui_led_get_pattern(void)
+{
+	return current_led_state;
+}
+
+int ui_led_set_color(u8_t red, u8_t green, u8_t blue)
+{
+#ifdef CONFIG_UI_LED_USE_PWM
+	return ui_led_set_rgb(red, green, blue);
+#else
+	return -ENOTSUP;
+#endif /* CONFIG_UI_LED_USE_PWM */
+}
+
+void ui_led_set_state(u32_t led, u8_t value)
+{
+#if !defined(CONFIG_UI_LED_USE_PWM)
+	if (value) {
+		current_led_state |= BIT(led - 1);
+	} else {
+		current_led_state &= ~BIT(led - 1);
+	}
+#endif
+}
+
+int ui_init(ui_callback_t cb)
+{
+	int err = 0;
+
+#ifdef CONFIG_UI_LED_USE_PWM
+	err = ui_leds_init();
+	if (err) {
+		LOG_ERR("Error when initializing PWM controlled LEDs");
+		return err;
+	}
+#else
+	err = dk_leds_init();
+	if (err) {
+		LOG_ERR("Could not initialize leds, err code: %d\n", err);
+		return err;
+	}
+
+	err = dk_set_leds_state(0x00, DK_ALL_LEDS_MSK);
+	if (err) {
+		LOG_ERR("Could not set leds state, err code: %d\n", err);
+		return err;
+	}
+
+	k_delayed_work_init(&leds_update_work, leds_update);
+	k_delayed_work_submit(&leds_update_work, K_NO_WAIT);
+#endif /* CONFIG_UI_LED_USE_PWM */
+
+	if (cb) {
+		callback  = cb;
+
+		err = dk_buttons_init(button_handler);
+		if (err) {
+			LOG_ERR("Could not initialize buttons, err code: %d\n",
+				err);
+			return err;
+		}
+	}
+
+#ifdef CONFIG_UI_BUZZER
+	err = ui_buzzer_init();
+	if (err) {
+		LOG_ERR("Could not enable buzzer, err code: %d\n", err);
+		return err;
+	}
+#endif /* CONFIG_UI_BUZZER */
+
+#ifdef CONFIG_UI_NMOS
+	err = ui_nmos_init();
+	if (err) {
+		LOG_ERR("Could not enable NMOS control, err code: %d\n", err);
+		return err;
+	}
+#endif /* CONFIG_UI_NMOS */
+
+	return err;
+}
+
+bool ui_button_is_active(u32_t button)
+{
+	return dk_get_buttons() & BIT((button - 1));
+}


### PR DESCRIPTION
applications: asset_tracker: Use UI module for LEDs and buttons

Adapts the asset tracker to use the user interface module to
handle buttons and LEDs.

---

applications: asset_tracker: Add user interface module

This patch adds a user interface (UI) module to handle buttons,
LEDs, buzzer and NMOS trnasistors. The application can provide,
an event handler and receive events from the UI module on button
state changes.

There are two modes of LED operation:
- PWM-based for RGB
- Non-PWM for simple signalling of application state.

The buzzer is operated by using PWM to vary frequency and
intensity of the output sound.

NMOS transistors are controlled using either using GPIO or PWM.

---

Note: The LED handling using PWM is mostly based on nRF dekstop's LED handling, with some simplification for our use-case.