### PR TITLE
applications: nrf_desktop: Store Fn lock state

### DIFF
--- a/applications/nrf_desktop/src/modules/Kconfig.fn_keys
+++ b/applications/nrf_desktop/src/modules/Kconfig.fn_keys
@@ -25,6 +25,12 @@ config DESKTOP_FN_KEYS_LOCK
 	help
 	  Define button used as a function key lock.
 
+config DESKTOP_STORE_FN_LOCK
+	bool "Store Fn lock state"
+	default y
+	help
+	  Define if device should store Fn lock state after reboot.
+
 config DESKTOP_FN_KEYS_MAX_ACTIVE
 	int "Max Fn key pressed"
 	default 8


### PR DESCRIPTION
Change adds storing Fn lock state after device reboots.