### PR TITLE
samples: lwm2m_client: Update PSK identity in docs

### DIFF
--- a/samples/nrf9160/lwm2m_client/README.rst
+++ b/samples/nrf9160/lwm2m_client/README.rst
@@ -91,7 +91,7 @@ The following are instructions specific to `Leshan Demo Server`_::
 
     Security mode: Pre-Shared Key
 
-    Identity: Client_identity
+    Identity: nrf-{Your Device IMEI}
 
     Key: 000102030405060708090a0b0c0d0e0f
 


### PR DESCRIPTION
The lwm2m_client sample documentation was incorrect in terms of PSK
identity used by the sample for DTLS handshake.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>