### PR TITLE
bootloader: update reference to moved files

### DIFF
--- a/subsys/bootloader/c_runtime_setup/CMakeLists.txt
+++ b/subsys/bootloader/c_runtime_setup/CMakeLists.txt
@@ -13,9 +13,9 @@ zephyr_library()
 
 # TODO Use zephyr build code for this directly?
 zephyr_library_sources(
-  ${CORTEX_M}/prep_c.c
+  ${ARM}/prep_c.c
   ${CORTEX_M}/reset.S
-  ${ARM}/irq_init.c
+  ${CORTEX_M}/irq_init.c
   ${ARM}/exc_exit.S
   ${CORTEX_M}/vector_table.S
   ${ZEPHYR_BASE}/drivers/timer/cortex_m_systick.c


### PR DESCRIPTION
During mergeup some core files were moved.
Update the reference to these.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>