### PR TITLE
samples: secure_services: Fix printing of random numbers

### DIFF
--- a/samples/nrf9160/secure_services/src/main.c
+++ b/samples/nrf9160/secure_services/src/main.c
@@ -14,7 +14,7 @@ void print_number(u8_t *num, size_t len)
 {
 	printk("Random number len %d: 0x", len);
 	for (int i = 0; i < len; i++) {
-		printk("%x", num[i]);
+		printk("%02x", num[i]);
 	}
 	printk("\n");
 }


### PR DESCRIPTION
Trailing 0s were not printed.

Mostly a cosmetic fix.