### PR TITLE
subsys: spm: Add WDT to SPM

### DIFF
--- a/subsys/spm/Kconfig
+++ b/subsys/spm/Kconfig
@@ -137,6 +137,10 @@ config SPM_NRF_SAADC_NS
 	bool "SAADC is Non-Secure"
 	default y
 
+config SPM_NRF_WDT_NS
+	bool "WDT is Non-Secure"
+	default y
+
 config SPM_NRF_PWM0_NS
 	bool "PWM0 is Non-Secure"
 	default y

--- a/subsys/spm/spm.c
+++ b/subsys/spm/spm.c
@@ -333,6 +333,9 @@ static void spm_config_peripherals(void)
 #ifdef NRF_PWM3
 		PERIPH("NRF_PWM3", NRF_PWM3, CONFIG_SPM_NRF_PWM3_NS),
 #endif
+#ifdef NRF_WDT
+		PERIPH("NRF_WDT", NRF_WDT, CONFIG_SPM_NRF_WDT_NS),
+#endif
 		/* There is no DTS node for the peripherals below,
 		 * so address them using nrfx macros directly.
 		 */


### PR DESCRIPTION
This patch adds WDT to SPM so that it can
be configured as non-secure using Kconfig.

Signed-off-by: Justin Brzozoski <justin.brzozoski@signal-fire.com>