### PR TITLE
Fix GPS symbols used in NCS

### DIFF
--- a/drivers/nrf9160_gps/nrf9160_gps.c
+++ b/drivers/nrf9160_gps/nrf9160_gps.c
@@ -332,24 +332,25 @@ static int start(struct device *dev)
 {
 	int retval;
 	struct gps_drv_data *drv_data = dev->driver_data;
-	u16_t fix_retry     = 0;
-	u16_t fix_interval  = 1;
-	u16_t nmea_mask     = 0;
+	nrf_gnss_fix_retry_t    fix_retry    = 0;
+	nrf_gnss_fix_interval_t fix_interval = 1;
+	nrf_gnss_nmea_mask_t    nmea_mask    = 0;
+	nrf_gnss_delete_mask_t  delete_mask  = 0;
 
 #ifdef CONFIG_NRF9160_GPS_NMEA_GSV
-	nmea_mask |= NRF_CONFIG_NMEA_GSV_MASK;
+	nmea_mask |= NRF_GNSS_NMEA_GSV_MASK;
 #endif
 #ifdef CONFIG_NRF9160_GPS_NMEA_GSA
-	nmea_mask |= NRF_CONFIG_NMEA_GSA_MASK;
+	nmea_mask |= NRF_GNSS_NMEA_GSA_MASK;
 #endif
 #ifdef CONFIG_NRF9160_GPS_NMEA_GLL
-	nmea_mask |= NRF_CONFIG_NMEA_GLL_MASK;
+	nmea_mask |= NRF_GNSS_NMEA_GLL_MASK;
 #endif
 #ifdef CONFIG_NRF9160_GPS_NMEA_GGA
-	nmea_mask |= NRF_CONFIG_NMEA_GGA_MASK;
+	nmea_mask |= NRF_GNSS_NMEA_GGA_MASK;
 #endif
 #ifdef CONFIG_NRF9160_GPS_NMEA_RMC
-	nmea_mask |= NRF_CONFIG_NMEA_RMC_MASK;
+	nmea_mask |= NRF_GNSS_NMEA_RMC_MASK;
 #endif
 
 #ifdef CONFIG_NRF9160_GPS_HANDLE_MODEM_CONFIGURATION
@@ -376,7 +377,7 @@ static int start(struct device *dev)
 				NRF_SOL_GNSS,
 				NRF_SO_GNSS_FIX_RETRY,
 				&fix_retry,
-				sizeof(uint16_t));
+				sizeof(fix_retry));
 	if (retval != 0) {
 		LOG_ERR("Failed to set fix retry value");
 		return -EIO;
@@ -386,7 +387,7 @@ static int start(struct device *dev)
 				NRF_SOL_GNSS,
 				NRF_SO_GNSS_FIX_INTERVAL,
 				&fix_interval,
-				sizeof(uint16_t));
+				sizeof(fix_interval));
 
 	if (retval != 0) {
 		LOG_ERR("Failed to set fix interval value");
@@ -397,7 +398,7 @@ static int start(struct device *dev)
 				NRF_SOL_GNSS,
 				NRF_SO_GNSS_NMEA_MASK,
 				&nmea_mask,
-				sizeof(uint16_t));
+				sizeof(nmea_mask));
 
 	if (retval != 0) {
 		LOG_ERR("Failed to set nmea mask");
@@ -407,8 +408,8 @@ static int start(struct device *dev)
 	retval = nrf_setsockopt(drv_data->socket,
 				NRF_SOL_GNSS,
 				NRF_SO_GNSS_START,
-				NULL,
-				0);
+				&delete_mask,
+				sizeof(delete_mask));
 
 	if (retval != 0) {
 		LOG_ERR("Failed to start GPS");

--- a/samples/nrf9160/gps/src/main.c
+++ b/samples/nrf9160/gps/src/main.c
@@ -169,7 +169,7 @@ static void print_satellite_stats(nrf_gnss_data_frame_t *pvt_data)
 			tracked++;
 
 			if (pvt_data->pvt.sv[i].flags &
-					NRF_GNSS_PVT_FLAG_FIX_VALID_BIT) {
+					NRF_GNSS_SV_FLAG_USED_IN_FIX) {
 				in_fix++;
 			}
 

--- a/samples/nrf9160/gps/src/main.c
+++ b/samples/nrf9160/gps/src/main.c
@@ -83,14 +83,16 @@ static int enable_gps(void)
 
 static int init_app(void)
 {
-	u16_t fix_retry     = 0;
-	u16_t fix_interval  = 1;
-	u16_t nmea_mask     = NRF_CONFIG_NMEA_GSV_MASK |
-			      NRF_CONFIG_NMEA_GSA_MASK |
-			      NRF_CONFIG_NMEA_GLL_MASK |
-			      NRF_CONFIG_NMEA_GGA_MASK |
-			      NRF_CONFIG_NMEA_RMC_MASK;
-	int   retval;
+	int retval;
+
+	nrf_gnss_fix_retry_t    fix_retry    = 0;
+	nrf_gnss_fix_interval_t fix_interval = 1;
+	nrf_gnss_nmea_mask_t    delete_mask  = 0;
+	nrf_gnss_delete_mask_t  nmea_mask    = NRF_GNSS_NMEA_GSV_MASK |
+					       NRF_GNSS_NMEA_GSA_MASK |
+					       NRF_GNSS_NMEA_GLL_MASK |
+					       NRF_GNSS_NMEA_GGA_MASK |
+					       NRF_GNSS_NMEA_RMC_MASK;
 
 	if (enable_gps() != 0) {
 		printk("Failed to enable GPS\n");
@@ -110,7 +112,7 @@ static int init_app(void)
 				NRF_SOL_GNSS,
 				NRF_SO_GNSS_FIX_RETRY,
 				&fix_retry,
-				sizeof(uint16_t));
+				sizeof(fix_retry));
 
 	if (retval != 0) {
 		printk("Failed to set fix retry value\n");
@@ -121,7 +123,7 @@ static int init_app(void)
 				NRF_SOL_GNSS,
 				NRF_SO_GNSS_FIX_INTERVAL,
 				&fix_interval,
-				sizeof(uint16_t));
+				sizeof(fix_interval));
 
 	if (retval != 0) {
 		printk("Failed to set fix interval value\n");
@@ -132,7 +134,7 @@ static int init_app(void)
 				NRF_SOL_GNSS,
 				NRF_SO_GNSS_NMEA_MASK,
 				&nmea_mask,
-				sizeof(uint16_t));
+				sizeof(nmea_mask));
 
 	if (retval != 0) {
 		printk("Failed to set nmea mask\n");
@@ -142,8 +144,8 @@ static int init_app(void)
 	retval = nrf_setsockopt(fd,
 				NRF_SOL_GNSS,
 				NRF_SO_GNSS_START,
-				NULL,
-				0);
+				&delete_mask,
+				sizeof(delete_mask));
 
 	if (retval != 0) {
 		printk("Failed to start GPS\n");
@@ -304,4 +306,3 @@ int main(void)
 
 	return 0;
 }
-


### PR DESCRIPTION
A few symbol names were changed in `nrf_socket.h` header, update them here accordingly.