### PR TITLE
drivers: bh1749: Fix DT label

### DIFF
--- a/drivers/sensor/bh1749/bh1749.c
+++ b/drivers/sensor/bh1749/bh1749.c
@@ -306,6 +306,6 @@ static const struct sensor_driver_api bh1749_driver_api = {
 
 static struct bh1749_data bh1749_data;
 
-DEVICE_DEFINE(bh1749, DT_ROHM_BH1749_0_LABEL, bh1749_init,
-	      device_pm_control_nop, &bh1749_data, NULL,
+DEVICE_DEFINE(bh1749, DT_NORDIC_NRF_I2C_5000A000_ROHM_BH1749_38_LABEL,
+	      bh1749_init, device_pm_control_nop, &bh1749_data, NULL,
 	      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY, &bh1749_driver_api);


### PR DESCRIPTION
Use the new label format to remove the warning.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>