### PR TITLE
scripts: add ncs west extensions

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -3,3 +3,5 @@ sphinxcontrib-mscgen>=0.5
 ecdsa
 intelhex
 nrfutil
+pygit2>=0.26.0
+editdistance>=0.5.0

--- a/scripts/west-commands.yml
+++ b/scripts/west-commands.yml
@@ -1,0 +1,10 @@
+# Keep the help strings in sync with the values in the .py files!
+west-commands:
+  - file: scripts/west_commands/ncs_commands.py
+    commands:
+      - name: ncs-loot
+        class: NcsLoot
+        help: list out of tree unreverted NCS patches
+      - name: ncs-compare
+        class: NcsCompare
+        help: compare upstream manifest with NCS

--- a/scripts/west_commands/ncs_commands.py
+++ b/scripts/west_commands/ncs_commands.py
@@ -1,0 +1,377 @@
+# Copyright (c) 2019 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+'''The "ncs-xyz" extension commands.'''
+
+from pathlib import PurePath
+import subprocess
+from textwrap import dedent
+
+import packaging.version
+from west import log
+from west.commands import WestCommand
+from west.manifest import Manifest, MalformedManifest
+from west.version import __version__ as west_ver
+import yaml
+
+import ncs_west_helpers as nwh
+
+class NcsWestCommand(WestCommand):
+    # some common code that will be useful to multiple commands
+
+    def check_west_version(self):
+        min_ver = '0.6.99'
+        if (packaging.version.parse(west_ver) <
+                packaging.version.parse(min_ver)):
+            log.die('this command currently requires a pre-release west',
+                    '(your west version is {}, but must be at least {}).'.
+                    format(west_ver, min_ver))
+
+    def add_zephyr_rev_arg(self, parser):
+        parser.add_argument('-z', '--zephyr-rev',
+                            help='''upstream git ref to use for zephyr project;
+                            default is upstream/master''')
+
+    def add_projects_arg(self, parser):
+        parser.add_argument('projects', metavar='PROJECT', nargs='*',
+                            help='''projects (by name or path) to operate on;
+                            defaults to all projects in the manifest which
+                            are shared with the upstream manifest''')
+
+    def setup_upstream_downstream(self, args):
+        # set some instance state that will be useful for
+        # comparing upstream and downstream.
+        #
+        # below, "pmap" means "project map": a dict mapping project
+        # names to west.manifest.Project instances.
+
+        # z_manifest: upstream zephyr west.manifest.Manifest instance
+        #
+        # zephyr_rev: validated --zephyr-rev argument.
+        # (quits and print a message about what to do if things go wrong).
+        if hasattr(args, 'zephyr_rev'):
+            self.zephyr_rev = self.validate_zephyr_rev(args)
+            self.z_manifest = self.zephyr_manifest()
+            self.z_pmap = {p.name: p for p in self.z_manifest.projects}
+
+        # we want to build an ncs_pmap too. if we have a projects arg,
+        # we'll use that. otherwise, we'll just use all the projects
+        # in the NCS west manifest.
+        if hasattr(args, 'projects'):
+            try:
+                projects = self.manifest.get_projects(
+                    args.projects, only_cloned=True)
+            except ValueError as ve:
+                unknown, uncloned = ve.args
+                if unknown:
+                    log.die('unknown projects:', ', '.join(unknown))
+                if uncloned:
+                    log.die(
+                        'uncloned downstream projects: {}.\n'
+                        'Run "west update", then retry.'.
+                        format(', '.join(u.name for u in uncloned)))
+        else:
+            projects = self.manifest.projects
+        self.ncs_pmap = {p.name: p for p in projects}
+
+    def zephyr_manifest(self):
+        # load the upstream manifest. the west.manifest APIs guarantee
+        # in this case that its project hierarchy is rooted in the NCS
+        # directory.
+
+        z_project = self.manifest.get_projects(['zephyr'],
+                                               allow_paths=False,
+                                               only_cloned=True)[0]
+        cp = z_project.git('show {}:west.yml'.format(self.zephyr_rev),
+                           capture_stdout=True, check=True)
+        z_west_yml = cp.stdout.decode('utf-8')
+        try:
+            return Manifest.from_data(source_data=yaml.safe_load(z_west_yml),
+                                      topdir=self.topdir)
+        except MalformedManifest:
+            log.die("can't load zephyr manifest; file {} is malformed".
+                    format(z_west_yml))
+
+    def validate_zephyr_rev(self, args):
+        if args.zephyr_rev:
+            zephyr_rev = args.zephyr_rev
+        else:
+            zephyr_rev = 'upstream/master'
+        zephyr_project = self.manifest.get_projects(['zephyr'])[0]
+        try:
+            self.zephyr_sha = zephyr_project.sha(zephyr_rev)
+        except subprocess.CalledProcessError:
+            msg = 'unknown ZEPHYR_REV: {}'.format(zephyr_rev)
+            if not args.zephyr_rev:
+                msg += ('\nPlease run this in the zephyr repository and retry '
+                        '(or use --zephyr-rev):' +
+                        '\n  git remote add -f upstream ' + _UPSTREAM)
+            self.parser.error(msg)
+        return zephyr_rev
+
+class NcsLoot(NcsWestCommand):
+
+    def __init__(self):
+        super().__init__(
+            'ncs-loot',
+            'list out of tree (downstream only) NCS patches',
+            dedent('''
+            List commits which are not present in upstream repositories.
+
+            This command lists patches which are added for the NCS
+            in a downstream repository that have not been reverted.
+
+            Downstream revisions are loaded from nrf/west.yml.'''))
+
+    def do_add_parser(self, parser_adder):
+        parser = parser_adder.add_parser(self.name, help=self.help,
+                                         description=self.description)
+        self.add_zephyr_rev_arg(parser)
+        self.add_projects_arg(parser)
+        return parser
+
+    def do_run(self, args, unknown_args):
+        self.check_west_version()
+        self.setup_upstream_downstream(args)
+
+        for name, project in self.ncs_pmap.items():
+            if name in self.z_pmap and name != 'manifest':
+                z_project = self.z_pmap[name]
+            elif name == 'zephyr':
+                z_project = self.z_pmap['manifest']
+            else:
+                log.dbg('skipping downstream project {}'.format(name),
+                        level=log.VERBOSE_VERY)
+                continue
+            self.print_loot(name, project, z_project)
+
+    def print_loot(self, name, project, z_project):
+        # Print a list of out of tree outstanding patches in the given
+        # project.
+        #
+        # name: project name
+        # project: the west.manifest.Project instance in the NCS manifest
+        # z_project: the Project instance in the upstream manifest
+        msg = project.format('{name_and_path} outstanding downstream patches:')
+
+        # Get the upstream revision of the project. The zephyr project
+        # has to be treated as a special case.
+        if name == 'zephyr':
+            z_rev = self.zephyr_rev
+            msg += ' NOTE: {} *must* be up to date'.format(z_rev)
+        else:
+            z_rev = z_project.revision
+
+        log.banner(msg)
+
+        try:
+            nsha = project.sha(project.revision)
+            project.git('cat-file -e ' + nsha)
+        except subprocess.CalledProcessError:
+            log.wrn("can't get loot; please run \"west update {}\"".
+                    format(project.name),
+                    '(need revision {})'.format(project.revision))
+            return
+        try:
+            zsha = z_project.sha(z_project.revision)
+            z_project.git('cat-file -e ' + zsha)
+        except subprocess.CalledProcessError:
+            log.wrn("can't get loot; please fetch upstream URL",
+                    z_project.url,
+                    '(need revision {})'.format(z_project.revision))
+            return
+
+        try:
+            analyzer = nwh.RepoAnalyzer(project, z_project,
+                                        project.revision, z_rev)
+        except nwh.InvalidRepositoryError as ire:
+            log.die(str(ire))
+        try:
+            for c in analyzer.downstream_outstanding:
+                log.inf('- {} {}'.format(c.oid, nwh.commit_shortlog(c)))
+        except nwh.UnknownCommitsError as uce:
+            log.die('unknown commits:', str(uce))
+
+class NcsCompare(NcsWestCommand):
+    def __init__(self):
+        super().__init__(
+            'ncs-compare',
+            'compare upstream manifest with NCS',
+            dedent('''
+            Compares project status in upstream and NCS manifests.
+
+            Run this after doing a zephyr mergeup to double-check the
+            results. This command works using the current contents of
+            zephyr/west.yml, so the mergeup must be complete for output
+            to be valid.
+
+            Use --verbose to include information on blacklisted
+            upstream projects.'''))
+
+    def do_add_parser(self, parser_adder):
+        parser = parser_adder.add_parser(self.name, help=self.help,
+                                         description=self.description)
+        self.add_zephyr_rev_arg(parser)
+        return parser
+
+    def do_run(self, args, unknown_args):
+        self.check_west_version()
+        self.setup_upstream_downstream(args)
+
+        log.inf('Comparing nrf/west.yml with zephyr/west.yml at revision {}{}'.
+                format(self.zephyr_rev,
+                       (', sha: ' + self.zephyr_sha
+                        if self.zephyr_rev != self.zephyr_sha else '')))
+        log.inf()
+
+        present_blacklisted = []
+        present_allowed = []
+        missing_blacklisted = []
+        missing_allowed = []
+        for zn, zp in self.z_pmap.items():
+            nn = self.to_ncs_name(zp)
+            present = nn in self.ncs_pmap
+            blacklisted = PurePath(zp.path) in _PROJECT_BLACKLIST
+            if present:
+                if blacklisted:
+                    present_blacklisted.append(zp)
+                else:
+                    present_allowed.append(zp)
+            else:
+                if blacklisted:
+                    missing_blacklisted.append(zp)
+                else:
+                    missing_allowed.append(zp)
+
+        def print_lst(projects):
+            for p in projects:
+                log.small_banner(p.format('{name_and_path}'))
+
+        if missing_blacklisted and log.VERBOSE >= log.VERBOSE_NORMAL:
+            log.banner('blacklisted but missing in NCS (these are all OK):')
+            print_lst(missing_blacklisted)
+
+        if present_blacklisted:
+            log.banner('blacklisted upstream projects that are in NCS:')
+            log.wrn('these names should be removed from nrf/west.yml')
+            print_lst(present_blacklisted)
+
+        if missing_allowed:
+            log.banner('non-blacklisted upstream projects missing in NCS:')
+            log.wrn('these should be blacklisted or added to nrf/west.yml')
+            for p in missing_allowed:
+                log.small_banner(p.format('{name_and_path}'))
+                log.inf(p.format('upstream revision: {revision}'))
+                log.inf(p.format('upstream URL: {url}'))
+
+        if present_allowed:
+            log.banner('projects present in NCS:')
+            for zp in present_allowed:
+                # Do some extra checking on unmerged commits.
+                self.allowed_project(zp)
+
+    def allowed_project(self, zp):
+        nn = self.to_ncs_name(zp)
+        np = self.ncs_pmap[nn]
+
+        if np.name == 'zephyr':
+            nrev = self.manifest.get_projects(['zephyr'])[0].revision
+            zrev = self.zephyr_sha
+        else:
+            nrev = np.revision
+            zrev = zp.revision
+
+        log.small_banner(zp.format('{ncs_name} ({path}):', ncs_name=nn))
+
+        try:
+            nsha = np.sha(nrev)
+            np.git('cat-file -e ' + nsha)
+        except subprocess.CalledProcessError:
+            log.wrn("can't compare; please run \"west update {}\"".
+                    format(nn),
+                    '(need revision {})'.format(np.revision))
+            return
+        try:
+            zsha = np.sha(zrev)
+            np.git('cat-file -e ' + zsha)
+        except subprocess.CalledProcessError:
+            log.wrn("can't compare; please fetch upstream URL", zp.url,
+                    '(need revision {})'.format(zp.revision))
+            return
+
+        upstream_rev = 'upstream revision: ' + zrev
+        if zrev != zsha:
+            upstream_rev += ' ({})'.format(zsha)
+
+        downstream_rev = 'NCS revision: ' + nrev
+        if nrev != nsha:
+            downstream_rev += ' ({})'.format(nsha)
+
+        cp = np.git('rev-list --left-right --count {}...{}'.format(zsha, nsha),
+                    capture_stdout=True)
+        behind, ahead = [int(c) for c in cp.stdout.split()]
+
+        if zsha == nsha:
+            status = 'up to date'
+        elif ahead and not behind:
+            status = 'ahead by {} commits'.format(ahead)
+        elif np.is_ancestor_of(nsha, zsha):
+            status = ('behind by {} commits, can be fast-forwarded to {}'.
+                      format(behind, zsha))
+        else:
+            status = ('diverged from upstream: {} ahead, {} behind'.
+                      format(ahead, behind))
+
+        if 'behind' in status or 'diverged' in status:
+            color = log.WRN_COLOR
+        else:
+            color = log.INF_COLOR
+
+        log.msg(status, color=color)
+        log.inf(upstream_rev)
+        log.inf(downstream_rev)
+
+        analyzer = nwh.RepoAnalyzer(np, zp, nsha, zsha)
+        likely_merged = analyzer.likely_merged
+        if likely_merged:
+            # likely_merged is a map from downstream commits to
+            # lists of upstream commits that look similar.
+            log.msg('downstream patches which are likely merged upstream',
+                    '(revert these if appropriate):', color=log.WRN_COLOR)
+            for dc, ucs in likely_merged.items():
+                log.inf('- {} ({})\n  Similar upstream commits:'.
+                        format(dc.oid, nwh.commit_shortlog(dc)))
+                for uc in ucs:
+                    log.inf('  {} ({})'.
+                            format(uc.oid, nwh.commit_shortlog(uc)))
+        else:
+            log.inf('no downstream patches seem to have been merged upstream')
+
+    def to_ncs_name(self, zp):
+        # convert zp, a west.manifest.Project in the zephyr manifest,
+        # to the equivalent Project name in the NCS manifest.
+        #
+        # TODO: does the fact that this is needed mean the west commit
+        #       which names the manifest project 'manifest' unconditionally
+        #       was wrong to do so?
+        if zp.name == 'manifest':
+            return 'zephyr'
+        else:
+            return zp.name
+
+_UPSTREAM = 'https://github.com/zephyrproject-rtos/zephyr'
+
+# Set of project paths blacklisted from inclusion in the NCS.
+_PROJECT_BLACKLIST = set(
+    PurePath(p) for p in
+    ['modules/hal/atmel',
+     'modules/hal/esp-idf',
+     'modules/hal/qmsi',
+     'modules/hal/cypress',
+     'modules/hal/openisa',
+     'modules/hal/microchip',
+     'modules/hal/silabs',
+     'modules/hal/stm32',
+     'modules/hal/ti',
+     'modules/hal/nxp'])

--- a/scripts/west_commands/ncs_west_helpers.py
+++ b/scripts/west_commands/ncs_west_helpers.py
@@ -1,0 +1,373 @@
+# Copyright 2018 Open Source Foundries, Limited
+# Copyright 2018 Foundries.io, Limited
+# Copyright (c) 2019 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Helper code used by NCS west commands.
+#
+# Portions were copied from:
+# https://github.com/foundriesio/zephyr_tools/.
+
+from collections import OrderedDict
+import re
+import textwrap
+
+import editdistance
+import pygit2
+from west import log
+
+__all__ = [
+    'InvalidRepositoryError', 'UnknownCommitsError',
+
+    'shortlog_is_revert', 'shortlog_reverts_what', 'shortlog_has_sauce',
+    'shortlog_no_sauce',
+
+    'commit_reverts_what', 'commit_shortlog',
+
+    'RepoAnalyzer',
+]
+
+#
+# Exceptions
+#
+
+class InvalidRepositoryError(RuntimeError):
+    '''Git repository does not exist or cannot be analyzed.'''
+    pass
+
+class UnknownCommitsError(RuntimeError):
+    '''Unknown or invalid commit ref or refs.'''
+    pass
+
+#
+# git / pygit2 helper functions
+#
+
+def shortlog_is_revert(shortlog):
+    '''Return True if and only if the shortlog starts with 'Revert '.
+
+    :param shortlog: Git commit message shortlog.'''
+    return shortlog.startswith('Revert ')
+
+def shortlog_reverts_what(shortlog):
+    '''If the shortlog is a revert, returns shortlog of what it reverted.
+
+    :param shortlog: Git commit message shortlog
+
+    For example, if shortlog is:
+
+    'Revert "whoops: this turned out to be a bad idea"'
+
+    The return value is 'whoops: this turned out to be a bad idea';
+    i.e. the double quotes are also stripped.
+    '''
+    revert = 'Revert '
+    return shortlog[len(revert) + 1:-1]
+
+def shortlog_has_sauce(shortlog, sauce='nrf'):
+    '''Check if a Git shortlog has a 'sauce tag'.
+
+    :param shortlog: Git commit message shortlog, which might begin
+                     with a "sauce tag" that looks like '[sauce <tag>] '
+    :param sauce: String (or iterable of strings) indicating a source of
+                  "sauce". This is organization-specific but defaults to
+                  'nrf'.
+
+    For example, sauce="xyz" and the shortlog is:
+
+    [xyz fromlist] area: something
+
+    Then the return value is True. If the shortlog is any of these,
+    the return value is False:
+
+    area: something
+    [abc fromlist] area: something
+    [WIP] area: something
+    '''
+    if isinstance(sauce, str):
+        sauce = '[' + sauce
+    else:
+        sauce = tuple('[' + s for s in sauce)
+
+    return shortlog.startswith(sauce)
+
+def shortlog_no_sauce(shortlog, sauce='nrf'):
+    '''Return a Git shortlog without a 'sauce tag'.
+
+    :param shortlog: Git commit message shortlog, which might begin
+                     with a "sauce tag" that looks like '[sauce <tag>] '
+    :param sauce: String (or iterable of strings) indicating a source of
+                  "sauce". This is organization-specific but defaults to
+                  'nrf'.
+
+    For example, sauce="xyz" and the shortlog is:
+
+    "[xyz fromlist] area: something"
+
+    Then the return value is "area: something".
+
+    As another example with the same sauce, if shortlog is "foo: bar",
+    the return value is "foo: bar".
+    '''
+    if isinstance(sauce, str):
+        sauce = '[' + sauce
+    else:
+        sauce = tuple('[' + s for s in sauce)
+
+    if shortlog.startswith(sauce):
+        return shortlog[shortlog.find(']') + 1:].strip()
+    else:
+        return shortlog
+
+def commit_reverts_what(commit):
+    '''Look for the string "reverts commit SOME_SHA" in the commit message,
+    and return SOME_SHA. Raises ValueError if the string is not found.'''
+    match = re.search(r'reverts\s+commit\s+([0-9a-f]+)',
+                      ' '.join(commit.message.split()))
+    if not match:
+        raise ValueError(commit.message)
+    return match.groups()[0]
+
+def commit_shortlog(commit):
+    '''Return the first line in a commit's log message.
+
+    :param commit: pygit2 commit object'''
+    return commit.message.splitlines()[0]
+
+#
+# Repository analysis
+#
+
+class RepoAnalyzer:
+    '''Utility class for analyzing a repository, especially
+    upstream/downstream differences.'''
+
+    def __init__(self, downstream_project, upstream_project,
+                 downstream_ref, upstream_ref,
+                 downstream_domain='@nordicsemi.no', downstream_sauce='nrf',
+                 edit_dist_threshold=3, include_mergeups=False):
+        # - downstream and upstream west.manifest.Project instances
+        # - revisions within them to analyze
+        # - corresponding pygit2.Repository instance
+        self._dp = downstream_project
+        self._dr = downstream_ref
+        self._up = upstream_project
+        self._ur = upstream_ref
+        assert self._dp.path == self._up.path
+        self._repo = self._load_repo(self._dp.abspath)
+
+        # string identifying a downstream sauce tag;
+        # if your sauce tags look like [xyz <tag>], use "xyz". this can
+        # also be a tuple of strings to find multiple sources of sauce.
+        self._downstream_sauce = self._parse_sauce(downstream_sauce)
+        # domain name (like "@example.com") used by downstream committers;
+        # this can also be a tuple of domains.
+        self._downstream_domain = downstream_domain
+
+        # commit shortlog edit distance to use when fuzzy-matching
+        # upstream and downstream patches
+        self._edit_dist_threshold = edit_dist_threshold
+
+        # whether or not to include mergeup commits as downstream outstanding
+        # patches
+        self._include_mergeups = include_mergeups
+
+    #
+    # Main API, which is property based.
+    #
+    # We use properties *upstream_new*, *downstream_outstanding*,
+    # etc. so that the necessary analysis is done on demand and saved,
+    # rather than wasting work doing analysis the user doesn't care
+    # about.
+    #
+
+    def _upstream_new(self):
+        if not hasattr(self, '__upstream_new'):
+            self.__upstream_new = self._new_upstream_only_commits()
+        return self.__upstream_new
+
+    def _downstream_outstanding(self):
+        if not hasattr(self, '__downstream_out'):
+            self.__downstream_out = self._downstream_outstanding_commits()
+        return self.__downstream_out
+
+    def _likely_merged(self):
+        if not hasattr(self, '__likely_merged'):
+            self.__likely_merged = self._likely_merged_commits()
+        return self.__likely_merged
+
+    upstream_new = property(fget=_upstream_new)
+    '''Commits that are new in the upstream, as a list of pygit2 objects.'''
+
+    downstream_outstanding = property(_downstream_outstanding)
+    '''A list of outstanding downstream-only (oot = "out of tree")
+    patches, as pygit2 commit objects. A patch is outstanding if it is
+    neither a merge commit nor a patch which was later reverted.
+
+    Merge commits are included in the list if include_mergeupse=True
+    was given to the constructor. Patches are ordered from earliest
+    merged to latest merged, in a topological sorting.'''
+
+    likely_merged = property(_likely_merged)
+    '''A map representing downstream patches which look like they are
+    merged upstream, and candidate upstream patches.
+
+    The map's keys are downstream pygit2 objects. Its values are lists
+    of pygit2 commit objects that are merged upstream and have similar
+    shortlogs by edit distance to each key.'''
+
+    #
+    # Internal helpers
+    #
+
+    def _parse_sauce(self, sauce):
+        # Returns sauce as an immutable object (by copying a sequence
+        # into a tuple if sauce is not a string)
+
+        if isinstance(sauce, str):
+            return sauce
+        else:
+            return tuple(sauce)
+
+    def _load_repo(self, path):
+        try:
+            return pygit2.Repository(path)
+        except KeyError:
+            # pygit2 raises KeyError when the current path is not a Git
+            # repository.
+            msg = "Can't initialize Git repository at {}"
+            raise InvalidRepositoryError(msg.format(path))
+
+    def _new_upstream_only_commits(self):
+        '''Commits in `upstream_ref` history since merge base with
+        `downstream_ref`'''
+        try:
+            doid = self._repo.revparse_single(self._dr + '^{commit}').oid
+        except KeyError:
+            raise UnknownCommitsError(self._downstream_ref)
+        try:
+            uoid = self._repo.revparse_single(self._ur + '^{commit}').oid
+        except KeyError:
+            raise UnknownCommitsError(self._upstream_ref)
+
+        try:
+            merge_base = self._repo.merge_base(doid, uoid)
+        except ValueError:
+            log.wrn("can't get merge base;",
+                    "downstream SHA: {}, upstream SHA: {}".
+                    format(doid, uoid))
+            raise
+
+        sort = pygit2.GIT_SORT_TOPOLOGICAL | pygit2.GIT_SORT_REVERSE
+        walker = self._repo.walk(uoid, sort)
+        walker.hide(merge_base)
+        return list(walker)
+
+    def _downstream_outstanding_commits(self):
+        # Compute a list of commit objects for outstanding
+        # downstream patches.
+
+        # Convert downstream and upstream revisions to SHAs.
+        dsha = self._dp.sha(self._dr)
+        usha = self._up.sha(self._ur)
+        log.dbg('** NCS sha:', dsha)
+        log.dbg('** upstream sha:', usha)
+
+        # First, get a list of all downstream OOT patches. Note:
+        # pygit2 doesn't seem to have any ready-made rev-list
+        # equivalent, so call out to Project.git() to get the commit
+        # SHAs, then wrap them with pygit2 objects.
+        cp = self._dp.git('rev-list --reverse {} ^{}'.format(dsha, usha),
+                          capture_stdout=True)
+        if not cp.stdout.strip():
+            return []
+        commit_shas = cp.stdout.decode('utf-8').strip().splitlines()
+        all_downstream_oot = [self._repo.revparse_single(c)
+                              for c in commit_shas]
+
+        # Now filter out reverted patches and mergeups from the
+        # complete list of OOT patches.
+        downstream_out = OrderedDict()
+        for c in all_downstream_oot:
+            sha, sl = str(c.oid), commit_shortlog(c)
+            is_revert = shortlog_is_revert(sl)  # this is just a heuristic
+
+            if len(c.parents) > 1:
+                if not self._include_mergeups:
+                    # Skip all the mergeup commits.
+                    log.dbg('** skipped mergeup {} ("{}")'.format(sha, sl),
+                            level=log.VERBOSE_VERY)
+                    continue
+                else:
+                    is_revert = False  # a merge is never a revert
+
+            if is_revert:
+                # If a shortlog marks a revert, delete the original commit
+                # from downstream_out, if it can be found.
+                try:
+                    rsha = commit_reverts_what(c)
+                except ValueError:
+                    # Badly formatted revert message.
+                    # Treat as outstanding, but complain.
+                    log.wrn(
+                        'revert {} doesn\'t say "reverts commit <SHA>":\n{}'.
+                        format(str(sha), textwrap.indent(c.message, '\t')))
+                    rsha = None
+
+                if rsha in downstream_out:
+                    log.dbg('** commit {} ("{}") was reverted in {}'.
+                            format(rsha, commit_shortlog(downstream_out[rsha]),
+                                   sha), level=log.VERBOSE_VERY)
+                    del downstream_out[rsha]
+                    continue
+                elif rsha is not None:
+                    # Make sure the reverted commit is in downstream history.
+                    # (It might not be in all_downstream_oot if e.g.
+                    # downstream reverts an upstream patch as a hotfix, and we
+                    # shouldn't warn about that.)
+                    is_ancestor = self._dp.git(
+                        'merge-base --is-ancestor {} {}'.format(rsha, dsha),
+                        capture_stdout=True).returncode == 0
+                    if not is_ancestor:
+                        log.wrn(('commit {} ("{}") reverts {}, '
+                                 "which isn't in downstream history").
+                                format(sha, sl, rsha))
+
+            # Emit a warning if we have a non-revert patch with an
+            # incorrect sauce tag. (Again, downstream might carry reverts
+            # of upstream patches as hotfixes, which we shouldn't
+            # warn about.)
+            if (not shortlog_has_sauce(sl, self._downstream_sauce) and
+                    not is_revert):
+                log.wrn('bad or missing sauce tag: {} ("{}")'.format(sha, sl))
+
+            downstream_out[sha] = c
+            log.dbg('** added oot patch: {} ("{}")'.format(sha, sl),
+                    level=log.VERBOSE_VERY)
+
+        return list(downstream_out.values())
+
+    def _likely_merged_commits(self):
+        # Compute patches which are downstream and probably were
+        # merged upstream, using a shortlog edit distance heuristic.
+        # This is a map from pygit2 commit objects for downstream
+        # patches, to a list of pygit2 commit objects that are
+        # upstream patches which have similar shortlogs and the same
+        # authors.
+
+        likely_merged = OrderedDict()
+        for dc in self.downstream_outstanding:
+            sl = commit_shortlog(dc)
+
+            def ed(upstream_commit):
+                return editdistance.eval(
+                    shortlog_no_sauce(sl, self._downstream_sauce),
+                    commit_shortlog(upstream_commit))
+
+            matches = [c for c in self.upstream_new if
+                       ed(c) < self._edit_dist_threshold]
+            if len(matches) != 0:
+                likely_merged[dc] = matches
+
+        return likely_merged

--- a/west.yml
+++ b/west.yml
@@ -79,3 +79,4 @@ manifest:
 
   self:
     path: nrf
+    west-commands: scripts/west-commands.yml


### PR DESCRIPTION
NOTE: These require patches latest west master branch, so they are for internal use only for now.

Add two extensions:

- ncs-loot: list of out of tree patches which haven't been reverted
- ncs-compare: compare NCS with upstream

