### PR TITLE
subsys: spm: Add watchdog timer as non-secure peripheral

### DIFF
--- a/subsys/spm/Kconfig
+++ b/subsys/spm/Kconfig
@@ -153,6 +153,10 @@ config SPM_NRF_PWM3_NS
 	bool "PWM3 is Non-Secure"
 	default y
 
+config SPM_NRF_WDT_NS
+	bool "WDT is Non-Secure"
+	default y
+
 endif # IS_SPM
 
 endmenu

--- a/subsys/spm/spm.c
+++ b/subsys/spm/spm.c
@@ -333,6 +333,9 @@ static void spm_config_peripherals(void)
 #ifdef NRF_PWM3
 		PERIPH("NRF_PWM3", NRF_PWM3, CONFIG_SPM_NRF_PWM3_NS),
 #endif
+#ifdef NRF_WDT
+		PERIPH("NRF_WDT", NRF_WDT, CONIFG_SPM_NRF_WDT_NS),
+#endif
 		/* There is no DTS node for the peripherals below,
 		 * so address them using nrfx macros directly.
 		 */


### PR DESCRIPTION
Adds the functionality of configuring the nRF watchdog timer as a
non-secure peripheral.

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>