### PR TITLE
drivers: nrf9160_gps: Add option to handle AT commands manually

### DIFF
--- a/drivers/nrf9160_gps/Kconfig
+++ b/drivers/nrf9160_gps/Kconfig
@@ -11,7 +11,6 @@ menuconfig NRF9160_GPS
 	# FP_SHARING needs to be enabled if FLOAT is enabled, as other contexts
 	# might also use the FPU.
 	select FP_SHARING if FLOAT
-	select AT_CMD_PARSER
 	help
 	  Enable nRF9160 GPS driver.
 
@@ -25,6 +24,21 @@ config NRF9160_GPS_FIX_CHECK_INTERVAL
 	int "Interval in seconds to check for GPS fix"
 	default 1
 
+config NRF9160_GPS_HANDLE_MODEM_CONFIGURATION
+	bool "The GPS driver will handle modem configuration directly"
+	default y
+	select AT_CMD
+	select AT_CMD_PARSER
+	help
+	  Disabling this will cause the GPS driver to do no modem
+	  configuration.  This is useful if you need to remove the
+	  dependency on the at_cmd_host library from the GPS driver,
+	  but it will require that some other part of the
+	  application send the AT commands to configure the GPS
+	  properly.
+
+if NRF9160_GPS_HANDLE_MODEM_CONFIGURATION
+
 config NRF9160_GPS_SET_MAGPIO
 	bool "Let the driver set MAGPIO configuration"
 	default y if BOARD_NRF9160_PCA10090NS
@@ -36,6 +50,8 @@ config NRF9160_GPS_MAGPIO_STRING
 	default "AT\%XMAGPIO=1,0,0,1,1,1574,1577" if BOARD_NRF9160_PCA10090NS
 
 endif # NRF9160_GPS_SET_MAGPIO
+
+endif # NRF9160_GPS_HANDLE_MODEM_CONFIGURATION
 
 menu "NMEA strings"
 config NRF9160_GPS_NMEA_GSV

--- a/drivers/nrf9160_gps/nrf9160_gps.c
+++ b/drivers/nrf9160_gps/nrf9160_gps.c
@@ -14,11 +14,14 @@
 #include <logging/log.h>
 #include <nrf_socket.h>
 #include <net/socket.h>
+#ifdef CONFIG_NRF9160_GPS_HANDLE_MODEM_CONFIGURATION
 #include <at_cmd.h>
 #include <at_cmd_parser.h>
+#endif
 
 LOG_MODULE_REGISTER(nrf9160_gps, CONFIG_NRF9160_GPS_LOG_LEVEL);
 
+#ifdef CONFIG_NRF9160_GPS_HANDLE_MODEM_CONFIGURATION
 #define AT_CMD_LEN(x)			(sizeof(x) - 1)
 #define AT_XSYSTEMMODE_REQUEST		"AT%XSYSTEMMODE?"
 #define AT_XSYSTEMMODE_RESPONSE		"%XSYSTEMMODE:"
@@ -30,6 +33,7 @@ LOG_MODULE_REGISTER(nrf9160_gps, CONFIG_NRF9160_GPS_LOG_LEVEL);
 #define AT_CFUN_0			"AT+CFUN=0"
 #define AT_CFUN_1			"AT+CFUN=1"
 #define FUNCTIONAL_MODE_ENABLED		1
+#endif
 
 struct gps_drv_data {
 	gps_trigger_handler_t trigger_handler;
@@ -216,6 +220,7 @@ static int init_thread(struct device *dev)
 	return 0;
 }
 
+#ifdef CONFIG_NRF9160_GPS_HANDLE_MODEM_CONFIGURATION
 static int enable_gps(struct device *dev)
 {
 	int err;
@@ -321,6 +326,7 @@ enable_gps_clean_exit:
 	at_params_list_free(&at_resp_list);
 	return err;
 }
+#endif
 
 static int start(struct device *dev)
 {
@@ -346,10 +352,12 @@ static int start(struct device *dev)
 	nmea_mask |= NRF_CONFIG_NMEA_RMC_MASK;
 #endif
 
+#ifdef CONFIG_NRF9160_GPS_HANDLE_MODEM_CONFIGURATION
 	if (enable_gps(dev) != 0) {
 		LOG_ERR("Failed to enable GPS");
 		return -EIO;
 	}
+#endif
 
 	if (drv_data->socket < 0) {
 		drv_data->socket = nrf_socket(NRF_AF_LOCAL, NRF_SOCK_DGRAM,


### PR DESCRIPTION
Adds the NRF9160_GPS_HANDLE_MODEM_CONFIGURATION option.  This provides
the ability to remove the at_cmd library dependency from the GPS driver
in case someone's application is managing the AT socket in a custom
driver.  This obviously comes with the caveat that with this in the
non-default setting the application must separately send the proper AT
commands to configure the GPS.

Signed-off-by: Justin Brzozoski <justin.brzozoski@signal-fire.com>