### PR TITLE
tests: unity: Fix example compilation

### DIFF
--- a/tests/unity/example_test/src/foo/foo.h
+++ b/tests/unity/example_test/src/foo/foo.h
@@ -7,6 +7,8 @@
 #ifndef __FOO_H
 #define __FOO_H
 
+#include <toolchain/common.h>
+
 int foo_init(void *handle);
 
 static inline int foo_execute(void)


### PR DESCRIPTION
Test was not compiling due to missing include