### PR TITLE
applications: nrf_desktop: hw_interface: fixed exception in wakeup

### DIFF
--- a/applications/nrf_desktop/src/hw_interface/selector_hw.c
+++ b/applications/nrf_desktop/src/hw_interface/selector_hw.c
@@ -266,7 +266,7 @@ static void sleep(void)
 
 static void wake_up(void)
 {
-	for (size_t i = 0; ARRAY_SIZE(selectors); i++) {
+	for (size_t i = 0; i < ARRAY_SIZE(selectors); i++) {
 		int err = read_state_and_enable_interrupts(&selectors[i]);
 
 		if (err) {


### PR DESCRIPTION
Will fix exception when wake_up event handled
in hardware selector handler.

Jira: NO-JIRA

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>