### PR TITLE
samples: lwm2m_client: Change copyright notice

### DIFF
--- a/samples/nrf9160/lwm2m_client/src/lwm2m/include/lwm2m_client.h
+++ b/samples/nrf9160/lwm2m_client/src/lwm2m/include/lwm2m_client.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Foundries.io
+ * Copyright (c) 2019 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */

--- a/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_accelerometer.c
+++ b/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_accelerometer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Foundries.io
+ * Copyright (c) 2019 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */

--- a/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_button.c
+++ b/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_button.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Foundries.io
+ * Copyright (c) 2019 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */

--- a/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_buzzer.c
+++ b/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_buzzer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Foundries.io
+ * Copyright (c) 2019 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */

--- a/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_connmon.c
+++ b/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_connmon.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Foundries.io
+ * Copyright (c) 2019 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */

--- a/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_device.c
+++ b/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_device.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Foundries.io
+ * Copyright (c) 2019 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */

--- a/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_firmware.c
+++ b/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_firmware.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Foundries.io
+ * Copyright (c) 2019 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */

--- a/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_light_control.c
+++ b/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_light_control.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Foundries.io
+ * Copyright (c) 2019 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */

--- a/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_location.c
+++ b/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_location.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Foundries.io
+ * Copyright (c) 2019 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */

--- a/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_security.c
+++ b/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_security.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Foundries.io
+ * Copyright (c) 2019 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */

--- a/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_temp.c
+++ b/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_temp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Foundries.io
+ * Copyright (c) 2019 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */

--- a/samples/nrf9160/lwm2m_client/src/main.c
+++ b/samples/nrf9160/lwm2m_client/src/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Foundries.io
+ * Copyright (c) 2019 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */

--- a/samples/nrf9160/lwm2m_client/src/settings.c
+++ b/samples/nrf9160/lwm2m_client/src/settings.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Foundries.io
+ * Copyright (c) 2019 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/samples/nrf9160/lwm2m_client/src/settings.h
+++ b/samples/nrf9160/lwm2m_client/src/settings.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Foundries.io
+ * Copyright (c) 2019 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/samples/nrf9160/lwm2m_client/src/ui/button.c
+++ b/samples/nrf9160/lwm2m_client/src/ui/button.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Foundries.io
+ * Copyright (c) 2019 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */

--- a/samples/nrf9160/lwm2m_client/src/ui/include/button.h
+++ b/samples/nrf9160/lwm2m_client/src/ui/include/button.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Foundries.io
+ * Copyright (c) 2019 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */


### PR DESCRIPTION
The LWM2M sample is actually (c) Nordic Semiconductor, fix that in the
headers.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>