### PR TITLE
manifest: update nrf_security and nrf_cc310_mbedcrypto libs in nrfxlib

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -60,7 +60,7 @@ manifest:
       revision: 543ecb7c8662580ef803d59ceda7bd3b8a84a11b
     - name: nrfxlib
       path: nrfxlib
-      revision: a87551ba2e131ff17e0e1c796b73f7c37bbea9ec
+      revision: facb80173177ee7a14f445b63c69b9630aee2cbd
     - name: cmock
       path: test/cmock
       revision: c243b9a7a7b3c471023193992b46cf1bd1910450


### PR DESCRIPTION
Update nrfxlib revision to pull/62/head
with:
- nrf_cc310_mbedcrypto libs, v0.8.0

Additional bug fixes and improvements for nrf_security:
- CCM Configuration fixes
- Glue layer fixes for configurations
- mbed x509 and mbed SSL/TLS libs can also be controlled using Kconfig

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>