### PR TITLE
samples: nrf9160: aws_fota: Wrong variable name for client_id

### DIFF
--- a/samples/nrf9160/aws_fota/src/main.c
+++ b/samples/nrf9160/aws_fota/src/main.c
@@ -337,7 +337,7 @@ static int client_id_get(char *id_buf)
 
 	snprintf(id_buf, CLIENT_ID_LEN + 1, "nrf-%s", imei_buf);
 #else
-	memcpy(id, CONFIG_CLOUD_CLIENT_ID, CLIENT_ID_LEN + 1);
+	memcpy(id_buf, CONFIG_CLOUD_CLIENT_ID, CLIENT_ID_LEN + 1);
 #endif /* !defined(NRF_CLOUD_CLIENT_ID) */
 	return 0;
 }

--- a/samples/nrf9160/aws_fota/src/main.c
+++ b/samples/nrf9160/aws_fota/src/main.c
@@ -280,7 +280,7 @@ static int provision_certificates(void)
 
 		for (nrf_key_mgnt_cred_type_t type = 0; type < 3; type++) {
 			err = nrf_inbuilt_key_delete(sec_tag, type);
-			printk("nrf_inbuilt_key_delete(%lu, %d) => result=%d\n",
+			printk("nrf_inbuilt_key_delete(%u, %d) => result=%d\n",
 				sec_tag, type, err);
 		}
 
@@ -320,6 +320,7 @@ static int provision_certificates(void)
 			return err;
 		}
 	}
+	return 0;
 }
 #endif
 


### PR DESCRIPTION
I missed an search and replace for a variable name when I did a refactoring this changes it so that it uses the `id_buf` which is supplied from the caller of the function. Also some fixups for compilation warnings.