### PR TITLE
app: nrf_desktop: usb_state: Clear report pending flag when usb disconnected

### DIFF
--- a/applications/nrf_desktop/src/modules/usb_state.c
+++ b/applications/nrf_desktop/src/modules/usb_state.c
@@ -249,6 +249,14 @@ static void broadcast_usb_state(void)
 	EVENT_SUBMIT(event);
 }
 
+static void reset_pending_report(void)
+{
+	if (sent_report_type != IN_REPORT_COUNT) {
+		LOG_WRN("USB clear report notification waiting flag");
+		sent_report_type = IN_REPORT_COUNT;
+	}
+}
+
 static void broadcast_subscription_change(void)
 {
 	if (IS_ENABLED(CONFIG_DESKTOP_HID_MOUSE)) {
@@ -354,6 +362,7 @@ static void device_status(enum usb_dc_status_code cb_status, const u8_t *param)
 
 		if (old_state == USB_STATE_ACTIVE) {
 			broadcast_subscription_change();
+			reset_pending_report();
 		}
 
 		broadcast_usb_state();


### PR DESCRIPTION
Will fix problem with lack of notification about report sent in case
of sudden disconnection of USB. In such situation driver may be
disconnected before report is sent. That lead usb_state to be in an
unfinished report sent state and caused rise of assertion when new
report request arrived.

Jira:DESK-651

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>