### PR TITLE
ci: pick compliance_check.py fixes from master to v1.0-branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,6 +11,15 @@ def getRepoURL() {
   }
 }
 
+
+def getPRHEADSHA() {
+  dir('nrf') {
+    sh "git fetch $GIT_URL refs/pull/\$(echo -n $GIT_BRANCH | sed 's/PR-//')/head"
+    def GH_PR_HEAD_SHA = sh (script: "git rev-parse FETCH_HEAD | tr -d '\\n' ", returnStdout: true)
+    return "$GH_PR_HEAD_SHA"
+  }
+}
+
 def check_and_store_sample(path, new_name) {
   script {
     if (fileExists(file_path)) {
@@ -41,7 +50,7 @@ pipeline {
       GH_TOKEN = credentials('nordicbuilder-compliance-token') // This token is used to by check_compliance to comment on PRs and use checks
       GH_USERNAME = "NordicBuilder"
       COMPLIANCE_ARGS = "-r NordicPlayground/fw-nrfconnect-nrf"
-      COMPLIANCE_REPORT_ARGS = "-p $CHANGE_ID -S $GIT_COMMIT -g"
+      COMPLIANCE_REPORT_ARGS = "-p $CHANGE_ID -S ${getPRHEADSHA()} -g"
 
       // Build all custom samples that match the ci_build tag
       SANITYCHECK_OPTIONS = "--board-root $WORKSPACE/nrf/boards --testcase-root $WORKSPACE/nrf/samples --testcase-root $WORKSPACE/nrf/applications --build-only --disable-unrecognized-section-test -t ci_build --inline-logs"
@@ -130,7 +139,7 @@ pipeline {
                 println "TAG_NAME = ${env.TAG_NAME}"
 
                 if (env.CHANGE_TARGET) {
-                  COMMIT_RANGE = "origin/${env.CHANGE_TARGET}..HEAD"
+                  COMMIT_RANGE = "origin/${env.CHANGE_TARGET}..origin/${env.BRANCH_NAME}"
                   COMPLIANCE_ARGS = "$COMPLIANCE_ARGS $COMPLIANCE_REPORT_ARGS"
                   println "Building a PR: ${COMMIT_RANGE}"
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,7 +50,6 @@ pipeline {
       GH_TOKEN = credentials('nordicbuilder-compliance-token') // This token is used to by check_compliance to comment on PRs and use checks
       GH_USERNAME = "NordicBuilder"
       COMPLIANCE_ARGS = "-r NordicPlayground/fw-nrfconnect-nrf"
-      COMPLIANCE_REPORT_ARGS = "-p $CHANGE_ID -S ${getPRHEADSHA()} -g"
 
       // Build all custom samples that match the ci_build tag
       SANITYCHECK_OPTIONS = "--board-root $WORKSPACE/nrf/boards --testcase-root $WORKSPACE/nrf/samples --testcase-root $WORKSPACE/nrf/applications --build-only --disable-unrecognized-section-test -t ci_build --inline-logs"
@@ -140,6 +139,7 @@ pipeline {
 
                 if (env.CHANGE_TARGET) {
                   COMMIT_RANGE = "origin/${env.CHANGE_TARGET}..origin/${env.BRANCH_NAME}"
+                  COMPLIANCE_REPORT_ARGS = "-p $CHANGE_ID -S ${getPRHEADSHA()} -g"
                   COMPLIANCE_ARGS = "$COMPLIANCE_ARGS $COMPLIANCE_REPORT_ARGS"
                   println "Building a PR: ${COMMIT_RANGE}"
                 }


### PR DESCRIPTION
Enable PR's to be run on CI that are out of date (need rebasing) with v1.0-branch. 