### PR TITLE
scripts: Use PyPI's mscgen instead of a local fork

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,5 +1,5 @@
 recommonmark==0.4.0
-git+https://github.com/carlescufi/mscgen.git@python3
+sphinxcontrib-mscgen>=0.5
 ecdsa
 intelhex
 nrfutil


### PR DESCRIPTION
Now that sphinxcontrib-mscgen is already at version 0.5 and supports
Python 3, use the official version instead of keeping a fork.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>