### PR TITLE
lib: bsdlib: add missing errno translation

### DIFF
--- a/lib/bsdlib/bsd_os.c
+++ b/lib/bsdlib/bsd_os.c
@@ -223,6 +223,9 @@ void bsd_os_errno_set(int err_code)
 	case NRF_EIO:
 		errno = EIO;
 		break;
+	case NRF_ENOEXEC:
+		errno = ENOEXEC;
+		break;
 	case NRF_EBADF:
 		errno = EBADF;
 		break;

--- a/lib/bsdlib/bsd_os.c
+++ b/lib/bsdlib/bsd_os.c
@@ -315,8 +315,8 @@ void bsd_os_errno_set(int err_code)
 		 * Log the untranslated errno and return a magic value
 		 * to make sure this sitation is clearly distinguishable.
 		 */
-		__ASSERT(false, "Untranslated errno %d set by bsdlib!", errno);
-		LOG_ERR("Untranslated errno %d set by bsdlib!", errno);
+		__ASSERT(false, "Untranslated errno %d set by bsdlib!", err_code);
+		LOG_ERR("Untranslated errno %d set by bsdlib!", err_code);
 		errno = 0xBAADBAAD;
 		break;
 	}


### PR DESCRIPTION
- Add missing `ENOEXEC` errno translation.
- Fix printing of untranslated errnos.