### PR TITLE
manifest: update fw-nrfconnect-zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -40,7 +40,7 @@ manifest:
     - name: fw-nrfconnect-zephyr
       path: zephyr
       west-commands: scripts/west-commands.yml
-      revision: a494544d6e5b42c3606d6617dca27eccb92918e6
+      revision: 7e64ac737daead12d2dbdda5daec04188243a81c
     - name: nffs
       revision: bc62a2fa9d98ddb5d633c932ea199bc68e10f194
       path: modules/fs/nffs


### PR DESCRIPTION
Introduce logger bugfix that caused crashes on nrf9160_pca10090ns.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>