### PR TITLE
kconfig: use template for partition manager config

### DIFF
--- a/subsys/partition_manager/Kconfig.template.build_strategy
+++ b/subsys/partition_manager/Kconfig.template.build_strategy
@@ -1,0 +1,25 @@
+choice
+	prompt "$(module) build strategy"
+	default $(module)_BUILD_STRATEGY_FROM_SOURCE
+
+config $(module)_BUILD_STRATEGY_USE_HEX_FILE
+	# Mandatory option when being built through 'zephyr_add_executable'
+	bool "Use hex file instead of building $(module)"
+
+if $(module)_BUILD_STRATEGY_USE_HEX_FILE
+
+config $(module)_HEX_FILE
+	# Mandatory option when being built through 'zephyr_add_executable'
+	string "$(module) hex file"
+
+endif # $(module)_BUILD_STRATEGY_USE_HEX_FILE
+
+config $(module)_BUILD_STRATEGY_SKIP_BUILD
+	# Mandatory option when being built through 'zephyr_add_executable'
+	bool "Skip building $(module)"
+
+config $(module)_BUILD_STRATEGY_FROM_SOURCE
+	# Mandatory option when being built through 'zephyr_add_executable'
+	bool "Build from source"
+
+endchoice

--- a/subsys/partition_manager/Kconfig.template.partition_size
+++ b/subsys/partition_manager/Kconfig.template.partition_size
@@ -1,0 +1,6 @@
+# Define used by partition_manager.py to deduce size of partition
+config PM_PARTITION_SIZE_$(partition)
+	hex "Flash space reserved for $(partition)."
+	default $(partition-size)
+	help
+	  Flash space set aside for the $(partition) partition.

--- a/subsys/spm/Kconfig
+++ b/subsys/spm/Kconfig
@@ -12,33 +12,8 @@ config SPM
 	imply ARM_FIRMWARE_USES_SECURE_ENTRY_FUNCS
 
 if SPM
-
-choice
-	prompt "SPM build strategy"
-	default SPM_BUILD_STRATEGY_FROM_SOURCE
-
-config SPM_BUILD_STRATEGY_USE_HEX_FILE
-	# Mandatory option when being built through 'zephyr_add_executable'
-	bool "Use hex file instead of building SPM"
-
-if SPM_BUILD_STRATEGY_USE_HEX_FILE
-
-config SPM_HEX_FILE
-	# Mandatory option when being built through 'zephyr_add_executable'
-	string "SPM hex file"
-
-endif # SPM_USE_HEX_FILE
-
-config SPM_BUILD_STRATEGY_SKIP_BUILD
-	# Mandatory option when being built through 'zephyr_add_executable'
-	bool "Skip building SPM"
-
-config SPM_BUILD_STRATEGY_FROM_SOURCE
-	# Mandatory option when being built through 'zephyr_add_executable'
-	bool "Build from source"
-
-endchoice
-
+module=SPM
+source "${ZEPHYR_BASE}/../nrf/subsys/partition_manager/Kconfig.template.build_strategy"
 endif
 
 
@@ -48,7 +23,8 @@ menuconfig IS_SPM
 	select TRUSTED_EXECUTION_SECURE
 
 if IS_SPM
-# Define used by partition_manager.py to deduce size of partition
+# Define used by partition_manager.py to deduce size of partition.
+# Unable to use the size template due to non-trivial defaults.
 config PM_PARTITION_SIZE_SPM
 	hex "Flash space reserved for SPM"
 	default 0xc000 if SPM_SERVICE_RNG # To build correctly with MCUboot.


### PR DESCRIPTION
Leverage the kconfig template functionality to have cleaner
Kconfig code which is also less error prone.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>