### PR TITLE
codeowners: owner for nRF52 Desktop configuration channel

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -51,6 +51,7 @@ subsys/debug/CMakeLists.txt               @nordic-krch
 /samples/profiler/                        @pdunaj @pizi-nordic
 /samples/CMakeLists.txt                   @SebastianBoe
 /scripts/                                 @mbolivar @tejlmand
+/scripts/hid_configurator                 @pdunaj
 /subsys/bluetooth/                        @joerchan @carlescufi
 /subsys/bootloader/                       @hakonfam @ioannisg
 /subsys/enhanced_shockburst/              @Raane @lemrey


### PR DESCRIPTION
Add owner for HID configuration channel script.

Signed-off-by: Filip Kubicz <filip.kubicz@nordicsemi.no>