### PR TITLE
boards: pca20035: Add support for zephyr toolchain

### DIFF
--- a/boards/arm/nrf9160_pca20035/nrf9160_pca20035.yaml
+++ b/boards/arm/nrf9160_pca20035/nrf9160_pca20035.yaml
@@ -4,6 +4,7 @@ type: mcu
 arch: arm
 toolchain:
   - gnuarmemb
+  - zephyr
 ram: 64
 flash: 256
 supported:

--- a/boards/arm/nrf9160_pca20035/nrf9160_pca20035ns.yaml
+++ b/boards/arm/nrf9160_pca20035/nrf9160_pca20035ns.yaml
@@ -4,6 +4,7 @@ type: mcu
 arch: arm
 toolchain:
   - gnuarmemb
+  - zephyr
 ram: 128
 flash: 256
 supported:


### PR DESCRIPTION
This adds zephyr toolchain support to pca20035. Without this
sanitycheck will quietly drop build/test on this board unless
gnuarmemb toolchain is installed.

Signed-off-by: Jorgen Kvalvaag <jorgen.kvalvaag@nordicsemi.no>