### PR TITLE
subsys: bluetooth: Fixed return invalid pointer

### DIFF
--- a/subsys/bluetooth/services/hids_c.c
+++ b/subsys/bluetooth/services/hids_c.c
@@ -1286,7 +1286,7 @@ struct bt_gatt_hids_c_rep_info *bt_gatt_hids_c_rep_next(
 	/* Searching current report in array */
 	rep_arr = hids_c->rep_info;
 
-	for (n = 0; n + 1 <= hids_c->rep_cnt; ++n) {
+	for (n = 0; n + 1 < hids_c->rep_cnt; ++n) {
 		if (*rep_arr++ == rep) {
 			return *rep_arr;
 		}


### PR DESCRIPTION
Fix error of out of range loop step that leads
to return invalid pointer and possible CPU abort.

Jira: DESK-669

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>