### PR TITLE
applications: asset_tracker: Build with REBOOT and ASSERT disabled

### DIFF
--- a/applications/asset_tracker/src/main.c
+++ b/applications/asset_tracker/src/main.c
@@ -229,14 +229,17 @@ void error_handler(enum error_type err_type, int err_code)
 #if defined(CONFIG_LTE_LINK_CONTROL)
 		/* Turn off and shutdown modem */
 		int err = lte_lc_power_off();
-		__ASSERT(err == 0, "lte_lc_power_off failed: %d", err);
-#endif
+		if (err) {
+			printk("Could not shut down the LTE link, error: %d\n",
+			       err);
+		}
+#endif /* CONFIG_LTE_LINK_CONTROL */
 #if defined(CONFIG_BSD_LIBRARY)
 		bsdlib_shutdown();
 #endif
 	}
 
-#if !defined(CONFIG_DEBUG)
+#if !defined(CONFIG_DEBUG) && defined(CONFIG_REBOOT)
 	sys_reboot(SYS_REBOOT_COLD);
 #else
 	switch (err_type) {
@@ -716,8 +719,10 @@ static void cloud_init(void)
 	};
 
 	int err = nrf_cloud_init(&param);
-
-	__ASSERT(err == 0, "nRF Cloud library could not be initialized.");
+	if (err) {
+		printk("nRF Cloud library could not be initialized.");
+		nrf_cloud_error_handler(err);
+	}
 }
 
 /**@brief Connect to nRF Cloud, */


### PR DESCRIPTION
This patch fixes the issues where the application could not
be built when CONFIG_REBOOT is disabled.
It also fixes warnings about unused variables when CONFIG_ASSERT
is disabled. Asserts are replace with error checks and entering
the common error handling path.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>