### PR TITLE
subsys: bluetooth: services: hids: Attributes permissions config

### DIFF
--- a/include/bluetooth/gatt_pool.h
+++ b/include/bluetooth/gatt_pool.h
@@ -100,13 +100,14 @@ extern "C" {
  *  @param _gp GATT service object with dynamic attribute allocation.
  *  @param _ccc CCC descriptor configuration.
  *  @param _cb CCC descriptor callback.
+ *  @param _perm CCC descriptor permissions.
  */
-#define BT_GATT_POOL_CCC(_gp, _ccc, _ccc_changed)                              \
+#define BT_GATT_POOL_CCC(_gp, _ccc, _ccc_changed, _perm)                       \
 	do {                                                                   \
 		int _ret;                                                      \
 		_ccc = (struct _bt_gatt_ccc)BT_GATT_CCC_INITIALIZER(\
 			_ccc_changed, NULL, NULL);      \
-		_ret = bt_gatt_pool_ccc_alloc(_gp, &_ccc);                     \
+		_ret = bt_gatt_pool_ccc_alloc(_gp, &_ccc, _perm);              \
 		__ASSERT_NO_MSG(!_ret);                                        \
 		(void)_ret;                                                    \
 	} while (0)
@@ -161,11 +162,14 @@ int bt_gatt_pool_desc_alloc(struct bt_gatt_pool *gp,
  *
  *  @param gp GATT service object with dynamic attribute allocation.
  *  @param ccc CCC descriptor.
+ *  @param perm Permissions to access CCC.
+ *              Use the GATT attribute permission bit field values.
  *
  *  @return 0 or negative error code.
  */
 int bt_gatt_pool_ccc_alloc(struct bt_gatt_pool *gp,
-			   struct _bt_gatt_ccc *ccc);
+			   struct _bt_gatt_ccc *ccc,
+			   u8_t perm);
 
 /** @brief Free the whole dynamically created GATT service.
  *

--- a/include/bluetooth/services/hids.h
+++ b/include/bluetooth/services/hids.h
@@ -153,6 +153,21 @@ struct bt_gatt_hids_inp_rep {
 	/** Report data offset. */
 	u8_t offset;
 
+	/** Report permissions
+	 *
+	 * Use GATT attribute permission bit field values here.
+	 * As input report can only be read only 3 flags are used:
+	 * - BT_GATT_PERM_READ
+	 * - BT_GATT_PERM_READ_ENCRYPT
+	 * - BT_GATT_PERM_READ_AUTHEN
+	 *
+	 * If no attribute is chosen, the configured default is used.
+	 *
+	 * The CCC register would have set the proper permissions for read and
+	 * write, based on the read permissions for the whole report.
+	 */
+	u8_t perm;
+
 	/** Pointer to report mask. The least significant bit
 	 * corresponds to the least significant byte of the report value.
 	 * If this bit is set to 1 then the first byte of report is stored.
@@ -187,6 +202,21 @@ struct bt_gatt_hids_outp_feat_rep {
 
 	/** Index in the service attribute array. */
 	u8_t att_ind;
+
+	/** Report permissions
+	 *
+	 * Use GATT attribute permission bit field values here.
+	 * Different permissions may be used for write and read:
+	 * - BT_GATT_PERM_READ
+	 * - BT_GATT_PERM_READ_ENCRYPT
+	 * - BT_GATT_PERM_READ_AUTHEN
+	 * - BT_GATT_PERM_WRITE
+	 * - BT_GATT_PERM_WRITE_ENCRYPT
+	 * - BT_GATT_PERM_WRITE_AUTHEN
+	 *
+	 * If no attribute is chosen, the configured default is used.
+	 */
+	u8_t perm;
 
 	/** Callback with updated report data. */
 	bt_gatt_hids_rep_handler_t handler;

--- a/subsys/bluetooth/gatt_pool.c
+++ b/subsys/bluetooth/gatt_pool.c
@@ -379,13 +379,14 @@ int bt_gatt_pool_desc_alloc(struct bt_gatt_pool *gp,
 }
 
 int bt_gatt_pool_ccc_alloc(struct bt_gatt_pool *gp,
-			   struct _bt_gatt_ccc *ccc)
+			   struct _bt_gatt_ccc *ccc,
+			   u8_t perm)
 {
 	int ret;
 	struct bt_gatt_attr *attr;
 	struct bt_uuid      *uuid_gatt_ccc = BT_UUID_GATT_CCC;
 
-	if (!gp || !gp->svc.attrs || !ccc) {
+	if (!gp || !gp->svc.attrs || !ccc || !perm) {
 		LOG_ERR("Invalid attribute");
 		return -EINVAL;
 	}
@@ -396,6 +397,7 @@ int bt_gatt_pool_ccc_alloc(struct bt_gatt_pool *gp,
 
 	attr = &gp->svc.attrs[gp->svc.attr_count];
 	*attr = (struct bt_gatt_attr)BT_GATT_CCC_MANAGED(ccc);
+	attr->perm = perm;
 
 	attr->uuid = NULL;
 	ret = uuid_register((struct bt_uuid **) &attr->uuid, uuid_gatt_ccc);

--- a/subsys/bluetooth/services/Kconfig.hids
+++ b/subsys/bluetooth/services/Kconfig.hids
@@ -48,6 +48,25 @@ config BT_GATT_HIDS_FEATURE_REP_MAX
 	help
 	  Maximum number of HIDS Feature Reports that can be set for HIDS.
 
+choice
+	prompt "Default permissions used for HID attributes"
+	default BT_GATT_HIDS_DEFAULT_PERM_RW
+	help
+	  Default permissions for HID characteristic attributes
+	  used when no permission is set for the report.
+	  Used also for boot reports.
+
+config BT_GATT_HIDS_DEFAULT_PERM_RW
+	bool "Read and write allowed"
+
+config BT_GATT_HIDS_DEFAULT_PERM_RW_ENCRYPT
+	bool "Require encryption for access"
+
+config BT_GATT_HIDS_DEFAULT_PERM_RW_AUTHEN
+	bool "Require encryption using authenticated link-key for access"
+
+endchoice
+
 module = BT_GATT_HIDS
 module-str = HIDS
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"


### PR DESCRIPTION
This commit implements the option to configure permissions for HIDS
globally and for every report independently.

Signed-off-by: Radoslaw Koppel <radoslaw.koppel@nordicsemi.no>