### PR TITLE
bluetooth: services: hids_c: Fix bug with GATT subscribe flag

### DIFF
--- a/subsys/bluetooth/services/hids_c.c
+++ b/subsys/bluetooth/services/hids_c.c
@@ -1024,7 +1024,8 @@ int bt_gatt_hids_c_rep_subscribe(struct bt_gatt_hids_c *hids_c,
 	rep->notify_params.value = BT_GATT_CCC_NOTIFY;
 	rep->notify_params.value_handle = rep->handlers.val;
 	rep->notify_params.ccc_handle = rep->handlers.ccc;
-	atomic_set(rep->notify_params.flags, BT_GATT_SUBSCRIBE_FLAG_VOLATILE);
+	atomic_set_bit(rep->notify_params.flags,
+		       BT_GATT_SUBSCRIBE_FLAG_VOLATILE);
 
 	LOG_DBG("Subscribe: val: %u, ccc: %u",
 		rep->notify_params.value_handle,


### PR DESCRIPTION
Change fixes bug, where BT_GATT_SUBSCRIBE_FLAG_VOLATILE was not set properly (because of that subscriptions were not properly removed on disconnection).

Related Zephyr change: [link](https://github.com/zephyrproject-rtos/zephyr/pull/17575/commits/b61b8e3138ccb3c4e67a674844ce5b5b2c5244db)