### PR TITLE
nrf: lib: at_host: Fix AT command bug

### DIFF
--- a/lib/at_host/at_host.c
+++ b/lib/at_host/at_host.c
@@ -80,6 +80,9 @@ static void cmd_send(struct k_work *work)
 
 	ARG_UNUSED(work);
 
+	/* Make sure the string is 0-terminated */
+	at_buf[MIN(at_buf_len, AT_MAX_CMD_LEN - 1)] = 0;
+
 	err = at_cmd_write(at_buf, buf, AT_MAX_CMD_LEN, &state);
 	if (err < 0) {
 		LOG_ERR("Could not send AT command to modem: %d", err);


### PR DESCRIPTION
When at_host was switched over from using a private AT socket
to the common AT socket driver the AT command string needed
to be properly 0 terminated. This was not done, and the
result was that the driver would send out rand characters
in some cases.

Signed-off-by: Even Falch-Larsen <even.falch-larsen@nordicsemi.no>