### PR TITLE
Asset tracker: UI module fixes

### DIFF
--- a/applications/asset_tracker/src/ui/nmos.c
+++ b/applications/asset_tracker/src/ui/nmos.c
@@ -194,7 +194,7 @@ int ui_nmos_pwm_set(size_t nmos_idx, u32_t period, u32_t pulse)
 		return -EINVAL;
 	}
 
-	if (nmos_idx > (ARRAY_SIZE(nmos_pins) - 4)) {
+	if (nmos_idx > (ARRAY_SIZE(nmos_pins) - 1)) {
 		LOG_ERR("Invalid NMOS instance: %d", nmos_idx);
 		return -EINVAL;
 	}


### PR DESCRIPTION
applications: asset_tracker: Fix typo in UI

Fixes a typo in the UI library restricting the use of the external pins.

---
applications: asset_tracker: Fix PWM/GPIO consistency in UI

The UI library passes an initial period to the PWM driver, and
calls both the PWM and GPIO driver when used in non-PWM mode.
This ensures consistent output when the PWM hardware is enabled
and disabled at run-time.