### PR TITLE
samples: nrf9160: http_application_update: Add missing header

### DIFF
--- a/samples/nrf9160/http_application_update/src/main.c
+++ b/samples/nrf9160/http_application_update/src/main.c
@@ -11,6 +11,7 @@
 #include <gpio.h>
 #include <net/fota_download.h>
 #include <dfu/mcuboot.h>
+#include <lte_lc.h>
 
 #define LED_PORT	DT_ALIAS_LED0_GPIOS_CONTROLLER
 


### PR DESCRIPTION
Added missing header file lte_lc.h to get rid of compiler
warning.

Signed-off-by: Ole Sæther <ole.saether@nordicsemi.no>