### PR TITLE
samples: bluetooth: Add security change log

### DIFF
--- a/samples/bluetooth/central_bas/src/main.c
+++ b/samples/bluetooth/central_bas/src/main.c
@@ -171,9 +171,24 @@ static void disconnected(struct bt_conn *conn, u8_t reason)
 	}
 }
 
+static void security_changed(struct bt_conn *conn, bt_security_t level,
+			     enum bt_security_err err)
+{
+	char addr[BT_ADDR_LE_STR_LEN];
+
+	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+
+	if (!err) {
+		printk("Security changed: %s level %u", addr, level);
+	} else {
+		printk("Security failed: %s level %u err %d", addr, level, err);
+	}
+}
+
 static struct bt_conn_cb conn_callbacks = {
 	.connected = connected,
 	.disconnected = disconnected,
+	.security_changed = security_changed
 };
 
 static void scan_init(void)

--- a/samples/bluetooth/central_dfu_smp/src/main.c
+++ b/samples/bluetooth/central_dfu_smp/src/main.c
@@ -183,9 +183,24 @@ static void disconnected(struct bt_conn *conn, u8_t reason)
 	}
 }
 
+static void security_changed(struct bt_conn *conn, bt_security_t level,
+			     enum bt_security_err err)
+{
+	char addr[BT_ADDR_LE_STR_LEN];
+
+	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
+
+	if (!err) {
+		printk("Security changed: %s level %u", addr, level);
+	} else {
+		printk("Security failed: %s level %u err %d", addr, level, err);
+	}
+}
+
 static struct bt_conn_cb conn_callbacks = {
 	.connected = connected,
 	.disconnected = disconnected,
+	.security_changed = security_changed
 };
 
 static void scan_init(void)

--- a/samples/bluetooth/central_uart/src/main.c
+++ b/samples/bluetooth/central_uart/src/main.c
@@ -259,7 +259,6 @@ static void security_changed(struct bt_conn *conn, bt_security_t level,
 
 	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
-	printk("Security changed: %s level %u\n", addr, level);
 	if (!err) {
 		printk("Security changed: %s level %u", addr, level);
 	} else {

--- a/samples/bluetooth/peripheral_lbs/src/main.c
+++ b/samples/bluetooth/peripheral_lbs/src/main.c
@@ -78,7 +78,6 @@ static void security_changed(struct bt_conn *conn, bt_security_t level,
 
 	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
-	printk("Security changed: %s level %u\n", addr, level);
 	if (!err) {
 		printk("Security changed: %s level %u", addr, level);
 	} else {

--- a/samples/bluetooth/peripheral_uart/src/main.c
+++ b/samples/bluetooth/peripheral_uart/src/main.c
@@ -213,7 +213,6 @@ static void security_changed(struct bt_conn *conn, bt_security_t level,
 
 	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
-	printk("Security changed: %s level %u\n", addr, level);
 	if (!err) {
 		printk("Security changed: %s level %u", addr, level);
 	} else {

--- a/samples/bluetooth/shell_bt_nus/src/main.c
+++ b/samples/bluetooth/shell_bt_nus/src/main.c
@@ -58,15 +58,21 @@ static void disconnected(struct bt_conn *conn, u8_t reason)
 	}
 }
 
-static void __attribute__((unused)) security_changed(struct bt_conn *conn,
-						     bt_security_t level,
-						     enum bt_security_err err)
+static char *log_addr(struct bt_conn *conn)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
 
 	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
-	printk("Security changed: %s level %u\n", addr, level);
+	return log_strdup(addr);
+}
+
+static void __attribute__((unused)) security_changed(struct bt_conn *conn,
+						     bt_security_t level,
+						     enum bt_security_err err)
+{
+	char *addr = log_addr(conn);
+
 	if (!err) {
 		printk("Security changed: %s level %u", addr, level);
 	} else {
@@ -80,15 +86,6 @@ static struct bt_conn_cb conn_callbacks = {
 	COND_CODE_1(CONFIG_BT_SMP,
 		    (.security_changed = security_changed), ())
 };
-
-static char *log_addr(struct bt_conn *conn)
-{
-	char addr[BT_ADDR_LE_STR_LEN];
-
-	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
-
-	return log_strdup(addr);
-}
 
 static void auth_passkey_display(struct bt_conn *conn, unsigned int passkey)
 {


### PR DESCRIPTION
This commit provides a common security change log to all
bluetooth samples.

Signed-off-by: Kamil Gawor <Kamil.Gawor@nordicsemi.no>