### PR TITLE
ci: switch compile generator from make to Ninja

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,8 @@ pipeline {
       ZEPHYR_TOOLCHAIN_VARIANT = 'gnuarmemb'
       GNUARMEMB_TOOLCHAIN_PATH = '/workdir/gcc-arm-none-eabi-7-2018-q2-update'
 
-      SANITYCHECK_OPTIONS_COMMON = '''--board-root nrf/boards \
+      SANITYCHECK_OPTIONS_COMMON = '''--ninja \
+                                      --board-root nrf/boards \
                                       --board-root zephyr/boards \
                                       --testcase-root nrf/samples \
                                       --testcase-root nrf/applications \

--- a/west.yml
+++ b/west.yml
@@ -36,7 +36,7 @@ manifest:
     - name: zephyr
       repo-path: fw-nrfconnect-zephyr
       west-commands: scripts/west-commands.yml
-      revision: b3bc959667dc171f8c4087c900c19a7c0a458e0c
+      revision: 4493a423a645cb54de2ef2720ebb7c403774ae11
     - name: nffs
       revision: bc62a2fa9d98ddb5d633c932ea199bc68e10f194
       path: modules/fs/nffs


### PR DESCRIPTION
fw-nrfconnect-zephyr already using Ninja, which is faster

Signed-off-by: Thomas Stilwell <Thomas.Stilwell@nordicsemi.no>