### PR TITLE
spm: add to configure NRF_REGULATORS in non-secure zone

### DIFF
--- a/subsys/spm/Kconfig
+++ b/subsys/spm/Kconfig
@@ -153,6 +153,10 @@ config SPM_NRF_PWM3_NS
 	bool "PWM3 is Non-Secure"
 	default y
 
+config SPM_NRF_REGULATORS_NS
+	bool "Regulators is Non-Secure"
+	default n
+
 endif # IS_SPM
 
 endmenu

--- a/subsys/spm/spm.c
+++ b/subsys/spm/spm.c
@@ -344,6 +344,8 @@ static void spm_config_peripherals(void)
 
 		PERIPH("NRF_GPIOTE1", NRF_GPIOTE1_NS,
 				      CONFIG_SPM_NRF_GPIOTE1_NS),
+		PERIPH("NRF_REGULATORS", NRF_REGULATORS_S,
+				      CONFIG_SPM_NRF_REGULATORS_NS),
 	};
 
 	PRINT("Peripheral\t\tDomain\t\tStatus\n");


### PR DESCRIPTION
For application to put nRF91 into sleep, maybe to enable/disable DCDC as well.
DevZone discussion is [here](https://devzone.nordicsemi.com/f/nordic-q-a/47037/nrf9160-system-off-mode-bus-fault-error/188200).
This feature is used in serial modem project (PR to be created).