### PR TITLE
applications: nrf_desktop: Fix initial state of motion optical

### DIFF
--- a/applications/nrf_desktop/src/hw_interface/motion_optical.c
+++ b/applications/nrf_desktop/src/hw_interface/motion_optical.c
@@ -184,6 +184,9 @@ static int init(void)
 		return err;
 	}
 
+	state.state = STATE_IDLE;
+	module_set_state(MODULE_STATE_READY);
+
 	do {
 		err = enable_trigger();
 		if (err == -EBUSY) {
@@ -191,11 +194,8 @@ static int init(void)
 		}
 	} while (err == -EBUSY);
 
-	if (!err) {
-		state.state = STATE_IDLE;
-		module_set_state(MODULE_STATE_READY);
-	} else {
-		LOG_ERR("Cannot initialize");
+	if (err) {
+		LOG_ERR("Cannot enable trigger");
 		module_set_state(MODULE_STATE_ERROR);
 	}
 


### PR DESCRIPTION
Correctly handle interrupt just after trigger is enabled.

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>