### PR TITLE
ci: use Standard Library in Jenkinsfile to link sub-projects together

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
   parameters {
        booleanParam(name: 'RUN_DOWNSTREAM', description: 'if false skip downstream jobs', defaultValue: true)
        booleanParam(name: 'RUN_TESTS', description: 'if false skip testing', defaultValue: true)
-       booleanParam(name: 'RUN_BUILD', description: 'if false skip building', defaultValue: false)
+       booleanParam(name: 'RUN_BUILD', description: 'if false skip building', defaultValue: true)
        string(name: 'jsonstr_CI_STATE', description: 'Default State if no upstream job', defaultValue: INPUT_STATE)
   }
 

--- a/west.yml
+++ b/west.yml
@@ -40,7 +40,7 @@ manifest:
     - name: fw-nrfconnect-zephyr
       path: zephyr
       west-commands: scripts/west-commands.yml
-      revision: v1.14.99-ncs3-snapshot2
+      revision: 9420e7247ba2827f58940a921b3837bf3a2f8cd8
     - name: nffs
       revision: bc62a2fa9d98ddb5d633c932ea199bc68e10f194
       path: modules/fs/nffs
@@ -54,7 +54,7 @@ manifest:
       revision: 900c7eea92e45adba1067e044ec705d4541c84a5
     - name: fw-nrfconnect-mcuboot
       path: mcuboot
-      revision: v1.3.99-ncs3-snapshot2
+      revision: pull/45/head
     - name: fw-nrfconnect-mcumgr
       revision: f663988d35da559a37f263d369842dbce309d1fa
       path: modules/lib/mcumgr
@@ -63,7 +63,7 @@ manifest:
       revision: 543ecb7c8662580ef803d59ceda7bd3b8a84a11b
     - name: nrfxlib
       path: nrfxlib
-      revision: 9e46730fdfbcdb59ce116b460a48ddcc1acac6b3
+      revision: f423938e8eeae075d64cd22f997c343950169333
     - name: cmock
       path: test/cmock
       revision: c243b9a7a7b3c471023193992b46cf1bd1910450

--- a/west.yml
+++ b/west.yml
@@ -54,7 +54,7 @@ manifest:
       revision: 900c7eea92e45adba1067e044ec705d4541c84a5
     - name: fw-nrfconnect-mcuboot
       path: mcuboot
-      revision: pull/45/head
+      revision: ad33e1ec4171f71e9e73f81dd1dba615291c0f28
     - name: fw-nrfconnect-mcumgr
       revision: f663988d35da559a37f263d369842dbce309d1fa
       path: modules/lib/mcumgr


### PR DESCRIPTION
Managing Docker version, Agent Labels, Github Status, manifest updates, downstream jobs from CI_LIB.

More info: https://projecttools.nordicsemi.no/confluence/display/NCS/Linking+Jenkins+Jobs+Together

Signed-off-by: Thomas Stilwell Thomas.Stilwell@nordicsemi.no