### PR TITLE
add offset info to partition manager target

### DIFF
--- a/cmake/partition_manager.cmake
+++ b/cmake/partition_manager.cmake
@@ -176,4 +176,26 @@ if(FIRST_BOILERPLATE_EXECUTION)
     set(ZEPHYR_RUNNER_CONFIG_KERNEL_HEX "${PROJECT_BINARY_DIR}/merged.hex"
       CACHE STRING "Path to merged image in Intel Hex format" FORCE)
   endif()
+
+  if (CONFIG_SECURE_BOOT AND CONFIG_BOOTLOADER_MCUBOOT)
+    # Create symbols for the offsets required for moving test update hex files
+    # to MCUBoots secondary slot. This is needed because objcopy does not
+    # support arithmetic expressions as argument (e.g. '0x100+0x200'), and all
+    # of the symbols used to generate the offset is only available as a
+    # generator expression when MCUBoots cmake code exectues. This because
+    # partition manager is performed as the last step in the configuration stage.
+    math(EXPR s0_offset "${PM_MCUBOOT_SECONDARY_ADDRESS} - ${PM_S0_ADDRESS}")
+    math(EXPR s1_offset "${PM_MCUBOOT_SECONDARY_ADDRESS} - ${PM_S1_ADDRESS}")
+
+    set_property(
+      TARGET partition_manager
+      PROPERTY s0_TO_SECONDARY
+      ${s0_offset}
+      )
+    set_property(
+      TARGET partition_manager
+      PROPERTY s1_TO_SECONDARY
+      ${s1_offset}
+      )
+  endif()
 endif()

--- a/subsys/bootloader/cmake/sign.cmake
+++ b/subsys/bootloader/cmake/sign.cmake
@@ -65,7 +65,7 @@ endif ()
 
 foreach (slot ${slots})
   set(signed_hex ${PROJECT_BINARY_DIR}/signed_by_b0_${slot}.hex)
-  set(sign_depends ${slot}_hex)
+  set(sign_depends ${PROJECT_BINARY_DIR}/${slot}.hex;${slot}_hex)
   set(to_sign ${PROJECT_BINARY_DIR}/${slot}.hex)
   set(hash_file ${GENERATED_PATH}/${slot}_firmware.sha256)
   set(signature_file ${GENERATED_PATH}/${slot}_firmware.signature)
@@ -145,6 +145,8 @@ foreach (slot ${slots})
     --magic-value "${VALIDATION_INFO_MAGIC}"
     DEPENDS
     ${SIGN_KEY_FILE_DEPENDS}
+    ${signature_file}
+    ${slot}_signature_file_target
     WORKING_DIRECTORY
     ${PROJECT_BINARY_DIR}
     COMMENT

--- a/west.yml
+++ b/west.yml
@@ -51,7 +51,7 @@ manifest:
       revision: 900c7eea92e45adba1067e044ec705d4541c84a5
     - name: mcuboot
       repo-path: fw-nrfconnect-mcuboot
-      revision: 1e0e56e359511e0f04a1332b4c6508149fc6b767
+      revision: 57a219e8015b02e190a04a8f4ae4f93227b81979
     - name: mcumgr
       repo-path: fw-nrfconnect-mcumgr
       revision: f663988d35da559a37f263d369842dbce309d1fa


### PR DESCRIPTION
To help mcuboot sign s0 and s1, expose the offset from each slot to the secondary slot.