### PR TITLE
drivers: st25r3911b: Add tag sleep callback

### DIFF
--- a/drivers/st25r3911b/st25r3911b_nfca.c
+++ b/drivers/st25r3911b/st25r3911b_nfca.c
@@ -711,6 +711,10 @@ static int irq_process(void)
 
 		if (atomic_get(&nfca.state.tag) == STATE_SLEEP) {
 			state_set(STATE_IDLE);
+
+			if (nfca.cb->tag_sleep) {
+				nfca.cb->tag_sleep();
+			}
 		}
 	}
 

--- a/include/drivers/st25r3911b_nfca.h
+++ b/include/drivers/st25r3911b_nfca.h
@@ -157,6 +157,10 @@ struct st25r3911b_nfca_cb {
 	 *  @param tag_sleep If set, the tag is in sleep mode.
 	 */
 	void (*rx_timeout)(bool tag_sleep);
+
+	/** @brief NFC-A tag sleep state notification.
+	 */
+	void (*tag_sleep)(void);
 };
 
 /** @brief Initialize NFC Reader NFC-A technology.

--- a/samples/nfc/tag_reader/src/main.c
+++ b/samples/nfc/tag_reader/src/main.c
@@ -157,6 +157,11 @@ static void transfer_completed(const u8_t *data, size_t len, int err)
 	k_delayed_work_submit(&transmit_work, TRANSMIT_DELAY);
 }
 
+static void tag_sleep(void)
+{
+	printk("Tag entered the Sleep state.\n");
+}
+
 static const struct st25r3911b_nfca_cb cb = {
 	.field_on = nfc_field_on,
 	.field_off = nfc_field_off,
@@ -164,6 +169,7 @@ static const struct st25r3911b_nfca_cb cb = {
 	.anticollision_completed = anticollision_completed,
 	.rx_timeout = nfc_timeout,
 	.transfer_completed = transfer_completed,
+	.tag_sleep = tag_sleep
 };
 
 void main(void)


### PR DESCRIPTION
This commit add NFC-A tag sleep callback. This callback
is useful to get a information that sleep command was send
correctly.

Signed-off-by: Kamil Gawor <Kamil.Gawor@nordicsemi.no>