### PR TITLE
drivers: lte_lc: Add missing log_strdup

### DIFF
--- a/drivers/lte_link_control/lte_lc.c
+++ b/drivers/lte_link_control/lte_lc.c
@@ -67,7 +67,7 @@ static const char legacy_pco[] = "AT%XEPCO=0";
 
 void at_handler(char *response)
 {
-	LOG_DBG("recv: %s", response);
+	LOG_DBG("recv: %s", log_strdup(response));
 
 	if (!memcmp(status1, response, AT_CMD_SIZE(status1)) ||
 	    !memcmp(status2, response, AT_CMD_SIZE(status2)) ||


### PR DESCRIPTION
Adds the required `log_strdup` to the AT response log statement.

Signed-off-by: Bernt Johan Damslora <bernt.johan.damslora@nordicsemi.no>