### PR TITLE
subsys: net: lib: aws_fota: Implement fetching of AWS jobs

### DIFF
--- a/include/net/aws_jobs.h
+++ b/include/net/aws_jobs.h
@@ -94,7 +94,7 @@ extern "C" {
  * @param[in] identifier The identifier of the topic you want to subscribe to.
  *	This can be either "accepted", "rejected", or "#" for both.
  */
-#define JOB_ID_GET_TOPIC_TEMPLATE AWS "%s/jobs/%s/get/%s"
+#define JOB_ID_GET_TOPIC_TEMPLATE AWS "%s/jobs/%s/get%s"
 #define JOB_ID_GET_TOPIC_MAX_LEN (AWS_LEN +\
 				 CONFIG_CLIENT_ID_MAX_LEN +\
 				 JOB_ID_MAX_LEN +\
@@ -329,6 +329,21 @@ int aws_jobs_update_job_execution(struct mqtt_client *const client,
 			     int expected_version,
 			     const u8_t *client_token);
 
+/**
+ * @brief AWS Jobs get job execution.
+ *
+ * This implements fetching a job from the queue in AWS.
+ *
+ * @param[in] client	Initialized and connected MQTT Client instance.
+ * @param[in] job_id	The ID of the job you are fetching use "$next" for
+ *			fetching the next IN_PROGRESS. or QUEUED job. It will
+ *			fetch the first created job if multiple exsists.
+ *
+ * @retval 0       If the update is published successfully, otherwise return
+ *		   mqtt_publish error code or the error code of snprintf.
+ */
+int aws_jobs_get_job_execution(struct mqtt_client *const client,
+			       const char *job_id);
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/net/lib/aws_jobs/src/aws_jobs.c
+++ b/subsys/net/lib/aws_jobs/src/aws_jobs.c
@@ -421,6 +421,9 @@ int aws_jobs_unsubscribe_expected_topics(struct mqtt_client *const client,
  * @param[in] job_id Job ID of the current accepted job ormatted.
  * @param[in] topic_buf buffer for storing the topic string until mqtt_subscribe
  *	is called.
+ * @param[in] suffix Suffix at the end of the constructed mqtt topic. The topic
+ *	does not include a forward slash `/` so this has to be included when
+ *	passing a suffix to the topic.
  * @param[out] topic Outputs the constructed mqtt_topic into the given buffer.
  *
  * @retval 0 If sucessful otherwise the return value of report_snprintf_err
@@ -428,6 +431,7 @@ int aws_jobs_unsubscribe_expected_topics(struct mqtt_client *const client,
  */
 static int construct_job_id_get_topic(const u8_t *client_id,
 				      const u8_t *job_id,
+				      const u8_t *suffix,
 				      u8_t *topic_buf,
 				      struct mqtt_topic *topic)
 {
@@ -437,7 +441,7 @@ static int construct_job_id_get_topic(const u8_t *client_id,
 			  JOB_ID_GET_TOPIC_TEMPLATE,
 			  client_id,
 			  job_id,
-			  "#");
+			  suffix);
 	job_id_get_topic_len = ret;
 	ret = report_snprintf_err(ret,
 				  JOB_ID_GET_TOPIC_MAX_LEN,
@@ -464,6 +468,7 @@ int aws_jobs_subscribe_job_id_get_topic(struct mqtt_client *const client,
 	struct mqtt_topic subscribe_topic;
 	int err = construct_job_id_get_topic(client->client_id.utf8,
 					     job_id,
+					     "/#",
 					     job_id_get_topic,
 					     &subscribe_topic);
 	if (err) {
@@ -492,6 +497,7 @@ int aws_jobs_unsubscribe_job_id_get_topic(struct mqtt_client *const client,
 	struct mqtt_topic subscribe_topic;
 	int err = construct_job_id_get_topic(client->client_id.utf8,
 					     job_id,
+					     "/#",
 					     job_id_get_topic,
 					     &subscribe_topic);
 
@@ -556,7 +562,6 @@ int aws_jobs_subscribe_job_id_update(struct mqtt_client *const client,
 	if (client == NULL || job_id == NULL) {
 		return -EINVAL;
 	}
-
 	u8_t job_id_update_topic[JOB_ID_UPDATE_TOPIC_MAX_LEN + 1];
 	struct mqtt_topic subscribe_topic;
 	/* Subscribe to both update and rejected topic */
@@ -666,6 +671,38 @@ int aws_jobs_update_job_execution(struct mqtt_client *const client,
 		.message.topic = job_id_update_topic,
 		.message.payload.data = update_job_payload,
 		.message.payload.len = update_job_payload_len,
+		.message_id = sys_rand32_get(),
+		.dup_flag = 0,
+		.retain_flag = 0,
+	};
+
+	return mqtt_publish(client, &param);
+}
+
+#define JOB_ID_GET_PAYLOAD "{\"clientToken\": \"\"}"
+int aws_jobs_get_job_execution(struct mqtt_client *const client,
+				const char *job_id)
+{
+	if (client == NULL) {
+		return -EINVAL;
+	}
+
+	char job_id_get_topic_buf[JOB_ID_GET_TOPIC_MAX_LEN + 1];
+	struct mqtt_topic job_id_get_topic;
+
+	int err = construct_job_id_get_topic(client->client_id.utf8, job_id, "",
+				   job_id_get_topic_buf, &job_id_get_topic);
+	if (err) {
+		return err;
+	}
+
+	LOG_DBG("Topic: %s", log_strdup(job_id_get_topic.topic.utf8));
+	LOG_DBG("Payload: %s", log_strdup(JOB_ID_GET_PAYLOAD));
+
+	struct mqtt_publish_param param = {
+		.message.topic = job_id_get_topic,
+		.message.payload.data = JOB_ID_GET_PAYLOAD,
+		.message.payload.len = strlen(JOB_ID_GET_PAYLOAD),
 		.message_id = sys_rand32_get(),
 		.dup_flag = 0,
 		.retain_flag = 0,


### PR DESCRIPTION
Implements pushing to the `$next` topic when connecting to the AWS MQTT
broker. Which returns any queued jobs for the device. This allows for a
device to be updated without having to be online at the time the update
is created.

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>