### PR TITLE
spm: Add type to incomplete kconfig ARM_ENTRY_VENEERS_LIB_NAME

### DIFF
--- a/subsys/spm/Kconfig
+++ b/subsys/spm/Kconfig
@@ -185,5 +185,6 @@ if SPM || IS_SPM
 # Set new default name for the veneers file. To avoid file name collisions if
 # someone has multiple secure firmwares with secure entry functions.
 config ARM_ENTRY_VENEERS_LIB_NAME
+	string
 	default "libspmsecureentries.a"
 endif


### PR DESCRIPTION
The kconfig acts as an overlay, but fails for some configurations when
the original is not present.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>