### PR TITLE
drivers: bh1749: Fix DT label once again

### DIFF
--- a/drivers/sensor/bh1749/bh1749.c
+++ b/drivers/sensor/bh1749/bh1749.c
@@ -306,6 +306,6 @@ static const struct sensor_driver_api bh1749_driver_api = {
 
 static struct bh1749_data bh1749_data;
 
-DEVICE_DEFINE(bh1749, DT_NORDIC_NRF_I2C_5000A000_ROHM_BH1749_38_LABEL,
+DEVICE_DEFINE(bh1749, DT_INST_0_ROHM_BH1749_LABEL,
 	      bh1749_init, device_pm_control_nop, &bh1749_data, NULL,
 	      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY, &bh1749_driver_api);


### PR DESCRIPTION
This is a follow-up to commit 97a4ca0b872d4b6ab6f5fb4ee2849df792471d51.

The currently used label contains the slave address of the sensor and
the base address of the TWIM peripheral, so it's not a proper one to be
used in the code that is supposed to be generic. This commit changes it
to DT_INST_0_ROHM_BH1749_LABEL.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>