### PR TITLE
manifest: nrfxlib

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -60,7 +60,7 @@ manifest:
       revision: 543ecb7c8662580ef803d59ceda7bd3b8a84a11b
     - name: nrfxlib
       path: nrfxlib
-      revision: 940a3788b1bc29e43a33cffc18dd71a4fdd26e26
+      revision: efcbc258d7c869457e5af59f100fe9a7eeb19b62
     - name: cmock
       path: test/cmock
       revision: c243b9a7a7b3c471023193992b46cf1bd1910450


### PR DESCRIPTION
This PR is including the newly-added licenses in the nrfxlib (license for nfc and bsdlib)