### PR TITLE
lib: at_host: fix unresponsiveness after memory error

### DIFF
--- a/drivers/at_cmd/at_cmd.c
+++ b/drivers/at_cmd/at_cmd.c
@@ -122,7 +122,7 @@ static void socket_thread_fn(void *arg1, void *arg2, void *arg3)
 {
 	int                        bytes_read;
 	int                        payload_len;
-	char                       buf[CONFIG_AT_CMD_RESPONSE_MAX_LEN];
+	static char                buf[CONFIG_AT_CMD_RESPONSE_MAX_LEN];
 	bool                       callback = true;
 	struct return_state_object ret = {
 						.state = AT_CMD_OK,

--- a/lib/at_host/at_host.c
+++ b/lib/at_host/at_host.c
@@ -74,7 +74,7 @@ static void cmd_send(struct k_work *work)
 {
 	size_t            chars;
 	char              str[15];
-	char              buf[AT_MAX_CMD_LEN] = {0};
+	static char       buf[AT_MAX_CMD_LEN];
 	enum at_cmd_state state;
 	int               err;
 

--- a/lib/at_host/at_host.c
+++ b/lib/at_host/at_host.c
@@ -86,7 +86,7 @@ static void cmd_send(struct k_work *work)
 	err = at_cmd_write(at_buf, buf, AT_MAX_CMD_LEN, &state);
 	if (err < 0) {
 		LOG_ERR("Could not send AT command to modem: %d", err);
-		return;
+		state = AT_CMD_ERROR;
 	}
 
 	switch (state) {


### PR DESCRIPTION
The AT host library driver did not enable the
uart reception interrupt when the at_write_cmd
function failed because of a non-AT related issue.
It will now treat such errors as the generic
AT error. Also moved the reception buffers in
at_host.c:cmd_send and the thread in at_cmd.c
so they are not allocated on the workqueue and
thread stacks.

Signed-off-by: Even Falch-Larsen <even.falch-larsen@nordicsemi.no>