### PR TITLE
bluetooth: controller: Use default LL buffer count to reduce RAM usage

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -30,7 +30,7 @@ endchoice
 
 config BLECTRL_MEMPOOL_SIZE
 	int "Reserved RAM for the BLE controller"
-	default 13104
+	default 5344
 	help
 	  Reserved RAM for the BLE Controller. This size is dependent on the
 	  configuration set before the controller is enabled. If the size is too

--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -374,8 +374,8 @@ static int ble_enable(void)
 
 	cfg.buffer_cfg.rx_packet_size = 251;
 	cfg.buffer_cfg.tx_packet_size = 251;
-	cfg.buffer_cfg.rx_packet_count = 10;
-	cfg.buffer_cfg.tx_packet_count = 10;
+	cfg.buffer_cfg.rx_packet_count = BLE_CONTROLLER_DEFAULT_RX_PACKET_COUNT;
+	cfg.buffer_cfg.tx_packet_count = BLE_CONTROLLER_DEFAULT_TX_PACKET_COUNT;
 
 	required_memory =
 		ble_controller_cfg_set(BLE_CONTROLLER_DEFAULT_RESOURCE_CFG_TAG,


### PR DESCRIPTION
Reduces the reserved RAM size from 13104B to 5344 B.
Verified that the throughput is not reduced.

Signed-off-by: Rubin Gerritsen <Rubin.Gerritsen@nordicsemi.no>