### PR TITLE
subsys/bluetooth/gatt_pool: Test of the uuid value when allocating de…

### DIFF
--- a/subsys/bluetooth/gatt_pool.c
+++ b/subsys/bluetooth/gatt_pool.c
@@ -388,6 +388,12 @@ int bt_gatt_pool_desc_alloc(struct bt_gatt_pool *gp,
 		LOG_ERR("Invalid attribute");
 		return -EINVAL;
 	}
+	if (!bt_uuid_cmp(descriptor->uuid, BT_UUID_GATT_PRIMARY) ||
+	    !bt_uuid_cmp(descriptor->uuid, BT_UUID_GATT_CHRC)    ||
+	    !bt_uuid_cmp(descriptor->uuid, BT_UUID_GATT_CCC)) {
+		LOG_ERR("Wrong function used for special attribute allocation");
+		return -EINVAL;
+	}
 	if (gp->svc.attr_count >= gp->attr_array_size) {
 		LOG_ERR("No space left on given svc");
 		return -ENOSPC;


### PR DESCRIPTION
…scriptor

This commit adds the checking of the uuid value provided to
bt_gatt_pool_desc_alloc function.
Forbidden uuid codes expects more dynamically allocated data thous
dedicated function to create such attribute is required.

Signed-off-by: Radoslaw Koppel <radoslaw.koppel@nordicsemi.no>