### PR TITLE
subsys: profiler: Fix warning

### DIFF
--- a/include/profiler.h
+++ b/include/profiler.h
@@ -16,6 +16,8 @@
 
 
 #include <zephyr/types.h>
+#include <misc/util.h>
+#include <misc/__assert.h>
 
 #ifndef CONFIG_MAX_NUMBER_OF_CUSTOM_EVENTS
 /** Maximum number of custom events. */

--- a/subsys/profiler/profiler_common_shell.c
+++ b/subsys/profiler/profiler_common_shell.c
@@ -106,9 +106,7 @@ static int disable_event_profiling(const struct shell *shell, size_t argc,
 	return 0;
 }
 
-
-SHELL_CREATE_STATIC_SUBCMD_SET(sub_profiler)
-{
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_profiler,
 	SHELL_CMD_ARG(list, NULL, "Display list of events",
 			display_registered_events, 0, 0),
 	SHELL_CMD_ARG(enable, NULL, "Enable profiling of event with given ID",
@@ -118,6 +116,5 @@ SHELL_CREATE_STATIC_SUBCMD_SET(sub_profiler)
 			disable_event_profiling, 1,
 			sizeof(profiler_enabled_events) * 8),
 	SHELL_SUBCMD_SET_END
-};
-
+);
 SHELL_CMD_REGISTER(profiler, &sub_profiler, "Profiler commands", NULL);

--- a/subsys/profiler/profiler_sysview.c
+++ b/subsys/profiler/profiler_sysview.c
@@ -57,7 +57,7 @@ static void event_module_description(void)
 static u32_t shorten_mem_address(const void *event_mem_address)
 {
 #ifdef CONFIG_SRAM_BASE_ADDRESS
-	return (u32_t)(event_mem_address - CONFIG_SRAM_BASE_ADDRESS);
+	return (u32_t)(((u8_t *)event_mem_address) - CONFIG_SRAM_BASE_ADDRESS);
 #else
 	return (u32_t)event_mem_address;
 #endif


### PR DESCRIPTION
This change fixes warnings when building with CONFIG_PROFILER_SYSVIEW

Signed-off-by: Justin Brzozoski <justin.brzozoski@signal-fire.com>