### PR TITLE
bluetooth: controller: Reduce ble controller RAM usage

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -28,4 +28,12 @@ choice BLE_CONTROLLER_VARIANT
 
 endchoice
 
+config BLECTRL_MEMPOOL_SIZE
+	int "Reserved RAM for the BLE controller"
+	default 13104
+	help
+	  Reserved RAM for the BLE Controller. This size is dependent on the
+	  configuration set before the controller is enabled. If the size is too
+	  small, the HCI driver initialization will return an error.
+
 endmenu

--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -31,7 +31,7 @@ static K_THREAD_STACK_DEFINE(recv_thread_stack, CONFIG_BLECTLR_RX_STACK_SIZE);
 static K_THREAD_STACK_DEFINE(signal_thread_stack,
 			     CONFIG_BLECTLR_SIGNAL_STACK_SIZE);
 
-static u8_t ble_controller_mempool[0x6000];
+static u8_t ble_controller_mempool[CONFIG_BLECTRL_MEMPOOL_SIZE];
 
 void blectlr_assertion_handler(const char *const file, const u32_t line)
 {

--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -398,6 +398,10 @@ static int ble_enable(void)
 	       sizeof(ble_controller_mempool), required_memory);
 
 	if (required_memory > sizeof(ble_controller_mempool)) {
+		BT_ERR("Allocated memory too low: %u < %u",
+		       sizeof(ble_controller_mempool), required_memory);
+		k_panic();
+		/* No return from k_panic(). */
 		return -ENOMEM;
 	}
 

--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -348,24 +348,28 @@ static int ble_init(struct device *unused)
 static int ble_enable(void)
 {
 	int err;
+	int required_memory;
 	ble_controller_cfg_t cfg;
 
 	cfg.master_count.count = 1;
 
-	err = ble_controller_cfg_set(BLE_CONTROLLER_DEFAULT_RESOURCE_CFG_TAG,
-				     BLE_CONTROLLER_CFG_TYPE_MASTER_COUNT,
-				     &cfg);
-	if (err < 0 || err > sizeof(ble_controller_mempool)) {
-		return err;
+	/* NOTE: ble_controller_cfg_set() returns a negative errno on error. */
+	required_memory =
+		ble_controller_cfg_set(BLE_CONTROLLER_DEFAULT_RESOURCE_CFG_TAG,
+				       BLE_CONTROLLER_CFG_TYPE_MASTER_COUNT,
+				       &cfg);
+	if (required_memory < 0) {
+		return required_memory;
 	}
 
 	cfg.slave_count.count = 1;
 
-	err = ble_controller_cfg_set(BLE_CONTROLLER_DEFAULT_RESOURCE_CFG_TAG,
-				     BLE_CONTROLLER_CFG_TYPE_SLAVE_COUNT,
-				     &cfg);
-	if (err < 0 || err > sizeof(ble_controller_mempool)) {
-		return err;
+	required_memory =
+		ble_controller_cfg_set(BLE_CONTROLLER_DEFAULT_RESOURCE_CFG_TAG,
+				       BLE_CONTROLLER_CFG_TYPE_SLAVE_COUNT,
+				       &cfg);
+	if (required_memory < 0) {
+		return required_memory;
 	}
 
 	cfg.buffer_cfg.rx_packet_size = 251;
@@ -373,19 +377,28 @@ static int ble_enable(void)
 	cfg.buffer_cfg.rx_packet_count = 10;
 	cfg.buffer_cfg.tx_packet_count = 10;
 
-	err = ble_controller_cfg_set(BLE_CONTROLLER_DEFAULT_RESOURCE_CFG_TAG,
-				     BLE_CONTROLLER_CFG_TYPE_BUFFER_CFG,
-				     &cfg);
-	if (err < 0 || err > sizeof(ble_controller_mempool)) {
-		return err;
+	required_memory =
+		ble_controller_cfg_set(BLE_CONTROLLER_DEFAULT_RESOURCE_CFG_TAG,
+				       BLE_CONTROLLER_CFG_TYPE_BUFFER_CFG,
+				       &cfg);
+	if (required_memory < 0) {
+		return required_memory;
 	}
 
 	cfg.event_length.event_length_us = 7500;
-	err = ble_controller_cfg_set(BLE_CONTROLLER_DEFAULT_RESOURCE_CFG_TAG,
-				     BLE_CONTROLLER_CFG_TYPE_EVENT_LENGTH,
-				     &cfg);
-	if (err < 0 || err > sizeof(ble_controller_mempool)) {
-		return err;
+	required_memory =
+		ble_controller_cfg_set(BLE_CONTROLLER_DEFAULT_RESOURCE_CFG_TAG,
+				       BLE_CONTROLLER_CFG_TYPE_EVENT_LENGTH,
+				       &cfg);
+	if (required_memory < 0) {
+		return required_memory;
+	}
+
+	BT_DBG("BT mempool size: %u, required: %u",
+	       sizeof(ble_controller_mempool), required_memory);
+
+	if (required_memory > sizeof(ble_controller_mempool)) {
+		return -ENOMEM;
 	}
 
 	err = MULTITHREADING_LOCK_ACQUIRE();


### PR DESCRIPTION
This PR does two things:
- Adds a Kconfig option `BLECTRL_MEMPOOL_SIZE` for configuring the static memory pool reserved for the BLE controller. The reserved size has also
been reduced from 24576B to 13104B.
- Fixes a bug where the HCI driver initialization would return the required size of the BLE controller memory pool, instead of -ENOMEM, if a given configuration could not fit.