### PR TITLE
net: lib: download_client: reconnect on connection closed

### DIFF
--- a/include/download_client.h
+++ b/include/download_client.h
@@ -98,15 +98,20 @@ struct download_client {
 	size_t file_size;
 	/** Download progress, number of bytes downloaded. */
 	size_t progress;
+
 	/** Whether the HTTP header for
 	 * the current fragment has been processed.
 	 */
 	bool has_header;
+	/** The server has closed the connection. */
+	bool connection_close;
 
 	/** Server hosting the file, null-terminated. */
 	char *host;
 	/** File name, null-terminated. */
 	char *file;
+	/** TLS security tag. */
+	int sec_tag;
 
 	/** Internal thread ID. */
 	k_tid_t tid;

--- a/include/download_client.rst
+++ b/include/download_client.rst
@@ -15,7 +15,12 @@ The application can then resume the download by calling the :cpp:func:`download_
 
 The download happens in a separate thread which can be paused and resumed.
 
-Make sure to configure :option:`CONFIG_NRF_DOWNLOAD_MAX_FRAGMENT_SIZE` in a way that suits your application. A small fragment size results in more download requests, and thus a higher protocol overhead, while large fragments require more RAM.
+Make sure to configure :option:`CONFIG_NRF_DOWNLOAD_MAX_FRAGMENT_SIZE` in a way that suits your application.
+A large fragment size requires more RAM, while a small fragment size results in more download requests, and thus a higher protocol overhead.
+If the size of the file being downloaded is larger than a hundred times the size of one fragment, the server might close the HTTP connection
+after the hundreth fragment has been transfered. The library is able to detect when the server has closed the HTTP connection
+and reconnect automatically. Increasing the fragment size prevents having to establish several HTTP connections and thus helps
+in keeping protocol overhead to a minimum.
 
 
 Protocols


### PR DESCRIPTION
The maximum number of requests that can be served through one keep-alive connection usually defaults to 100, after which the connection is closed by the server.

This change re-introduces the capability of the library to detect when the server includes the field: "Connection: close" in the response header, and attempts to reconnect automatically.