### PR TITLE
lib: Remove workarounds for fixed logger issue

### DIFF
--- a/lib/at_host/Kconfig
+++ b/lib/at_host/Kconfig
@@ -67,6 +67,10 @@ config AT_HOST_TERMINATION
 	default 2 if LF_TERMINATION
 	default 3 if CR_LF_TERMINATION
 
+module = AT_HOST
+module-str = AT host
+source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
+
 endif # AT_HOST_LIBRARY
 
 endmenu

--- a/lib/at_host/at_host.c
+++ b/lib/at_host/at_host.c
@@ -4,18 +4,16 @@
  * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */
 
-#include <logging/log.h>
-#define LOG_DOMAIN at_host
-#define LOG_LEVEL CONFIG_LOG_AT_HOST_LEVEL
-LOG_MODULE_REGISTER(LOG_DOMAIN);
-
 #include <zephyr.h>
 #include <stdio.h>
 #include <ctype.h>
+#include <logging/log.h>
 #include <uart.h>
 #include <string.h>
 #include <init.h>
 #include <at_cmd.h>
+
+LOG_MODULE_REGISTER(at_host, CONFIG_AT_HOST_LOG_LEVEL);
 
 #define CONFIG_UART_0_NAME      "UART_0"
 #define CONFIG_UART_1_NAME      "UART_1"

--- a/lib/bsdlib/nrf91_sockets.c
+++ b/lib/bsdlib/nrf91_sockets.c
@@ -10,13 +10,6 @@
  * @brief nrf91 socket offload provider
  */
 
-/* TODO A workaround for intrusive behavior of networking subsystem logging.
- *      Upstream issue #11659.
- */
-#include <logging/log.h>
-#define LOG_LEVEL LOG_LEVEL_NONE
-LOG_MODULE_REGISTER(nrf91_sockets);
-
 #include <bsd_limits.h>
 #include <bsd_os.h>
 #include <errno.h>


### PR DESCRIPTION
The issue with logging in networking subsystem was solved upstream, there's no need for a workaround anymore.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>