### PR TITLE
lib: modem_info: git describe should use NRF_DIR instead of "."

### DIFF
--- a/lib/modem_info/CMakeLists.txt
+++ b/lib/modem_info/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(Git QUIET)
 if(NOT APP_VERSION AND GIT_FOUND)
   execute_process(
     COMMAND ${GIT_EXECUTABLE} describe --abbrev=12
-    WORKING_DIRECTORY                "."
+    WORKING_DIRECTORY                ${NRF_DIR}
     OUTPUT_VARIABLE                  APP_VERSION
     OUTPUT_STRIP_TRAILING_WHITESPACE
     ERROR_STRIP_TRAILING_WHITESPACE


### PR DESCRIPTION
Git describe command for generating APP_VERSION currently uses
a working directory of "." which during the build equates to the
location of build/.

Let's fix this by referring to the NRF_DIR which corrects the
APP_VERSION generation.

Signed-off-by: Michael Scott <mike@foundries.io>