### PR TITLE
drivers: lte_link_control: split init_and_connect into 2 parts

### DIFF
--- a/drivers/lte_link_control/lte_lc.c
+++ b/drivers/lte_link_control/lte_lc.c
@@ -76,7 +76,7 @@ void at_handler(char *response)
 	}
 }
 
-static int w_lte_lc_init_and_connect(struct device *unused)
+static int w_lte_lc_init(void)
 {
 #if defined(CONFIG_LTE_EDRX_REQ)
 	/* Request configured eDRX settings to save power */
@@ -108,6 +108,12 @@ static int w_lte_lc_init_and_connect(struct device *unused)
 	}
 	LOG_INF("PDP Context: %s", cgdcont);
 #endif
+
+	return 0;
+}
+
+static int w_lte_lc_connect(void)
+{
 	if (at_cmd_write(network_mode, NULL, 0, NULL) != 0) {
 		return -EIO;
 	}
@@ -125,6 +131,30 @@ static int w_lte_lc_init_and_connect(struct device *unused)
 	at_cmd_set_notification_handler(NULL);
 
 	return 0;
+}
+
+static int w_lte_lc_init_and_connect(struct device *unused)
+{
+	int ret;
+
+	ret = w_lte_lc_init();
+	if (ret) {
+		return ret;
+	}
+
+	return w_lte_lc_connect();
+}
+
+/* lte lc Init wrapper */
+int lte_lc_init(void)
+{
+	return w_lte_lc_init();
+}
+
+/* lte lc Connect wrapper */
+int lte_lc_connect(void)
+{
+	return w_lte_lc_connect();
 }
 
 /* lte lc Init and connect wrapper */

--- a/include/lte_lc.h
+++ b/include/lte_lc.h
@@ -13,6 +13,22 @@
 #define ZEPHYR_INCLUDE_LTE_LINK_CONTROL_H_
 
 /** @brief Function for initializing
+ * the modem.  NOTE: a follow-up call to lte_lc_connect()
+ * must be made.
+ *
+ * @return Zero on success or (negative) error code otherwise.
+ */
+int lte_lc_init(void);
+
+/** @brief Function to make a connection with the modem.
+ * NOTE: prior to calling this function a call to lte_lc_init()
+ * must be made.
+ *
+ * @return Zero on success or (negative) error code otherwise.
+ */
+int lte_lc_connect(void);
+
+/** @brief Function for initializing
  * and make a connection with the modem
  *
  * @return Zero on success or (negative) error code otherwise.


### PR DESCRIPTION
Let's allow applications the option of first initializing the modem
and then later establishing the cellular connection by splitting
the current lte_lc_init_and_connect() function into 2 parts:
lte_lc_init()
lte_lc_connect()

This enables such behavior as:
- Initializing the modem
- Query IMEI information
- Setup security data based on AT-command queries
- Finally, starting the cellular connection

Signed-off-by: Michael Scott <mike@foundries.io>