### PR TITLE
drivers: at_cmd: Increase default AT_CMD_RESPONSE_MAX_LEN

### DIFF
--- a/drivers/at_cmd/Kconfig
+++ b/drivers/at_cmd/Kconfig
@@ -36,7 +36,7 @@ config AT_CMD_THREAD_STACK_SIZE
 
 config AT_CMD_RESPONSE_MAX_LEN
 	int "Maximum AT command response length"
-	default 1792
+	default 2700
 
 module = AT_CMD
 module-str = AT command driver


### PR DESCRIPTION
Increased the default AT_CMD_RESPONSE_MAX_LEN to support
writing of certificates used by nRF Cloud.

Signed-off-by: Jon Helge Nistad <jon.helge.nistad@nordicsemi.no>