### PR TITLE
samples: nrf9160: mqtt: Fix missing definition names

### DIFF
--- a/samples/nrf9160/aws_fota/Kconfig
+++ b/samples/nrf9160/aws_fota/Kconfig
@@ -44,11 +44,11 @@ config USE_PROVISIONED_CERTIFICATES
 	  should provide a valid server certificate in `certificates.h` file.
 
 config MQTT_MESSAGE_BUFFER_SIZE
-	int ""
+	int "MQTT message buffer size"
 	default 128
 
 config MQTT_PAYLOAD_BUFFER_SIZE
-	int ""
+	int "MQTT payload buffer size"
 	default 128
 
 endmenu

--- a/samples/nrf9160/mqtt_simple/Kconfig
+++ b/samples/nrf9160/mqtt_simple/Kconfig
@@ -26,11 +26,11 @@ config MQTT_BROKER_PORT
 	default 1883
 
 config MQTT_MESSAGE_BUFFER_SIZE
-	int ""
+	int "MQTT message buffer size"
 	default 128
 
 config MQTT_PAYLOAD_BUFFER_SIZE
-	int ""
+	int "MQTT payload buffer size"
 	default 128
 
 endmenu


### PR DESCRIPTION
Both `mqtt_simple` and `aws_fota` lacks defined name for some of the
configuration parameters in Kconfig. This commit adds a name to these
configuration parameters. @oyvindronningstad @hakonfam 
NCSDK-2386

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>