### PR TITLE
dts: remove unsupported fields from bh1749 sensor bindings

### DIFF
--- a/dts/bindings/sensor/rohm,bh1749.yaml
+++ b/dts/bindings/sensor/rohm,bh1749.yaml
@@ -5,7 +5,6 @@
 #
 
 title: BH1749 Digital 16bit Serial Output Type Color Sensor IC
-version: 0.1
 
 description: >
     This is a representation of the BH1749 sensor
@@ -20,4 +19,3 @@ properties:
     int-gpios:
       type: compound
       category: required
-      generation: define, use-prop-name


### PR DESCRIPTION
Upstream has removed and is rejecting the version and generation fields.

Signed-off-by: Jon Helge Nistad <jon.helge.nistad@nordicsemi.no>