### PR TITLE
samples: nrf9160: Compile for boards defined in fw-nrfconnect-nrf

### DIFF
--- a/samples/nrf9160/at_client/CMakeLists.txt
+++ b/samples/nrf9160/at_client/CMakeLists.txt
@@ -6,6 +6,7 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
+include(../../../cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/nrf9160/coap_client/CMakeLists.txt
+++ b/samples/nrf9160/coap_client/CMakeLists.txt
@@ -6,6 +6,7 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
+include(../../../cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(nrf-coap-client)
 

--- a/samples/nrf9160/gps/CMakeLists.txt
+++ b/samples/nrf9160/gps/CMakeLists.txt
@@ -6,6 +6,7 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
+include(../../../cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(gps_socket_sample)
 

--- a/samples/nrf9160/http_application_update/CMakeLists.txt
+++ b/samples/nrf9160/http_application_update/CMakeLists.txt
@@ -6,6 +6,7 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
+include(../../../cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(http_application_update)
 

--- a/samples/nrf9160/secure_services/CMakeLists.txt
+++ b/samples/nrf9160/secure_services/CMakeLists.txt
@@ -6,6 +6,7 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
+include(../../../cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(secure_services)
 

--- a/samples/nrf9160/spm/CMakeLists.txt
+++ b/samples/nrf9160/spm/CMakeLists.txt
@@ -5,6 +5,7 @@
 #
 cmake_minimum_required(VERSION 3.8.2)
 
+include(../../../cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 


### PR DESCRIPTION
…nnect-nrf

It is now also possible to compile nrf9160 samples for boards that are
defined in fw-nrfconnect-nrf repo. I.e the nrf9160_pca20035

Signed-off-by: Jon Helge Nistad <jon.helge.nistad@nordicsemi.no>