### PR TITLE
net: lib: download_client: report header errors to caller

### DIFF
--- a/include/net/download_client.h
+++ b/include/net/download_client.h
@@ -40,6 +40,8 @@ enum download_client_evt_id {
 	 * the connection to the server has been lost.
 	 * - ENOTCONN: error reading from socket
 	 * - ECONNRESET: peer closed connection
+	 * - EBADMSG: HTTP response header not
+	 *            as expected
 	 *
 	 * In both cases, the application should
 	 * disconnect (@ref download_client_disconnect)

--- a/subsys/net/lib/download_client/src/download_client.c
+++ b/subsys/net/lib/download_client/src/download_client.c
@@ -422,6 +422,8 @@ restart_and_suspend:
 				continue;
 			}
 			if (rc < 0) {
+				/* Something was wrong with the header */
+				error_evt_send(dl, EBADMSG);
 				/* Restart and suspend */
 				break;
 			}


### PR DESCRIPTION
If the HTTP header response looks invalid for some reason, the
download_client can't make any more progress.  This used to just halt
the client silently, but should be reported back to the caller.

Signed-off-by: Justin Brzozoski <justin.brzozoski@signal-fire.com>