### PR TITLE
drivers: at_cmd: Rework AT command data handling

### DIFF
--- a/drivers/at_cmd/Kconfig
+++ b/drivers/at_cmd/Kconfig
@@ -38,6 +38,10 @@ config AT_CMD_RESPONSE_MAX_LEN
 	int "Maximum AT command response length"
 	default 2700
 
+config AT_CMD_RESPONSE_BUFFER_COUNT
+	int "Number of buffers provided by AT command driver."
+	default 2
+
 module = AT_CMD
 module-str = AT command driver
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"

--- a/drivers/at_cmd/at_cmd.c
+++ b/drivers/at_cmd/at_cmd.c
@@ -232,10 +232,11 @@ static void socket_thread_fn(void *arg1, void *arg2, void *arg3)
 			k_work_submit(&item->work);
 		}
 next:
-		callback            = true;
-		current_cmd_handler = NULL;
+		callback = true;
 
 		if (ret.state != AT_CMD_NOTIFICATION) {
+			current_cmd_handler = NULL;
+
 			struct return_state_object ret_copy = {
 				.state = ret.state,
 				.code  = ret.code,


### PR DESCRIPTION
Introduce a few changes in `at_cmd` driver:
1) Give up on heap use in the module in favor of a ~~static buffer~~ memory slabs,
2) ~~Don't use system work queue, to prevent unnecessary complexity~~ work queue not avoidable at the moment unfortunately,
3) Minor cleanup in `socket_thread_fn`, simplifying the logic and preventing potential bugs (like `current_cmd_handler` being clear by AT notification, before AT response arrives).

Tested with several samples (`coap_client`, `mqtt_simple`, `lwm2m_client`, `at_client`)