### PR TITLE
boards: arm: nrf9160_pca20035: Remove unused UART2

### DIFF
--- a/boards/arm/nrf9160_pca20035/nrf9160_pca20035_common.dts
+++ b/boards/arm/nrf9160_pca20035/nrf9160_pca20035_common.dts
@@ -172,11 +172,6 @@
 	cts-pin = <25>;
 };
 
-/* UART2 must be enabled for defines to be available for SPM. */
-&uart2 {
-	status = "okay";
-};
-
 &flash0 {
 	/*
 	 * For more information, see:


### PR DESCRIPTION
~~Adds the required TX and RX pins for UART2. This peripheral is not
actually used, so the pins are set to the disconnect value.~~

~~As outlined in the comment, this workaround is ultimately necessary because the SPM uses defines for each peripheral from the device tree, and fails to build if one of them is not present.~~

Removes the unused UART2 peripheral from the DTS board description. The
definition was previously needed by the SPM.