### PR TITLE
lte_link_control: enhance to support various networks

### DIFF
--- a/drivers/lte_link_control/Kconfig
+++ b/drivers/lte_link_control/Kconfig
@@ -34,6 +34,21 @@ config LTE_LOCK_BAND_MASK
 		can be omitted. The maximum length is 88 characters.
 endif # LTE_LOCK_BANDS
 
+config LTE_LOCK_PLMN
+	bool "Enable LTE PLMN lock"
+	default n
+	help
+		Enable PLMN locks for network selection.
+
+if LTE_LOCK_PLMN
+config LTE_LOCK_PLMN_STRING
+	string "PLMN string"
+	default "00101"
+	help
+		Mobile Country Code (MCC) and Mobile Network Code (MNC) values.
+		Only numeric string formats supported.
+endif # LTE_LOCK_PLMN
+
 config LTE_PSM_REQ_RPTAU
 	string "PSM setting requested periodic TAU"
 	default "00000011"
@@ -82,14 +97,33 @@ config LTE_LEGACY_PCO_MODE
 
 config LTE_PDP_CMD
 	bool "Enable Packet Data Protocol AT command"
+	default n
+	help
+		Enable PDP define using AT+CGDCONT.
 
+if LTE_PDP_CMD
 config LTE_PDP_CONTEXT
 	string "Packet Data Protocol Context"
-	depends on LTE_PDP_CMD
 	default "0,\"IPv4v6\",\"internet.apn\""
 	help
 		The +CGDCONT command defines Packet Data Protocol (PDP) Context.
 		For reference, see 3GPP 27.007 Ch. 10.1.1
+endif  # LTE_PDP_CMD
+
+config LTE_PDN_AUTH_CMD
+	bool "Enable PDN connection authentication AT command"
+	default n
+	help
+		Enable PDP connection authentication using AT+CGAUTH.
+
+if LTE_PDN_AUTH_CMD
+config LTE_PDN_AUTH
+	string "PDN connection authentication parameters"
+	default "0,1,\"username\",\"password\""
+	help
+		The +CGAUTH command specifies authentication parameters for a PDN connection.
+		For reference, see 3GPP 27.007 Ch. 10.1.31.
+endif # LTE_PDN_AUTH_CMD
 
 choice
 	prompt "Select network mode"
@@ -100,8 +134,14 @@ choice
 config LTE_NETWORK_MODE_LTE_M
 	bool "LTE-M"
 
+config LTE_NETWORK_MODE_LTE_M_GPS
+	bool "LTE-M and GPS"
+
 config LTE_NETWORK_MODE_NBIOT
 	bool "NB-IoT"
+
+config LTE_NETWORK_MODE_NBIOT_GPS
+	bool "NB-IoT and GPS"
 
 endchoice
 


### PR DESCRIPTION
Add below to the lte_lc_driver:
 .PLMN lock, default false
 .PDN connection authentication, default false
 .Modem modes without GPS (LTE-M or NB-IoT only)
 .Enable modem trace if configured in BSD lib

Based on real need of testing in different networks.