### PR TITLE
applications: nrf_desktop: Simulated motion - fix warning

### DIFF
--- a/applications/nrf_desktop/src/hw_interface/motion_simulated.c
+++ b/applications/nrf_desktop/src/hw_interface/motion_simulated.c
@@ -189,12 +189,11 @@ static int stop_motion(const struct shell *shell, size_t argc, char **argv)
 	return 0;
 }
 
-SHELL_CREATE_STATIC_SUBCMD_SET(sub_motion_sim)
-{
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_motion_sim,
 	SHELL_CMD(start, NULL, "Start motion", start_motion),
 	SHELL_CMD(stop, NULL, "Stop motion", stop_motion),
 	SHELL_SUBCMD_SET_END
-};
+);
 
 SHELL_CMD_REGISTER(motion_sim, &sub_motion_sim,
 		   "Simulated motion commands", NULL);


### PR DESCRIPTION
Change removes "Macro is deprecated" warning, showing during compilation.