### PR TITLE
Extend lib: modem_info with IMEI and IMSI

### DIFF
--- a/include/modem_info.h
+++ b/include/modem_info.h
@@ -54,6 +54,8 @@ enum modem_info {
 	MODEM_INFO_LTE_MODE,	/**< LTE-M support mode. */
 	MODEM_INFO_NBIOT_MODE,	/**< NB-IoT support mode. */
 	MODEM_INFO_GPS_MODE,	/**< GPS support mode. */
+	MODEM_INFO_IMSI,	/**< Mobile subscriber identity. */
+	MODEM_INFO_IMEI,	/**< Modem serial number. */
 	MODEM_INFO_COUNT,	/**< Number of legal elements in the enum. */
 };
 
@@ -88,12 +90,14 @@ struct network_param {
 struct sim_param {
 	struct lte_param uicc; /**< UICC state. */
 	struct lte_param iccid; /**< SIM ICCID. */
+	struct lte_param imsi; /**< Mobile subscriber identity. */
 };
 
 /**@brief Device parameters. */
 struct device_param {
 	struct lte_param modem_fw; /**< Modem firmware version. */
 	struct lte_param battery; /**< Battery voltage. */
+	struct lte_param imei; /**< Modem serial number. */
 	const char *board; /**< Board version. */
 	const char *app_version; /**< Application version. */
 	const char *app_name; /**< Application name. */

--- a/include/modem_info.rst
+++ b/include/modem_info.rst
@@ -11,9 +11,10 @@ It issues AT commands to retrieve the following data:
 * Tracking area code, mobile country code, and mobile network code
 * Current mode and operator
 * The cell ID and IP address of the device
-* UICC state and SIM ICCID
+* UICC state, SIM ICCID and SIM IMSI
 * The battery voltage and temperature level, measured by the modem
 * The modem firmware version
+* The modem serial number
 * The LTE-M, NB-IoT, and GPS support mode
 
 The modem information library uses the :ref:`at_cmd_parser_readme`.

--- a/lib/at_cmd_parser/src/at_cmd_parser.c
+++ b/lib/at_cmd_parser/src/at_cmd_parser.c
@@ -23,8 +23,8 @@
 static int at_parse_param_u32(char *at_str, u32_t *val,
 				size_t *consumed)
 {
-	u32_t value = 0;
-	u32_t check_value;
+	u64_t value = 0;
+	u64_t check_value;
 	bool negative = false;
 
 	*consumed = 0;
@@ -44,7 +44,7 @@ static int at_parse_param_u32(char *at_str, u32_t *val,
 		check_value = value * 10;
 		value = check_value + ((*at_str) - '0');
 
-		if ((value < check_value) || (value == UINT32_MAX)) {
+		if (value >= UINT32_MAX) {
 			return -EINVAL;
 		}
 		at_str++;
@@ -70,7 +70,7 @@ static int at_parse_param_numeric(char *at_str,
 
 	u32_t val;
 	size_t consumed_bytes;
-	u32_t err = at_parse_param_u32(at_str, &val, &consumed_bytes);
+	int err = at_parse_param_u32(at_str, &val, &consumed_bytes);
 
 	if (err) {
 		*consumed = 0;

--- a/lib/modem_info/Kconfig
+++ b/lib/modem_info/Kconfig
@@ -47,6 +47,13 @@ config MODEM_INFO_ADD_SIM_ICCID
 	  Add the SIM card ICCID to the returned
 	  device JSON object.
 
+config MODEM_INFO_ADD_SIM_IMSI
+	bool "Read the SIM card IMSI from the modem"
+	default y
+	help
+	  Add the SIM card IMSI to the returned
+	  device JSON object.
+
 config MODEM_INFO_ADD_DEVICE
 	bool "Add the device information to the modem informer"
 	default y

--- a/lib/modem_info/modem_info.c
+++ b/lib/modem_info/modem_info.c
@@ -38,6 +38,8 @@ LOG_MODULE_REGISTER(modem_info);
 #define AT_CMD_CRSM		"AT+CRSM"
 #define AT_CMD_ICCID		"AT+CRSM=176,12258,0,0,10"
 #define AT_CMD_SYSTEMMODE	"AT%XSYSTEMMODE?"
+#define AT_CMD_IMSI		"AT+CIMI"
+#define AT_CMD_IMEI		"AT+CGSN"
 #define AT_CMD_SUCCESS_SIZE	5
 
 #define RSRP_DATA_NAME		"rsrp"
@@ -58,6 +60,8 @@ LOG_MODULE_REGISTER(modem_info);
 #define LTE_MODE_DATA_NAME	"lteMode"
 #define NBIOT_MODE_DATA_NAME	"nbiotMode"
 #define GPS_MODE_DATA_NAME	"gpsMode"
+#define IMSI_DATA_NAME		"imsi"
+#define MODEM_IMEI_DATA_NAME	"imei"
 
 #define RSRP_PARAM_INDEX	0
 #define RSRP_PARAM_COUNT	2
@@ -100,6 +104,12 @@ LOG_MODULE_REGISTER(modem_info);
 #define NBIOT_MODE_PARAM_INDEX	1
 #define GPS_MODE_PARAM_INDEX	2
 #define SYSTEMMODE_PARAM_COUNT	4
+
+#define IMSI_PARAM_INDEX    0
+#define IMSI_PARAM_COUNT    1
+
+#define MODEM_IMEI_PARAM_INDEX	0
+#define MODEM_IMEI_PARAM_COUNT  1
 
 struct modem_info_data {
 	const char *cmd;
@@ -253,6 +263,22 @@ static const struct modem_info_data gps_mode_data = {
 	.data_type	= AT_PARAM_TYPE_NUM_SHORT,
 };
 
+static const struct modem_info_data imsi_data = {
+	.cmd		= AT_CMD_IMSI,
+	.data_name	= IMSI_DATA_NAME,
+	.param_index	= IMSI_PARAM_INDEX,
+	.param_count	= IMSI_PARAM_COUNT,
+	.data_type	= AT_PARAM_TYPE_STRING,
+};
+
+static const struct modem_info_data imei_data = {
+	.cmd		= AT_CMD_IMEI,
+	.data_name	= MODEM_IMEI_DATA_NAME,
+	.param_index	= MODEM_IMEI_PARAM_INDEX,
+	.param_count	= MODEM_IMEI_PARAM_COUNT,
+	.data_type	= AT_PARAM_TYPE_STRING,
+};
+
 static const struct modem_info_data *const modem_data[] = {
 	[MODEM_INFO_RSRP]	= &rsrp_data,
 	[MODEM_INFO_CUR_BAND]	= &band_data,
@@ -272,6 +298,8 @@ static const struct modem_info_data *const modem_data[] = {
 	[MODEM_INFO_LTE_MODE]	= &lte_mode_data,
 	[MODEM_INFO_NBIOT_MODE] = &nbiot_mode_data,
 	[MODEM_INFO_GPS_MODE]   = &gps_mode_data,
+	[MODEM_INFO_IMSI]	= &imsi_data,
+	[MODEM_INFO_IMEI]	= &imei_data,
 };
 
 static rsrp_cb_t modem_info_rsrp_cb;
@@ -427,7 +455,9 @@ int modem_info_string_get(enum modem_info info, char *buf)
 		return -EIO;
 	}
 
-	if (info != MODEM_INFO_FW_VERSION) {
+	if ((info != MODEM_INFO_FW_VERSION)
+		&& (info != MODEM_INFO_IMEI)
+		&& (info != MODEM_INFO_IMSI)) {
 		cmd_length = modem_info_remove_cmd(recv_buf);
 	}
 

--- a/lib/modem_info/modem_info_json.c
+++ b/lib/modem_info/modem_info_json.c
@@ -153,6 +153,7 @@ static int sim_data_add(struct sim_param *sim, cJSON *json_obj)
 
 	total_len = json_add_data(&sim->uicc, json_obj);
 	total_len += json_add_data(&sim->iccid, json_obj);
+	total_len += json_add_data(&sim->imsi, json_obj);
 
 	return total_len;
 }
@@ -167,6 +168,7 @@ static int device_data_add(struct device_param *device, cJSON *json_obj)
 
 	total_len = json_add_data(&device->modem_fw, json_obj);
 	total_len += json_add_data(&device->battery, json_obj);
+	total_len += json_add_data(&device->imei, json_obj);
 	total_len += json_add_str(json_obj, "board", device->board);
 	total_len += json_add_str(json_obj, "appVersion", device->app_version);
 	total_len += json_add_str(json_obj, "appName", device->app_name);

--- a/lib/modem_info/modem_info_params.c
+++ b/lib/modem_info/modem_info_params.c
@@ -34,9 +34,11 @@ int modem_info_params_init(struct modem_param_info *modem)
 
 	modem->sim.uicc.type			= MODEM_INFO_UICC;
 	modem->sim.iccid.type			= MODEM_INFO_ICCID;
+	modem->sim.imsi.type		        = MODEM_INFO_IMSI;
 
 	modem->device.modem_fw.type		= MODEM_INFO_FW_VERSION;
 	modem->device.battery.type		= MODEM_INFO_BATTERY;
+	modem->device.imei.type			= MODEM_INFO_IMEI;
 	modem->device.board			= CONFIG_BOARD;
 	modem->device.app_version		= STRINGIFY(APP_VERSION);
 	modem->device.app_name			= STRINGIFY(PROJECT_NAME);
@@ -159,6 +161,9 @@ int modem_info_params_get(struct modem_param_info *modem)
 		if (IS_ENABLED(CONFIG_MODEM_INFO_ADD_SIM_ICCID)) {
 			ret += modem_data_get(&modem->sim.iccid);
 		}
+		if (IS_ENABLED(CONFIG_MODEM_INFO_ADD_SIM_IMSI)) {
+			ret += modem_data_get(&modem->sim.imsi);
+		}
 		if (ret) {
 			LOG_DBG("Sim data not obtained: %d", ret);
 			return -EAGAIN;
@@ -168,6 +173,7 @@ int modem_info_params_get(struct modem_param_info *modem)
 	if (IS_ENABLED(CONFIG_MODEM_INFO_ADD_DEVICE)) {
 		ret = modem_data_get(&modem->device.modem_fw);
 		ret += modem_data_get(&modem->device.battery);
+		ret += modem_data_get(&modem->device.imei);
 		if (ret) {
 			LOG_DBG("Device data not obtained: %d", ret);
 			return -EAGAIN;


### PR DESCRIPTION
Fixed overflow in lib: at_cmd_parser so that modem responses containing numbers larger than uint32 can be properly parsed as string.

Extended lib: modem_info with IMEI and IMSI.