### PR TITLE
lib: bsdlib: support NRF_ENETRESET error code

### DIFF
--- a/lib/bsdlib/bsd_os.c
+++ b/lib/bsdlib/bsd_os.c
@@ -274,6 +274,9 @@ void bsd_os_errno_set(int err_code)
 	case NRF_ENETUNREACH:
 		errno = ENETUNREACH;
 		break;
+	case NRF_ENETRESET:
+		errno = ENETRESET;
+		break;
 	case NRF_ECONNRESET:
 		errno = ECONNRESET;
 		break;


### PR DESCRIPTION
This error code means "Connection aborted by network"
e.g. it's a normal case at LwM2M bootstrapping phase
Current default handling leads to system halt