### PR TITLE
applications: nrf_desktop: Fix system power down

### DIFF
--- a/applications/nrf_desktop/src/modules/power_manager.c
+++ b/applications/nrf_desktop/src/modules/power_manager.c
@@ -230,6 +230,12 @@ static bool event_handler(const struct event_header *eh)
 			LOG_INF("Wake up event consumed");
 			return true;
 		}
+
+		if (power_state == POWER_STATE_OFF) {
+			LOG_INF("Wake up when going into sleep - rebooting");
+			sys_reboot(SYS_REBOOT_WARM);
+		}
+
 		LOG_INF("Wake up the board");
 
 		power_state = POWER_STATE_IDLE;


### PR DESCRIPTION
Change adds reboot when wake up is received during power down handling.
Without it system wakes up improperly.