### PR TITLE
samples: nrf9160: mqtt_simple: Update to new hostname

### DIFF
--- a/samples/nrf9160/mqtt_simple/Kconfig
+++ b/samples/nrf9160/mqtt_simple/Kconfig
@@ -19,7 +19,7 @@ config MQTT_CLIENT_ID
 
 config MQTT_BROKER_HOSTNAME
 	string "MQTT broker hostname"
-	default "iot.eclipse.org"
+	default "mqtt.eclipse.org"
 
 config MQTT_BROKER_PORT
 	int "MQTT broker port"

--- a/samples/nrf9160/mqtt_simple/prj.conf
+++ b/samples/nrf9160/mqtt_simple/prj.conf
@@ -31,7 +31,7 @@ CONFIG_MQTT_LIB_TLS=n
 #CONFIG_MQTT_PUB_TOPIC="/my/publish/topic"
 #CONFIG_MQTT_SUB_TOPIC="/my/subscribe/topic"
 #CONFIG_MQTT_CLIENT_ID="my-client-id"
-#CONFIG_MQTT_BROKER_HOSTNAME="iot.eclipse.org"
+#CONFIG_MQTT_BROKER_HOSTNAME="mqtt.eclipse.org"
 #CONFIG_MQTT_BROKER_PORT=1883
 
 # Main thread

--- a/samples/nrf9160/mqtt_simple/prj_qemu_x86.conf
+++ b/samples/nrf9160/mqtt_simple/prj_qemu_x86.conf
@@ -33,7 +33,7 @@ CONFIG_NET_CONFIG_MY_IPV4_GW="192.0.2.2"
 #CONFIG_MQTT_PUB_TOPIC="/my/publish/topic"
 #CONFIG_MQTT_SUB_TOPIC="/my/subscribe/topic"
 #CONFIG_MQTT_CLIENT_ID="my-client-id"
-#CONFIG_MQTT_BROKER_HOSTNAME="iot.eclipse.org"
+#CONFIG_MQTT_BROKER_HOSTNAME="mqtt.eclipse.org"
 #CONFIG_MQTT_BROKER_PORT=1883
 
 # Main thread


### PR DESCRIPTION
The MQTT broker has changed hostname from iot.oclipse.org to mqtt.eclipse.org
See: https://iot.eclipse.org/getting-started/ and https://bugs.eclipse.org/bugs/show_bug.cgi?id=541419

Signed-off-by: Sigurd Olav Nevstad <sigurdolav.nevstad@nordicsemi.no>