### PR TITLE
drivers: at_cmd: add option to initialize manually

### DIFF
--- a/drivers/at_cmd/Kconfig
+++ b/drivers/at_cmd/Kconfig
@@ -12,9 +12,17 @@ config AT_CMD
 
 if AT_CMD
 
+config AT_CMD_SYS_INIT
+	bool "Initialize the AT Command driver during system init"
+	default y if BSD_LIBRARY_SYS_INIT
+
+if AT_CMD_SYS_INIT
+
 config AT_CMD_INIT_PRIORITY
 	int "AT Command driver init priority"
 	default 40
+
+endif
 
 config AT_CMD_THREAD_PRIO
 	int "AT thread priority level"

--- a/drivers/at_cmd/at_cmd.c
+++ b/drivers/at_cmd/at_cmd.c
@@ -307,13 +307,16 @@ void at_cmd_set_notification_handler(at_cmd_handler_t handler)
 	k_mutex_unlock(&cmd_pending);
 }
 
-static int at_cmd_init(struct device *dev)
+static int at_cmd_driver_init(struct device *dev)
 {
+	int err;
+
 	ARG_UNUSED(dev);
 
-	if (open_socket() != 0) {
-		LOG_ERR("Failed to open AT socket (err:%d)", errno);
-		return -1;
+	err = open_socket();
+	if (err) {
+		LOG_ERR("Failed to open AT socket (err:%d)", err);
+		return err;
 	}
 
 	LOG_DBG("Common AT socket created");
@@ -329,5 +332,12 @@ static int at_cmd_init(struct device *dev)
 	return 0;
 }
 
-SYS_INIT(at_cmd_init, APPLICATION, CONFIG_AT_CMD_INIT_PRIORITY);
+int at_cmd_init(void)
+{
+	return at_cmd_driver_init(NULL);
+}
 
+
+#ifdef CONFIG_AT_CMD_SYS_INIT
+SYS_INIT(at_cmd_driver_init, APPLICATION, CONFIG_AT_CMD_INIT_PRIORITY);
+#endif

--- a/include/at_cmd.h
+++ b/include/at_cmd.h
@@ -50,6 +50,12 @@ enum at_cmd_state {
  */
 typedef void (*at_cmd_handler_t)(char *response);
 
+/**@brief Initialize AT command driver.
+ *
+ * @return Zero on success, non-zero otherwise.
+ */
+int at_cmd_init(void);
+
 /**
  * @brief Function to send an AT command to the modem, any data from the modem
  *        will trigger the callback defined by the handler parameter in the


### PR DESCRIPTION
Initialization during SYS_INIT is now optional and controlled via a dedicated Kconfig option.
This option is necessary because BSD library might be initialized by the application, outside (after)
of the SYS_INIT sequence, at which point this library can't open the AT socket yet.