### PR TITLE
subsys: net: lib: aws_fota: Fix faulty topic matching

### DIFF
--- a/subsys/net/lib/aws_fota/src/aws_fota.c
+++ b/subsys/net/lib/aws_fota/src/aws_fota.c
@@ -397,11 +397,6 @@ int aws_fota_mqtt_evt_handler(struct mqtt_client *const client,
 			return err;
 		}
 
-		err = aws_jobs_subscribe_job_id_get_topic(client, "$next");
-		if (err) {
-			LOG_ERR("Unable to subscribe to jobs/$next/get");
-		}
-
 		err = update_device_shadow_version(client);
 		if (err) {
 			LOG_ERR("Unable to update device shadow");
@@ -538,7 +533,7 @@ int aws_fota_init(struct mqtt_client *const client,
 
 	err = construct_job_id_get_topic(client->client_id.utf8,
 					 "$next",
-					 "",
+					 "/accepted",
 					 get_next_job_execution_topic);
 	if (err != 0) {
 		LOG_ERR("construct_job_id_get_topic error %d", err);


### PR DESCRIPTION
The matching on which topic new jobs have been published on when trying
to fetch jobs was wrong. This commit fixes the matching by adding
"/accepted" string to the topic.

Also removed duplicated subscribe.

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>