### PR TITLE
west.yml: test zephyr:PR-183

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -36,7 +36,7 @@ manifest:
     - name: zephyr
       repo-path: fw-nrfconnect-zephyr
       west-commands: scripts/west-commands.yml
-      revision: 56f6a33a71c46ec5b2e1beb6076edf9521014ad3
+      revision: 736c7dd7525b050cbea3e34fe160b2af15cecbbb
     - name: nffs
       revision: bc62a2fa9d98ddb5d633c932ea199bc68e10f194
       path: modules/fs/nffs


### PR DESCRIPTION

Package "hub" has been renamed some time ago to "git-spindle".
Recently package with the same name "hub" has been released on PyPi
page, which causes installing pip requirements.txt to fail since
it is trying to install different package.

Signed-off-by: Thomas Stilwell <Thomas.Stilwell@nordicsemi.no>