### PR TITLE
boards: nrf52810_pca20045: Fix CTS pin configuration

### DIFF
--- a/boards/arm/nrf52810_pca20045/nrf52810_pca20045.dts
+++ b/boards/arm/nrf52810_pca20045/nrf52810_pca20045.dts
@@ -39,7 +39,7 @@
 	tx-pin = <18>;
 	rx-pin = <20>;
 	rts-pin = <16>;
-	rts-pin = <15>;
+	cts-pin = <15>;
 };
 
 &qdec {


### PR DESCRIPTION
Fix typo in CTS pin configuration.

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>