### PR TITLE
net: nrf_cloud: Use inet_pton instead of custom-made function

### DIFF
--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
@@ -591,39 +591,6 @@ int nct_init(void)
 }
 
 #if defined(CONFIG_NRF_CLOUD_STATIC_IPV4)
-/* Partly copy/paste from zephyr/subsys/net/ip/utils.c
- * Cannot be used when BSD library selects NET_RAW_MODE
- */
-int af_inet_addr_pton(sa_family_t family, const char *src, void *dst)
-{
-	if (family == AF_INET) {
-		struct in_addr *addr = (struct in_addr *)dst;
-		size_t i, len;
-
-		len = strlen(src);
-		for (i = 0; i < len; i++) {
-			if (!(src[i] >= '0' && src[i] <= '9') &&
-				src[i] != '.') {
-				return -EINVAL;
-			}
-		}
-
-		(void)memset(addr, 0, sizeof(struct in_addr));
-
-		for (i = 0; i < sizeof(struct in_addr); i++) {
-			char *endptr;
-
-			addr->s4_addr[i] = strtol(src, &endptr, 10);
-
-			src = ++endptr;
-		}
-	} else {
-		return -ENOTSUP;
-	}
-
-	return 0;
-}
-
 int nct_connect(void)
 {
 	int err;
@@ -631,8 +598,8 @@ int nct_connect(void)
 	struct sockaddr_in *broker =
 		((struct sockaddr_in *)&nct.broker);
 
-	af_inet_addr_pton(AF_INET, CONFIG_NRF_CLOUD_STATIC_IPV4_ADDR,
-		&broker->sin_addr);
+	inet_pton(AF_INET, CONFIG_NRF_CLOUD_STATIC_IPV4_ADDR,
+		  &broker->sin_addr);
 	broker->sin_family = AF_INET;
 	broker->sin_port = htons(NRF_CLOUD_PORT);
 


### PR DESCRIPTION
Small cleanup - it's now possible to use Zephyrs standard `inet_pton`
implementation instead of providing custom implementation in NCS.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>