### PR TITLE
applications: asset_tracker: Send '1' when button is pressed

### DIFF
--- a/applications/asset_tracker/src/main.c
+++ b/applications/asset_tracker/src/main.c
@@ -365,7 +365,9 @@ static void button_send(bool pressed)
 		return;
 	}
 
-	if (!pressed) {
+	if (pressed) {
+		data[0] = '1';
+	} else {
 		data[0] = '0';
 	}
 


### PR DESCRIPTION
When the user-defined 'cloud button' is pressed, '1' should be
sent as value. Current situation is that '1' will only be sent
the first time the button is pressed, and '0' for all
following presses.
This patch fixes this issue, which was introduced when
the value buffer was made static.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>