### PR TITLE
applications: asset_tracker: Add qemu build target

### DIFF
--- a/applications/asset_tracker/sample.yaml
+++ b/applications/asset_tracker/sample.yaml
@@ -4,5 +4,5 @@ tests:
   test_build:
     build_only: true
     build_on_all: true
-    platform_whitelist: nrf9160_pca10090ns nrf9160_pca20035ns
+    platform_whitelist: nrf9160_pca10090ns nrf9160_pca20035ns qemu_x86
     tags: ci_build


### PR DESCRIPTION
Add qemu_x86 to targets built by CI/sanitycheck.

Signed-off-by: Jorgen Kvalvaag <jorgen.kvalvaag@nordicsemi.no>