### PR TITLE
Implement partial FOTA download restarts

### DIFF
--- a/include/net/fota_download.h
+++ b/include/net/fota_download.h
@@ -64,6 +64,21 @@ int fota_download_init(fota_download_callback_t client_callback);
  */
 int fota_download_start(char *host, char *file);
 
+/**@brief Restart a failed download of the given file from the given host.
+ *
+ * Can be used to restart a download that has made progress before reporting a
+ * FOTA_DOWNLOAD_EVT_ERROR event.  Note that due to semaphore handling issues,
+ * the restart cannot be triggered within the fota_download callback that
+ * reports the error, and must be triggered after that callback has completed.
+ * This function will close and reopen the socket connection to the server as
+ * needed.
+ *
+ * @retval 0	     If download has restarted successfully.
+ * @retval -EALREADY If download is already ongoing.
+ *                   Otherwise, a negative value is returned.
+ */
+int fota_download_continue(char *host, char *file);
+
 #ifdef __cplusplus
 }
 #endif

--- a/samples/nrf9160/http_application_update/Kconfig
+++ b/samples/nrf9160/http_application_update/Kconfig
@@ -12,6 +12,10 @@ config DOWNLOAD_HOST
 config DOWNLOAD_FILE
 	string "The file to download"
 
+config DOWNLOAD_RESTARTS
+	int "Number of times to try restarting download on failure"
+	default 2
+
 config APPLICATION_VERSION
 	int "Application version"
 	default 1


### PR DESCRIPTION
This is a workaround for an issue we've been having with our application and FOTA downloads stalling and timing out.

I tried to provide functionality to allow an application to restart a failed FOTA download without having to re-download the portions it already downloaded, and with minimal changes in the libraries.

One issue with this implementation is that the FOTA event handler that receives the FOTA_DOWNLOAD_EVT_ERROR event cannot directly call the restart function.  This is because it is running inside the download_client thread, and that thread loop calls k_thread_suspend as soon as the handler returns.  I could have worked around this by changing the download_client API to pay attention to the return result of it's handler call and conditionally skip the suspend, but I felt that API changes were beyond the scope of what I could do without a thumbs-up from the Nordic team first.

(While testing this I also discovered that calling k_thread_resume() on your current thread does bad things and may prevent future k_thread_suspend() calls from working, but that's not an issue here...)