### PR TITLE
sample: nrf9160: aws_fota: Change naming in certificates.h

### DIFF
--- a/samples/nrf9160/aws_fota/src/certificates.h
+++ b/samples/nrf9160/aws_fota/src/certificates.h
@@ -11,7 +11,7 @@
 
 #define CLOUD_CLIENT_PUBLIC_CERTIFICATE \
 	"-----BEGIN CERTIFICATE-----\n" \
-	"AWS IoT certificate public key\n"\
+	"AWS IoT public certificate\n"\
 	"-----END CERTIFICATE-----\n"
 
 #define CLOUD_CA_CERTIFICATE \


### PR DESCRIPTION
Change the naming of public key to certificate to avoid confusion with
regards to which file from AWS the user should provide.

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>