### PR TITLE
CODEOWNERS: remove me from west.yml

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,7 +8,7 @@
 /LICENSE                                  @carlescufi
 /README.rst                               @ru-fu @carlescufi
 /Jenkinsfile                              @carlescufi
-/west.yml                                 @carlescufi @mbolivar @tejlmand
+/west.yml                                 @carlescufi @tejlmand
 
 # Applications
 /applications/asset_tracker/              @joakimtoe @jtguggedal @rlubos


### PR DESCRIPTION
Since every PR that touches any NCS repository ultimately touches this
file if only to update the revision, I get email requesting my review
"as a code owner" for essentially every change made to NCS.

The resulting email volume is overwhelming me, and I don't want to
sacrifice the value of the "as a code owner" filter on my email, so
I'm removing myself from this file to hopefully get things under
control.
