### PR TITLE
manifest: update manifest to include nrf_security v1.0.0 fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -60,7 +60,7 @@ manifest:
       revision: 543ecb7c8662580ef803d59ceda7bd3b8a84a11b
     - name: nrfxlib
       path: nrfxlib
-      revision: be4d8e08958e4ad960f39be24cf2816ced008841
+      revision: pull/64/head
     - name: cmock
       path: test/cmock
       revision: c243b9a7a7b3c471023193992b46cf1bd1910450


### PR DESCRIPTION
Update nrfxlib revision to pull/64/head
with various fixes for nrf_security Kconfig and CMake updates.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>