### PR TITLE
bluetooth: service: nus: Add function for max data length when sending

### DIFF
--- a/include/bluetooth/services/nus.h
+++ b/include/bluetooth/services/nus.h
@@ -17,6 +17,7 @@
 #include <zephyr/types.h>
 #include <bluetooth/conn.h>
 #include <bluetooth/uuid.h>
+#include <bluetooth/gatt.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -85,6 +86,19 @@ int bt_gatt_nus_init(struct bt_gatt_nus_cb *callbacks);
  *           Otherwise, a negative value is returned.
  */
 int bt_gatt_nus_send(struct bt_conn *conn, const u8_t *data, u16_t len);
+
+/**@brief Get maximum data length that can be used for @ref bt_gatt_nus_send.
+ *
+ * @param[in] conn Pointer to connection Object.
+ *
+ * @return Maximum data length.
+ */
+static inline u32_t bt_gatt_nus_max_send(struct bt_conn *conn)
+{
+	/* According to 3.4.7.1 Handle Value Notification off the ATT protocol.
+	 * Maximum supported notification is ATT_MTU - 3 */
+	return bt_gatt_get_mtu(conn) - 3;
+}
 
 #ifdef __cplusplus
 }

--- a/subsys/shell/shell_bt_nus.c
+++ b/subsys/shell/shell_bt_nus.c
@@ -39,7 +39,7 @@ static void tx_try(const struct shell_bt_nus *bt_nus)
 {
 	u8_t *buf;
 	u32_t size;
-	u32_t req_len = (u32_t)bt_gatt_get_mtu(bt_nus->ctrl_blk->conn);
+	u32_t req_len = bt_gatt_nus_max_send(bt_nus->ctrl_blk->conn);
 
 	size = ring_buf_get_claim(bt_nus->tx_ringbuf, &buf, req_len);
 


### PR DESCRIPTION
Exceeding capability of MTU results in data being dropped.
NUS user then must not send data which exceeds that limitation.
Added API which can be used to retrieve maximal possible length
of a buffer used for sending.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>