### PR TITLE
Add debug option to SPM

### DIFF
--- a/include/spm.rst
+++ b/include/spm.rst
@@ -50,6 +50,11 @@ Peripherals configured as Non-Secure
    * TWIM2
    * UARTE0, UARTE1
 
+If you want to use software breakpoints when stepping through your code, it is necessary to disable the lock bit on permissions for flash and RAM.
+You can use the :option:`CONFIG_SPM_DEBUG` option to prevent SPM from setting this lock bit.
+Keep in mind however, that this configuration disables some security features and must never be used in production.
+By setting :option:`CONFIG_SPM_DEBUG` the SPM does not set the lock bit for the permissions; hence disabling some of the security features in the SPM and should never be used in production.
+
 .. _lib_spm_secure_services:
 
 Secure Services

--- a/subsys/spm/Kconfig
+++ b/subsys/spm/Kconfig
@@ -55,7 +55,9 @@ config SPM_DEBUG
 	default y if DEBUG_OPTIMIZATIONS
 	default n
 	help
-	  Disables the lock bit of the flash and sram allowing it to be changed by a
+	  Disables the lock bit of the flash and SRAM.
+	  This allows a debugger to write software breakpoints to flash
+	  and to modify SRAM.
 	  debugger so that software breakpoints can be written to flash and sram can
 	  be modified.
 

--- a/subsys/spm/Kconfig
+++ b/subsys/spm/Kconfig
@@ -48,6 +48,17 @@ menuconfig IS_SPM
 	select TRUSTED_EXECUTION_SECURE
 
 if IS_SPM
+
+config SPM_DEBUG
+	bool "SPM debug mode"
+	default y if NO_OPTIMIZATIONS
+	default y if DEBUG_OPTIMIZATIONS
+	default n
+	help
+	  Disables the lock bit of the flash and sram allowing it to be changed by a
+	  debugger so that software breakpoints can be written to flash and sram can
+	  be modified.
+
 # Define used by partition_manager.py to deduce size of partition
 config PM_PARTITION_SIZE_SPM
 	hex "Flash space reserved for SPM"

--- a/subsys/spm/spm.c
+++ b/subsys/spm/spm.c
@@ -29,6 +29,14 @@
 #define NON_SECURE_APP_ADDRESS DT_FLASH_AREA_IMAGE_0_NONSECURE_OFFSET_0
 #endif /* USE_PARTITION_MANAGER */
 
+#if defined(CONFIG_SPM_DEBUG)
+#define SPM_DEBUG true
+#warning "SPM debug is enabled, so some security features are disabled. Do not"\
+	 " use this configuration in the final product."
+#else
+#define SPM_DEBUG false
+#endif /* CONFIG_SPM_DEBUG */
+
 #define FIRST_NONSECURE_ADDRESS (NON_SECURE_APP_ADDRESS)
 #define LAST_SECURE_REGION_INDEX \
 	((FIRST_NONSECURE_ADDRESS / FLASH_SECURE_ATTRIBUTION_REGION_SIZE) - 1)
@@ -135,7 +143,6 @@ static void spm_config_nsc_flash(void)
 }
 #endif /* CONFIG_ARM_FIRMWARE_HAS_SECURE_ENTRY_FUNCS */
 
-
 static void spm_config_flash(void)
 {
 	/* Regions of flash up to and including SPM are configured as Secure.
@@ -145,11 +152,11 @@ static void spm_config_flash(void)
 		/* Configuration for Secure Regions */
 		[0 ... LAST_SECURE_REGION_INDEX] =
 			FLASH_READ | FLASH_WRITE | FLASH_EXEC |
-			FLASH_LOCK | FLASH_SECURE,
+			(SPM_DEBUG ? 0 : FLASH_LOCK) | FLASH_SECURE,
 		/* Configuration for Non Secure Regions */
 		[(LAST_SECURE_REGION_INDEX + 1) ... 31] =
 			FLASH_READ | FLASH_WRITE | FLASH_EXEC |
-			FLASH_LOCK | FLASH_NONSEC,
+			(SPM_DEBUG ? 0 : FLASH_LOCK) | FLASH_NONSEC,
 	};
 
 	PRINT("Flash region\t\tDomain\t\tPermissions\n");
@@ -193,10 +200,10 @@ static void spm_config_sram(void)
 	static const u32_t sram_perm[] = {
 		/* Configuration for Regions 0 - 7 (0 - 64 kB) */
 		[0 ... 7] = SRAM_READ | SRAM_WRITE | SRAM_EXEC |
-			    SRAM_LOCK | SRAM_SECURE,
+			    (SPM_DEBUG ? 0 : SRAM_LOCK) | SRAM_SECURE,
 		/* Configuration for Regions 8 - 31 (64 - 256 kB) */
 		[8 ... 31] = SRAM_READ | SRAM_WRITE | SRAM_EXEC |
-			     SRAM_LOCK | SRAM_NONSEC,
+			     (SPM_DEBUG ? 0 : SRAM_LOCK) | SRAM_NONSEC,
 	};
 
 	PRINT("SRAM region\t\tDomain\t\tPermissions\n");


### PR DESCRIPTION
With regards to some discussions around setting the lock bit in the SPU for flash/ram could hinder the debugger from setting a software breakpoints in the code on the device. This is a patch were developed which adds an option to turn on/off the lock bit in the SPU while also warning the user not to use this feature in production through `#warning`.

Ref. https://infocenter.nordicsemi.com/topic/ps_nrf9160/spu.html?resultof=%22%53%50%55%22%20%22%73%70%75%22%20
>  For each region, permissions can be set and then locked by using the `FLASHPERM[].PERM.LOCK` bit, to prevent subsequent modifications.
>For each region, permissions can be set and then locked to prevent subsequent modifications by using the `RAMPERM[].PERM.LOCK` bit.

By not setting this bit we give the debugger the option of manipulating permissions and hence modify flash/ram. 