### PR TITLE
scripts: partition_manager: Remove empty container partitions

### DIFF
--- a/scripts/partition_manager/partition_manager.rst
+++ b/scripts/partition_manager/partition_manager.rst
@@ -94,8 +94,7 @@ span: list OR dict: list
    Partitions with this property are container partitions.
    Therefore, this property cannot be used together with the ``placement`` property.
 
-   The Partition Manager fails if a span is empty or if the partitions are not consecutive after processing.
-   Non-existing partitions are ignored.
+   Non-existing partitions are removed from the ``span`` list before processing, and partitions with empty ``span`` lists are removed altogether (unless filled via ``inside``).
 
    .. note::
       You can specify configurations with an ambiguous ordering (see the following examples).


### PR DESCRIPTION
If a container partition ends up empty after the first cleanup,
remove it.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>