### PR TITLE
manifest: Updated manifest to use v1.0.0 release tags

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -40,7 +40,7 @@ manifest:
     - name: fw-nrfconnect-zephyr
       path: zephyr
       west-commands: scripts/west-commands.yml
-      revision: 7e64ac737daead12d2dbdda5daec04188243a81c
+      revision: v1.14.99-ncs2
     - name: nffs
       revision: bc62a2fa9d98ddb5d633c932ea199bc68e10f194
       path: modules/fs/nffs
@@ -51,7 +51,7 @@ manifest:
       remote: zephyrproject
     - name: fw-nrfconnect-mcuboot
       path: mcuboot
-      revision: 8b0e50cd5898e66e8bf92b5378c5b29fb0838471
+      revision: v1.3.99-ncs2
     - name: fw-nrfconnect-mcumgr
       revision: c8f675a5fa7f62106b9d913844bd5ed6e16ae69e
       path: modules/lib/mcumgr
@@ -60,7 +60,7 @@ manifest:
       revision: 543ecb7c8662580ef803d59ceda7bd3b8a84a11b
     - name: nrfxlib
       path: nrfxlib
-      revision: 940a3788b1bc29e43a33cffc18dd71a4fdd26e26
+      revision: v1.0.0
     - name: cmock
       path: test/cmock
       revision: c243b9a7a7b3c471023193992b46cf1bd1910450


### PR DESCRIPTION
Updated the west.yml to use release tags:
- zephyr:  v1.14.99-ncs2
- mcuboot: v1.3.99-ncs2
- nrfxlib: v1.0.0

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>