### PR TITLE
boards: nrf52810_pca20045: Remove DCDC regulator config

### DIFF
--- a/boards/arm/nrf52810_pca20045/Kconfig
+++ b/boards/arm/nrf52810_pca20045/Kconfig
@@ -6,9 +6,4 @@
 
 if BOARD_NRF52810_PCA20045
 
-config BOARD_ENABLE_DCDC
-        bool "Enable DCDC mode"
-        select SOC_DCDC_NRF52X
-        default y
-
 endif # BOARD_NRF52810_PCA20045


### PR DESCRIPTION
PCA20045 does not have the required filters so DCDC regulator
cannot be enabled.

Jira:DESK-595

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>