### PR TITLE
Pr/0002 ficr service in spm

### DIFF
--- a/samples/nrf9160/secure_services/src/main.c
+++ b/samples/nrf9160/secure_services/src/main.c
@@ -65,6 +65,17 @@ void main(void)
 	print_hex_number(buf, num_bytes_to_read);
 #endif
 
+	u32_t info_part = 0;
+	u32_t ficr_addr = (u32_t)&NRF_FICR_S->INFO.PART;
+
+	printk("\nRead FICR, offset 0x20C (address 0x%08x):\n", ficr_addr);
+	ret = spm_request_read(&info_part, ficr_addr, sizeof(u32_t));
+	if (ret != 0) {
+		printk("Could not read FICR (err: %d)\n", ret);
+	} else {
+		printk("FICR.INFO.PART (+0x20C) = 0x%08X\n", info_part);
+	}
+
 	printk("\nReboot in %d seconds.\n", sleep_time_s);
 	k_sleep(K_SECONDS(5));
 

--- a/subsys/spm/secure_services.c
+++ b/subsys/spm/secure_services.c
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */
+#include <zephyr.h>
 #include <errno.h>
 #include <cortex_m/tz.h>
 #include <misc/reboot.h>
@@ -54,6 +55,13 @@ int spm_secure_services_init(void)
 
 
 #ifdef CONFIG_SPM_SERVICE_READ
+
+#define FICR_BASE               NRF_FICR_S_BASE
+#define FICR_PUBLIC_ADDR        (FICR_BASE + 0x204)
+#define FICR_PUBLIC_SIZE        0xA1C
+#define FICR_RESTRICTED_ADDR    (FICR_BASE + 0x130)
+#define FICR_RESTRICTED_SIZE    0x8
+
 struct read_range {
 	u32_t start;
 	size_t size;
@@ -68,6 +76,10 @@ int spm_request_read(void *destination, u32_t addr, size_t len)
 		{.start = PM_MCUBOOT_PAD_ADDRESS,
 		 .size = PM_MCUBOOT_PAD_SIZE},
 #endif
+		{.start = FICR_PUBLIC_ADDR,
+		 .size = FICR_PUBLIC_SIZE},
+		{.start = FICR_RESTRICTED_ADDR,
+		 .size = FICR_RESTRICTED_SIZE},
 	};
 
 	if (destination == NULL || len <= 0) {


### PR DESCRIPTION
There are applications which requires reading of FICR. Therefore, there needs to be an interface to read them.

Range 0x204 ~ 0xC20 are published in infocenter.
Range 0x130 ~ 0x134 happens in system_nrf9160.c. They are used to check whether certain errata fixes are required. It does not harm to read them.