### PR TITLE
lib: lwm2m carrier: Rework psk handling

### DIFF
--- a/lib/lwm2m_carrier/Kconfig
+++ b/lib/lwm2m_carrier/Kconfig
@@ -33,12 +33,27 @@ menuconfig LWM2M_CARRIER
 
 if LWM2M_CARRIER
 
-config LWM2M_CARRIER_BOOTSTRAP_URI
-	string "LwM2M carrier bootstrap URI"
+config LWM2M_CARRIER_USE_CUSTOM_BOOTSTRAP_URI
+	bool "Use custom bootstrap URI"
+	help
+	  Use a custom bootstrap URI.
+
+	  Enabling this option requires that a file "bootstrap_psk.h" is
+	  made available in an include folder.
+
+	  This file must define the LWM2M bootstrap pre-shared key e.g.:
+
+	  static const char bootstrap_psk[] = {'m', 'y', 'k', 'e', 'y'};
+
+if LWM2M_CARRIER_USE_CUSTOM_BOOTSTRAP_URI
+
+config LWM2M_CARRIER_CUSTOM_BOOTSTRAP_URI
+	string "LwM2M carrier custom bootstrap URI"
 	default ""
 	help
-	  An URI of the bootstrap server.
-	  Leave empty to use the library defaults.
+	  URI of the custom bootstrap server.
+
+endif # LWM2M_CARRIER_USE_CUSTOM_BOOTSTRAP_URI
 
 module=LWM2M_CARRIER
 module-dep=LOG

--- a/lib/lwm2m_carrier/os/bootstrap_psk.h
+++ b/lib/lwm2m_carrier/os/bootstrap_psk.h
@@ -1,7 +1,0 @@
-/*
- * Copyright (c) 2019 Nordic Semiconductor ASA
- *
- * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
- */
-
-static const char bootstrap_psk[] = { };

--- a/lib/lwm2m_carrier/os/lwm2m_carrier.c
+++ b/lib/lwm2m_carrier/os/lwm2m_carrier.c
@@ -8,11 +8,9 @@
 #include <zephyr.h>
 #include <lwm2m_carrier.h>
 
-#include "bootstrap_psk.h"
-
-BUILD_ASSERT_MSG((sizeof(CONFIG_LWM2M_CARRIER_BOOTSTRAP_URI) == 1) ||
-		 (sizeof(bootstrap_psk) > 0),
-		 "Custom bootstrap URI specified, please provide a valid PSK.");
+#ifdef CONFIG_LWM2M_CARRIER_USE_CUSTOM_BOOTSTRAP_URI
+#include <bootstrap_psk.h>
+#endif
 
 #define LWM2M_CARRIER_THREAD_STACK_SIZE 8192
 #define LWLM2_CARRIER_THREAD_PRIORITY K_LOWEST_APPLICATION_THREAD_PRIO
@@ -28,14 +26,11 @@ void lwm2m_carrier_thread_run(void)
 {
 	int err;
 
-	if (strlen(CONFIG_LWM2M_CARRIER_BOOTSTRAP_URI) > 0) {
-		config.bootstrap_uri = CONFIG_LWM2M_CARRIER_BOOTSTRAP_URI;
-	}
-
-	if (sizeof(bootstrap_psk) > 0) {
-		config.psk = (char *)bootstrap_psk;
-		config.psk_length = sizeof(bootstrap_psk);
-	}
+#ifdef CONFIG_LWM2M_CARRIER_USE_CUSTOM_BOOTSTRAP_URI
+	config.bootstrap_uri = CONFIG_LWM2M_CARRIER_CUSTOM_BOOTSTRAP_URI;
+	config.psk = (char *)bootstrap_psk;
+	config.psk_length = sizeof(bootstrap_psk);
+#endif
 
 	err = lwm2m_carrier_init(&config);
 	__ASSERT(err == 0, "Failed to initialize LwM2M carrier library");


### PR DESCRIPTION
When using a custom bootstrap URI, the psk is currently
fetched from a file in the nrf tree (bootstrap_psk.h).

This patch allows the user to add this file from the
application source area.

Signed-off-by: Jorgen Kvalvaag <jorgen.kvalvaag@nordicsemi.no>