### PR TITLE
lib: modem_info: dont require CJSON_LIB

### DIFF
--- a/include/modem_info.h
+++ b/include/modem_info.h
@@ -7,7 +7,9 @@
 #ifndef ZEPHYR_INCLUDE_MODEM_INFO_H_
 #define ZEPHYR_INCLUDE_MODEM_INFO_H_
 
+#ifdef CONFIG_CJSON_LIB
 #include <cJSON.h>
+#endif
 
 /**
  * @file modem_info.h
@@ -178,6 +180,7 @@ int modem_info_name_get(enum modem_info info, char *name);
  */
 enum at_param_type modem_info_type_get(enum modem_info info);
 
+#ifdef CONFIG_CJSON_LIB
 /** @brief Encode the modem parameters.
  *
  * The data is stored to a JSON object.
@@ -204,6 +207,7 @@ int modem_info_json_string_encode(struct modem_param_info *modem_param,
  */
 int modem_info_json_object_encode(struct modem_param_info *modem,
 				  cJSON *root_obj);
+#endif
 
 /** @brief Obtain the modem parameters.
  *

--- a/lib/modem_info/CMakeLists.txt
+++ b/lib/modem_info/CMakeLists.txt
@@ -6,8 +6,8 @@
 
 zephyr_library()
 zephyr_library_sources(modem_info.c)
-zephyr_library_sources(modem_info_json.c)
 zephyr_library_sources(modem_info_params.c)
+zephyr_library_sources_ifdef(CONFIG_CJSON_LIB modem_info_json.c)
 
 find_package(Git QUIET)
 if(NOT APP_VERSION AND GIT_FOUND)

--- a/lib/modem_info/modem_info_params.c
+++ b/lib/modem_info/modem_info_params.c
@@ -7,7 +7,6 @@
 #include <zephyr.h>
 #include <string.h>
 #include <stdlib.h>
-#include <cJSON.h>
 #include <modem_info.h>
 #include <at_params.h>
 #include <logging/log.h>


### PR DESCRIPTION
modem_info lib currently requires the use of JSON lib for
encoding data into JSON.

Some use-cases such as LwM2M can make use of the modem_info lib
but don't need the JSON formatting functions.

Let's make CJSON_LIB optional for this purpose.

Signed-off-by: Michael Scott <mike@foundries.io>