### PR TITLE
ci: move ci-tools to latest on master

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 // Due to JENKINS-42369 we put these defines outside the pipeline
 def IMAGE_TAG = "ncs-toolchain:1.09"
 def REPO_CI_TOOLS = "https://github.com/zephyrproject-rtos/ci-tools.git"
-def REPO_CI_TOOLS_SHA = "9f4dc0be401c2b1e9b1c647513fb996bd8abd057"
+def REPO_CI_TOOLS_SHA = "bfe635f102271a4ad71c1a14824f9d5e64734e57"
 
 // Function to get the current repo URL, to be propagated to the downstream job
 def getRepoURL() {


### PR DESCRIPTION
Fixes some missing KConfig argument errors in check_compliance.py

Signed-off-by: Thomas Stilwell <Thomas.Stilwell@nordicsemi.no>