### PR TITLE
LTE link control: Use fallback network mode if conenction fails

### DIFF
--- a/drivers/lte_link_control/Kconfig
+++ b/drivers/lte_link_control/Kconfig
@@ -147,6 +147,24 @@ config LTE_NETWORK_MODE_NBIOT_GPS
 
 endchoice
 
+config LTE_NETWORK_USE_FALLBACK
+	bool "Use fallback network mode if selected mode fails"
+	default y
+	help
+		When enabled, the network mode will be switched to the other
+		available if the preferred fails to establish connection within
+		specified timeout.
+		If LTE-M is selected as the network mode, NB-IoT will be the
+		fallback mode and vice versa.
+
+config LTE_NETWORK_TIMEOUT
+	int "Time period [s] to attempt establishing connection"
+	default 600
+	help
+		Time period in seconds to attempt establishing an LTE link, before timing
+		out. If fallback mode is enabled, the fallback mode will also be
+		tried for the same period.
+
 module = LTE_LINK_CONTROL
 module-dep = LOG
 module-str = LTE link control library

--- a/drivers/lte_link_control/lte_lc.c
+++ b/drivers/lte_link_control/lte_lc.c
@@ -26,7 +26,7 @@ LOG_MODULE_REGISTER(lte_lc, CONFIG_LTE_LINK_CONTROL_LOG_LEVEL);
 static const char mdm_trace[] = "AT%XMODEMTRACE=1,2";
 #endif
 /* Subscribes to notifications with level 2 */
-static const char subscribe[] = "AT+CEREG=2";
+static const char subscribe[] = "AT+CEREG=5";
 
 #if defined(CONFIG_LTE_LOCK_BANDS)
 /* Lock LTE bands 3, 4, 13 and 20 (volatile setting) */


### PR DESCRIPTION
This path adds the option to use a fallback network node if connection cannot be established using the preferred one.
So if LTE-m is set as the preferred, but a connection cannot be established within the configured timeout, NB-IoT is tried for the same amount of time, and vice versa.