### PR TITLE
lib: bsdlib: Forward POLLHUP event

### DIFF
--- a/lib/bsdlib/nrf91_sockets.c
+++ b/lib/bsdlib/nrf91_sockets.c
@@ -692,6 +692,9 @@ static inline int nrf91_socket_offload_poll(struct pollfd *fds, int nfds,
 		if (tmp[i].returned & NRF_POLLNVAL) {
 			fds[i].revents |= POLLNVAL;
 		}
+		if (tmp[i].returned & NRF_POLLHUP) {
+			fds[i].revents |= POLLHUP;
+		}
 	}
 
 	return retval;


### PR DESCRIPTION
Forward POLLHUP events from bsdlib to application.