### PR TITLE
Pr/0001 link list in at cmd notif

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -38,6 +38,7 @@
 /include/shell/                           @nordic-krch @jarz-nordic
 /lib/at_cmd_parser/                       @rlubos
 /lib/at_host/                             @rlubos
+/lib/at_notif/                            @pkchan
 /lib/bsdlib/                              @rlubos
 /lib/modem_info/                          @rlubos
 /lib/pdn_management/                      @rlubos

--- a/drivers/lte_link_control/Kconfig
+++ b/drivers/lte_link_control/Kconfig
@@ -8,6 +8,7 @@ menuconfig LTE_LINK_CONTROL
 	bool "nRF91 LTE Link control library"
 	select AT_CMD
 	select AT_CMD_PARSER
+	select AT_NOTIF
 	default n
 
 if LTE_LINK_CONTROL

--- a/include/at_notif.h
+++ b/include/at_notif.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#ifndef AT_NOTIF_H_
+#define AT_NOTIF_H_
+
+/**
+ * @file at_notif.h
+ *
+ * @defgroup at_notif AT command notification manager
+ *
+ * @{
+ *
+ * @brief Public APIs for the AT command notification manager.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <zephyr/types.h>
+
+/**
+ * @typedefs at_notif_handler_t
+ *
+ * Because this driver let multiple threads share the same socket, it must make
+ * sure that the correct thread gets the correct data returned from the AT
+ * interface. Notifications will be dispatched to handlers registered using
+ * the @ref at_notif_register_handler() function. Handlers can be de-registered
+ * using the @ref at_notif_deregister_handler() function.
+ *
+ * @param context      Pointer to context provided by the module which has
+ *                     registered the handler.
+ * @param response     Null terminated string containing the modem message
+ *
+ */
+typedef void (*at_notif_handler_t)(void *context, char *response);
+
+/**@brief Initialize AT command notification manager.
+ *
+ * @return Zero on success, non-zero otherwise.
+ */
+int at_notif_init(void);
+
+/**
+ * @brief Function to register AT command notification handler
+ *
+ * @note  If the same combination of context and handler exists in the memory,
+ *        then the request will be ignored and command execution will be
+ *        regarded as finished successfully.
+ *
+ * @param context Pointer to context provided by the module which has
+ *                registered the handler.
+ * @param handler Pointer to a received notification handler function of type
+ *                @ref at_notif_handler_t.
+ *
+ * @retval 0            If command execution was successful.
+ * @retval -ENOBUFS     If memory cannot be allocated.
+ * @retval -EINVAL      If handler is a NULL pointer.
+ */
+int at_notif_register_handler(void *context, at_notif_handler_t handler);
+
+/**
+ * @brief Function to de-register AT command notification handler
+ *
+ * @param context Pointer to context provided by the module which has
+ *                registered the handler.
+ * @param handler Pointer to a received notification handler function of type
+ *                @ref at_notif_handler_t.
+ *
+ * @retval 0            If command execution was successful.
+ * @retval -ENXIO       If the combination of context and handler cannot be
+ *                      found.
+ * @retval -EINVAL      If handler is a NULL pointer.
+ */
+int at_notif_deregister_handler(void *context, at_notif_handler_t handler);
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* AT_NOTIF_H_ */

--- a/include/at_notif.rst
+++ b/include/at_notif.rst
@@ -1,0 +1,19 @@
+.. _at_notif_readme:
+
+AT command notifications
+########################
+
+AT command notifications can be dispatched to registered modules.
+Modules can register a callback function to receive AT command notifications as raw string.
+Multiple instances, which can be identified by pointers to contexts, are also supported.
+Modules can de-register the callback function to stop receiving notifications.
+
+API documentation
+*****************
+
+| Header file: :file:`include/at_notif.h`
+| Source file: :file:`lib/at_notif/at_notif.c`
+
+.. doxygengroup:: at_notif
+   :project: nrf
+   :members:

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -7,6 +7,7 @@
 add_subdirectory_ifdef(CONFIG_BSD_LIBRARY bsdlib)
 add_subdirectory_ifdef(CONFIG_LWM2M_CARRIER lwm2m_carrier)
 add_subdirectory_ifdef(CONFIG_DK_LIBRARY dk_buttons_and_leds)
+add_subdirectory_ifdef(CONFIG_AT_NOTIF at_notif)
 add_subdirectory_ifdef(CONFIG_AT_HOST_LIBRARY at_host)
 add_subdirectory_ifdef(CONFIG_AT_CMD_PARSER at_cmd_parser)
 add_subdirectory_ifdef(CONFIG_MODEM_INFO modem_info)

--- a/lib/Kconfig
+++ b/lib/Kconfig
@@ -10,6 +10,8 @@ rsource "bsdlib/Kconfig"
 
 rsource "lwm2m_carrier/Kconfig"
 
+rsource "at_notif/Kconfig"
+
 rsource "at_host/Kconfig"
 
 rsource "dk_buttons_and_leds/Kconfig"

--- a/lib/at_host/Kconfig
+++ b/lib/at_host/Kconfig
@@ -9,6 +9,7 @@ menu "AT Host Library for nrf91"
 config AT_HOST_LIBRARY
 	bool "AT Host Library for nrf91"
 	select AT_CMD
+	select AT_NOTIF
 
 if AT_HOST_LIBRARY
 

--- a/lib/at_notif/CMakeLists.txt
+++ b/lib/at_notif/CMakeLists.txt
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2019 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+zephyr_include_directories(.)
+zephyr_library()
+zephyr_library_sources(at_notif.c)

--- a/lib/at_notif/Kconfig
+++ b/lib/at_notif/Kconfig
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2019 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+menuconfig AT_NOTIF
+	bool "AT-command notification manager"
+	depends on AT_CMD
+	help
+	  A library for managing AT-command notifications.
+
+if AT_NOTIF
+
+config AT_NOTIF_SYS_INIT
+	bool "Initialize the AT-command notification manager during system init"
+	default y if AT_CMD_SYS_INIT
+
+module=AT_NOTIF
+module-dep=LOG
+module-str= AT-command notification management library
+source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
+
+endif # AT_NOTIF

--- a/lib/at_notif/at_notif.c
+++ b/lib/at_notif/at_notif.c
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#include <logging/log.h>
+#include <zephyr.h>
+#include <stdio.h>
+#include <init.h>
+#include <at_cmd.h>
+#include <at_notif.h>
+#include <misc/slist.h>
+
+LOG_MODULE_REGISTER(at_notif, CONFIG_AT_NOTIF_LOG_LEVEL);
+
+static K_MUTEX_DEFINE(list_mtx);
+
+/**@brief Link list element for notification handler. */
+struct notif_handler {
+	sys_snode_t        node;
+	void               *ctx;
+	at_notif_handler_t handler;
+};
+
+static sys_slist_t handler_list;
+
+
+/**@brief Find notification handler.
+ *
+ * @note  Returns next and writes previous to prev.
+ */
+static struct notif_handler *find_node(struct notif_handler **prev_out,
+	void *ctx, at_notif_handler_t handler)
+{
+	struct notif_handler *prev = NULL, *curr, *tmp;
+
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&handler_list, curr, tmp, node) {
+		if (curr->ctx == ctx && curr->handler == handler) {
+			*prev_out = prev;
+			return curr;
+		}
+		prev = curr;
+	}
+	return NULL;
+}
+
+/**@brief Append notification handler. */
+static int append_notif_handler(void *ctx, at_notif_handler_t handler)
+{
+	struct notif_handler *to_ins;
+
+	k_mutex_lock(&list_mtx, K_FOREVER);
+
+	/* Check if it exists */
+	if (find_node(&to_ins, ctx, handler) != NULL) {
+		LOG_DBG("Already in the list.\n");
+		k_mutex_unlock(&list_mtx);
+		return 0;
+	}
+
+	/* Allocate memory and fill. */
+	to_ins = (struct notif_handler *)k_malloc(sizeof(struct notif_handler));
+	if (to_ins == NULL) {
+		k_mutex_unlock(&list_mtx);
+		return -ENOBUFS;
+	}
+	memset(to_ins, 0, sizeof(struct notif_handler));
+	to_ins->ctx     = ctx;
+	to_ins->handler = handler;
+
+	/* Append. */
+	sys_slist_append(&handler_list, &to_ins->node);
+
+	k_mutex_unlock(&list_mtx);
+	return 0;
+}
+
+/**@brief Remove notification handler. */
+static int remove_notif_handler(void *ctx, at_notif_handler_t handler)
+{
+	struct notif_handler *curr, *prev = NULL;
+
+	k_mutex_lock(&list_mtx, K_FOREVER);
+
+	/* Check if it exists */
+	curr = find_node(&prev, ctx, handler);
+	if (curr == NULL) {
+		LOG_DBG("Not found.\n");
+		k_mutex_unlock(&list_mtx);
+		return -ENXIO;
+	}
+
+	/* Remove */
+	sys_slist_remove(&handler_list, &prev->node, &curr->node);
+	k_free(curr);
+
+	k_mutex_unlock(&list_mtx);
+	return 0;
+}
+
+/**@brief Dispatcher for notifications. */
+static void notif_dispatch(char *response)
+{
+	struct notif_handler *curr, *tmp;
+
+	k_mutex_lock(&list_mtx, K_FOREVER);
+
+	LOG_DBG("Dispatching events.\n");
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&handler_list, curr, tmp, node) {
+		LOG_DBG("ctx=0x%08X, handler=0x%08X", (u32_t)curr->ctx,
+			(u32_t)curr->handler);
+		curr->handler(curr->ctx, response);
+	}
+
+	k_mutex_unlock(&list_mtx);
+}
+
+static int module_init(struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	LOG_DBG("Initialization");
+	sys_slist_init(&handler_list);
+	at_cmd_set_notification_handler(notif_dispatch);
+	return 0;
+}
+
+int at_notif_init(void)
+{
+	return module_init(NULL);
+}
+
+int at_notif_register_handler(void *context, at_notif_handler_t handler)
+{
+	if (handler == NULL) {
+		LOG_DBG("context=0x%08X, handler=0x%08X", (u32_t)context,
+			(u32_t)handler);
+		return -EINVAL;
+	}
+	return append_notif_handler(context, handler);
+}
+
+int at_notif_deregister_handler(void *context, at_notif_handler_t handler)
+{
+	if (handler == NULL) {
+		LOG_DBG("context=0x%08X, handler=0x%08X", (u32_t)context,
+			(u32_t)handler);
+		return -EINVAL;
+	}
+	return remove_notif_handler(context, handler);
+}
+
+#ifdef CONFIG_AT_NOTIF_SYS_INIT
+SYS_INIT(module_init, APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+#endif


### PR DESCRIPTION
The original at_cmd module supports only one record notification handler, whereas the design in this PR is a link-list which can support infinite number of handlers theoretically.

The purpose is to allow for numerous modules to receive AT-command notifications at the same time.

A new interface at_cmd_remove_notification_handler() has also been created to remove an entry from the list. The only module which needs to have notification handler removed is lte_lc. It is also changed accordingly.