### PR TITLE
scripts: partition_manager: Set properties automatically

### DIFF
--- a/cmake/partition_manager.cmake
+++ b/cmake/partition_manager.cmake
@@ -83,28 +83,20 @@ if(FIRST_BOILERPLATE_EXECUTION)
       message(FATAL_ERROR "Partition Manager output generation failed, aborting. Command: ${pm_output_cmd}")
     endif()
 
-    # Make Partition Manager configuration available in CMake
-    import_kconfig(PM_ ${CMAKE_BINARY_DIR}/pm.config)
-
     # Create a dummy target that we can add properties to for
     # extraction in generator expressions.
     add_custom_target(partition_manager)
 
-    set_property(
-      TARGET partition_manager
-      PROPERTY MCUBOOT_SLOT_SIZE
-      ${PM_MCUBOOT_PRIMARY_SIZE}
-      )
-    set_property(
-      TARGET partition_manager
-      PROPERTY MCUBOOT_HEADER_SIZE
-      ${PM_MCUBOOT_PAD_SIZE}
-      )
-    set_property(
-      TARGET partition_manager
-      PROPERTY MCUBOOT_SECONDARY_ADDRESS
-      ${PM_MCUBOOT_SECONDARY_ADDRESS}
-      )
+    # Make Partition Manager configuration available in CMake
+    import_kconfig(PM_ ${CMAKE_BINARY_DIR}/pm.config pm_var_names)
+
+    foreach(name ${pm_var_names})
+      set_property(
+        TARGET partition_manager
+        PROPERTY ${name}
+        ${${name}}
+        )
+    endforeach()
 
     # Turn the space-separated list into a Cmake list.
     string(REPLACE " " ";" PM_ALL_BY_SIZE ${PM_ALL_BY_SIZE})

--- a/scripts/partition_manager/partition_manager.rst
+++ b/scripts/partition_manager/partition_manager.rst
@@ -325,24 +325,15 @@ When using the Partition Manager, run ``ninja rom_report`` to see the addresses 
 
 CMake
 -----
-The CMake variables from Partition Manager are typically used through `generator expressions`_, because these variables are made available at the end of the CMake configure stage.
+The CMake variables from Partition Manager are typically used through `generator expressions`_, because these variables are only made available late in the CMake configure stage.
 To read a Partition Manager variable through a generator expression, the variable must be assigned as a target property.
-The ``partition_manager`` target is used for this already and should be used for additional variables.
-Once the variable is available as a target property, the value can be read through generator expressions.
-
-.. code-block:: cmake
-   :caption: partition_manager.cmake (from MCUboot)
-
-   set_property(
-     TARGET partition_manager
-     PROPERTY MCUBOOT_SLOT_SIZE
-     ${PM_MCUBOOT_PARTITIONS_PRIMARY_SIZE}
-     )
+Partition Manager stores all variables as target properties on the ``partition_manager`` target,
+which means they can be used in generator expressions in the following way.
 
 .. code-block:: none
-   :caption: mcuboot/zephyr/CmakeLists.txt
+   :caption: Reading partition manager variables in generator expressions.
 
-   --slot-size $<TARGET_PROPERTY:partition_manager,MCUBOOT_SLOT_SIZE>
+   --slot-size $<TARGET_PROPERTY:partition_manager,PM_MCUBOOT_PARTITIONS_PRIMARY_SIZE>
 
 .. _ug_pm_static:
 

--- a/west.yml
+++ b/west.yml
@@ -51,7 +51,7 @@ manifest:
       remote: zephyrproject
     - name: fw-nrfconnect-mcuboot
       path: mcuboot
-      revision: 4a61a17c9fc9559512b7b790f841a92cc16e12e1
+      revision: 8b0e50cd5898e66e8bf92b5378c5b29fb0838471
     - name: fw-nrfconnect-mcumgr
       revision: c8f675a5fa7f62106b9d913844bd5ed6e16ae69e
       path: modules/lib/mcumgr


### PR DESCRIPTION
Using the new 'keys' output var from import_kconfig()
Instead of manually setting properties.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>