### PR TITLE
manifest: update zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -36,7 +36,7 @@ manifest:
     - name: zephyr
       repo-path: fw-nrfconnect-zephyr
       west-commands: scripts/west-commands.yml
-      revision: 1c3a001f62e6c51693b67e4f7ee7f66111d31801
+      revision: 40b430ba977cfea2cf733248d79d99ef0b57c19e
     - name: nffs
       revision: bc62a2fa9d98ddb5d633c932ea199bc68e10f194
       path: modules/fs/nffs


### PR DESCRIPTION
Update to get linker symbol for other s1 slot

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>