### PR TITLE
manifest: Fix broken revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -36,7 +36,7 @@ manifest:
     - name: zephyr
       repo-path: fw-nrfconnect-zephyr
       west-commands: scripts/west-commands.yml
-      revision: b1d603491de8a02698d74a789579561141bc60eb
+      revision: 1df8e74cc4add69d85ffc190f910b8d80110df3f
     - name: nffs
       revision: bc62a2fa9d98ddb5d633c932ea199bc68e10f194
       path: modules/fs/nffs


### PR DESCRIPTION
The revision pointing to zephyr is inexistent. Fix it.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>