### PR TITLE
lib: at_host: handle invalid UART state on init

### DIFF
--- a/lib/at_host/Kconfig
+++ b/lib/at_host/Kconfig
@@ -35,6 +35,10 @@ config AT_HOST_UART
 	default 1 if AT_HOST_UART_1
 	default 2 if AT_HOST_UART_2
 
+config AT_HOST_UART_INIT_TIMEOUT
+	int "Timeout waiting for a valid UART line on init (ms)"
+	default 500
+
 choice
 	prompt "Termination Mode"
 	default CR_TERMINATION


### PR DESCRIPTION
Handles errors on the UART line during initialization by cleaning the
buffer and retrying for some configured time. This fixes an issue on the
Thingy:91 board where there were errors on UART at startup.

Requesting comments on whether -EIO is the most sensible error to return on failiure.