### PR TITLE
manifest: Update nrfxlib version

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -60,7 +60,7 @@ manifest:
       revision: 543ecb7c8662580ef803d59ceda7bd3b8a84a11b
     - name: nrfxlib
       path: nrfxlib
-      revision: 8c4eb7fe59952e3f6ae190ce0bd2696a9e230aae
+      revision: 940a3788b1bc29e43a33cffc18dd71a4fdd26e26
     - name: cmock
       path: test/cmock
       revision: c243b9a7a7b3c471023193992b46cf1bd1910450


### PR DESCRIPTION
Updated nrfxlib revision to 940a3788b1bc29e43a33cffc18dd71a4fdd26e26
with:
- bsdlib, v0.3.3

Signed-off-by: Glenn Ruben Bakke <glenn.ruben.bakke@nordicsemi.no>