### PR TITLE
applications: nrf_desktop: Synch configuration data delivery

### DIFF
--- a/applications/nrf_desktop/src/hw_interface/motion_sensor.c
+++ b/applications/nrf_desktop/src/hw_interface/motion_sensor.c
@@ -576,7 +576,7 @@ EVENT_SUBSCRIBE(MODULE, wake_up_event);
 EVENT_SUBSCRIBE(MODULE, hid_report_sent_event);
 EVENT_SUBSCRIBE(MODULE, hid_report_subscription_event);
 #if CONFIG_DESKTOP_CONFIG_CHANNEL_ENABLE
-EVENT_SUBSCRIBE(MODULE, config_event);
+EVENT_SUBSCRIBE_EARLY(MODULE, config_event);
 EVENT_SUBSCRIBE(MODULE, config_fetch_request_event);
 #endif
 EVENT_SUBSCRIBE_EARLY(MODULE, power_down_event);

--- a/applications/nrf_desktop/src/modules/config.c
+++ b/applications/nrf_desktop/src/modules/config.c
@@ -268,5 +268,5 @@ static bool event_handler(const struct event_header *eh)
 EVENT_LISTENER(MODULE, event_handler);
 EVENT_SUBSCRIBE(MODULE, module_state_event);
 #if CONFIG_DESKTOP_CONFIG_CHANNEL_ENABLE
-EVENT_SUBSCRIBE(MODULE, config_event);
+EVENT_SUBSCRIBE_EARLY(MODULE, config_event);
 #endif

--- a/applications/nrf_desktop/src/modules/dfu.c
+++ b/applications/nrf_desktop/src/modules/dfu.c
@@ -462,7 +462,7 @@ static bool event_handler(const struct event_header *eh)
 }
 
 EVENT_LISTENER(MODULE, event_handler);
-EVENT_SUBSCRIBE(MODULE, module_state_event);
-EVENT_SUBSCRIBE(MODULE, config_event);
+EVENT_SUBSCRIBE_EARLY(MODULE, config_event);
 EVENT_SUBSCRIBE(MODULE, config_fetch_request_event);
+EVENT_SUBSCRIBE(MODULE, module_state_event);
 EVENT_SUBSCRIBE(MODULE, ble_peer_event);

--- a/applications/nrf_desktop/src/modules/usb_state.c
+++ b/applications/nrf_desktop/src/modules/usb_state.c
@@ -416,28 +416,25 @@ static int usb_init(void)
 
 static bool event_handler(const struct event_header *eh)
 {
-	if (IS_ENABLED(CONFIG_DESKTOP_HID_MOUSE)) {
-		if (is_hid_mouse_event(eh)) {
-			send_mouse_report(cast_hid_mouse_event(eh));
+	if (IS_ENABLED(CONFIG_DESKTOP_HID_MOUSE) &&
+	    is_hid_mouse_event(eh)) {
+		send_mouse_report(cast_hid_mouse_event(eh));
 
-			return false;
-		}
+		return false;
 	}
 
-	if (IS_ENABLED(CONFIG_DESKTOP_HID_KEYBOARD)) {
-		if (is_hid_keyboard_event(eh)) {
-			send_keyboard_report(cast_hid_keyboard_event(eh));
+	if (IS_ENABLED(CONFIG_DESKTOP_HID_KEYBOARD) &&
+	    is_hid_keyboard_event(eh)) {
+		send_keyboard_report(cast_hid_keyboard_event(eh));
 
-			return false;
-		}
+		return false;
 	}
 
-	if (IS_ENABLED(CONFIG_DESKTOP_HID_CONSUMER_CTRL)) {
-		if (is_hid_consumer_ctrl_event(eh)) {
-			send_consumer_ctrl_report(cast_hid_consumer_ctrl_event(eh));
+	if (IS_ENABLED(CONFIG_DESKTOP_HID_CONSUMER_CTRL) &&
+	    is_hid_consumer_ctrl_event(eh)) {
+		send_consumer_ctrl_report(cast_hid_consumer_ctrl_event(eh));
 
-			return false;
-		}
+		return false;
 	}
 
 	if (is_module_state_event(eh)) {
@@ -460,23 +457,27 @@ static bool event_handler(const struct event_header *eh)
 		return false;
 	}
 
-	if (IS_ENABLED(CONFIG_DESKTOP_CONFIG_CHANNEL_ENABLE)) {
-		if (is_config_forwarded_event(eh)) {
-			struct config_forwarded_event *event =
-				cast_config_forwarded_event(eh);
+	if (IS_ENABLED(CONFIG_DESKTOP_CONFIG_CHANNEL_ENABLE) &&
+	    is_config_forwarded_event(eh)) {
+		config_channel_forwarded_receive(&cfg_chan,
+						 cast_config_forwarded_event(eh));
 
-			config_channel_forwarded_receive(&cfg_chan, event);
+		return false;
+	}
 
-			return false;
-		}
+	if (IS_ENABLED(CONFIG_DESKTOP_CONFIG_CHANNEL_ENABLE) &&
+	    is_config_fetch_event(eh)) {
+		config_channel_fetch_receive(&cfg_chan,
+					     cast_config_fetch_event(eh));
 
-		if (is_config_fetch_event(eh)) {
-			struct config_fetch_event *event = cast_config_fetch_event(eh);
+		return false;
+	}
 
-			config_channel_fetch_receive(&cfg_chan, event);
+	if (IS_ENABLED(CONFIG_DESKTOP_CONFIG_CHANNEL_ENABLE) &&
+	    is_config_event(eh)) {
+		config_channel_event_done(&cfg_chan, cast_config_event(eh));
 
-			return false;
-		}
+		return false;
 	}
 
 	/* If event is unhandled, unsubscribe. */
@@ -492,4 +493,5 @@ EVENT_SUBSCRIBE(MODULE, hid_consumer_ctrl_event);
 #if CONFIG_DESKTOP_CONFIG_CHANNEL_ENABLE
 EVENT_SUBSCRIBE(MODULE, config_forwarded_event);
 EVENT_SUBSCRIBE(MODULE, config_fetch_event);
+EVENT_SUBSCRIBE(MODULE, config_event);
 #endif

--- a/applications/nrf_desktop/src/services/hids.c
+++ b/applications/nrf_desktop/src/services/hids.c
@@ -538,29 +538,25 @@ static void notify_hids(const struct ble_peer_event *event)
 
 static bool event_handler(const struct event_header *eh)
 {
-	if (IS_ENABLED(CONFIG_DESKTOP_HID_MOUSE)) {
-		if (is_hid_mouse_event(eh)) {
-			send_mouse_report(cast_hid_mouse_event(eh));
+	if (IS_ENABLED(CONFIG_DESKTOP_HID_MOUSE) &&
+	    is_hid_mouse_event(eh)) {
+		send_mouse_report(cast_hid_mouse_event(eh));
 
-			return false;
-		}
+		return false;
 	}
 
-	if (IS_ENABLED(CONFIG_DESKTOP_HID_KEYBOARD)) {
-		if (is_hid_keyboard_event(eh)) {
-			send_keyboard_report(cast_hid_keyboard_event(eh));
+	if (IS_ENABLED(CONFIG_DESKTOP_HID_KEYBOARD) &&
+	    is_hid_keyboard_event(eh)) {
+		send_keyboard_report(cast_hid_keyboard_event(eh));
 
-			return false;
-		}
+		return false;
 	}
 
-	if (IS_ENABLED(CONFIG_DESKTOP_HID_CONSUMER_CTRL)) {
-		if (is_hid_consumer_ctrl_event(eh)) {
-			send_consumer_ctrl_report(
-				cast_hid_consumer_ctrl_event(eh));
+	if (IS_ENABLED(CONFIG_DESKTOP_HID_CONSUMER_CTRL) &&
+	    is_hid_consumer_ctrl_event(eh)) {
+		send_consumer_ctrl_report(cast_hid_consumer_ctrl_event(eh));
 
-			return false;
-		}
+		return false;
 	}
 
 	if (is_ble_peer_event(eh)) {
@@ -596,14 +592,19 @@ static bool event_handler(const struct event_header *eh)
 		return false;
 	}
 
-	if (IS_ENABLED(CONFIG_DESKTOP_CONFIG_CHANNEL_ENABLE)) {
-		if (is_config_fetch_event(eh)) {
-			const struct config_fetch_event *event = cast_config_fetch_event(eh);
+	if (IS_ENABLED(CONFIG_DESKTOP_CONFIG_CHANNEL_ENABLE) &&
+	    is_config_fetch_event(eh)) {
+		config_channel_fetch_receive(&cfg_chan,
+					     cast_config_fetch_event(eh));
 
-			config_channel_fetch_receive(&cfg_chan, event);
+		return false;
+	}
 
-			return false;
-		}
+	if (IS_ENABLED(CONFIG_DESKTOP_CONFIG_CHANNEL_ENABLE) &&
+	    is_config_event(eh)) {
+		config_channel_event_done(&cfg_chan, cast_config_event(eh));
+
+		return false;
 	}
 
 	/* If event is unhandled, unsubscribe. */
@@ -619,5 +620,6 @@ EVENT_SUBSCRIBE(MODULE, hid_notification_event);
 EVENT_SUBSCRIBE(MODULE, module_state_event);
 #if CONFIG_DESKTOP_CONFIG_CHANNEL_ENABLE
 EVENT_SUBSCRIBE(MODULE, config_fetch_event);
+EVENT_SUBSCRIBE(MODULE, config_event);
 #endif
 EVENT_SUBSCRIBE_EARLY(MODULE, ble_peer_event);

--- a/applications/nrf_desktop/src/util/config_channel.h
+++ b/applications/nrf_desktop/src/util/config_channel.h
@@ -75,6 +75,9 @@ struct config_channel_state {
 
 	/** State of the fetch operation. */
 	struct fetch fetch;
+
+	/** Currently processed config event. */
+	void *pending_config_event;
 };
 
 /** @brief Initialize the configuration channel instance.
@@ -162,6 +165,16 @@ void config_channel_fetch_receive(struct config_channel_state *cfg_chan,
  */
 void config_channel_forwarded_receive(struct config_channel_state *cfg_chan,
 				      const struct config_forwarded_event *event);
+
+/**
+ * @brief Handle the confirmation that a configuration event is processed.
+ *
+ * @param cfg_chan Pointer to the configuration channel instance.
+ * @param event    Pointer to the event with status of the forwarded request.
+ *
+ */
+void config_channel_event_done(struct config_channel_state *cfg_chan,
+			       const struct config_event *event);
 
 /**
  * @brief Function for notifying a configuration channel instance that the


### PR DESCRIPTION
When config event is processed wait for event to be handled before
next event is accepted.

Jira:DESK-647

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>