### PR TITLE
applications: asset_tracker: Add basic cloud commands

### DIFF
--- a/applications/asset_tracker/src/main.c
+++ b/applications/asset_tracker/src/main.c
@@ -161,6 +161,7 @@ static void env_data_send(void);
 static void sensors_init(void);
 static void work_init(void);
 static void sensor_data_send(struct cloud_channel_data *data);
+static void device_status_send(struct k_work *work);
 
 /**@brief nRF Cloud error handler. */
 void error_handler(enum error_type err_type, int err_code)
@@ -362,6 +363,21 @@ exit:
 static void cloud_cmd_handler(struct cloud_command *cmd)
 {
 	/* Command handling goes here. */
+	if (cmd->recipient == CLOUD_RCPT_MODEM_INFO) {
+#if CONFIG_MODEM_INFO
+		if (cmd->type == CLOUD_CMD_READ) {
+			device_status_send(NULL);
+		}
+#endif
+	} else if (cmd->recipient == CLOUD_RCPT_UI) {
+		if (cmd->type == CLOUD_CMD_LED_RED) {
+			ui_led_set_color(127, 0, 0);
+		} else if (cmd->type == CLOUD_CMD_LED_GREEN) {
+			ui_led_set_color(0, 127, 0);
+		} else if (cmd->type == CLOUD_CMD_LED_BLUE) {
+			ui_led_set_color(0, 0, 127);
+		}
+	}
 }
 
 #if CONFIG_MODEM_INFO

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud.c
@@ -308,8 +308,11 @@ static void event_handler(const struct nrf_cloud_evt *nrf_cloud_evt)
 		LOG_DBG("NRF_CLOUD_EVT_RX_DATA");
 
 		evt.type = CLOUD_EVT_DATA_RECEIVED;
+		evt.data.msg.buf = (char *)nrf_cloud_evt->param.data.ptr;
+		evt.data.msg.len = nrf_cloud_evt->param.data.len;
 
-		cloud_notify_event(nrf_cloud_backend, &evt, config->user_data);
+		cloud_notify_event(nrf_cloud_backend, &evt,
+				   config->user_data);
 		break;
 	default:
 		LOG_DBG("Unknown event type: %d", nrf_cloud_evt->type);


### PR DESCRIPTION
The cloud command interface is now able to set
the LED to either red, green or blue. It is also
possible to request the device information string.
    
Signed-off-by: Henrik Malvik Halvorsen <henrik.halvorsen@nordicsemi.no>
