### PR TITLE
bootloader: Move memcpy32 to the file it is used in

### DIFF
--- a/samples/bootloader/src/main.c
+++ b/samples/bootloader/src/main.c
@@ -22,15 +22,6 @@
 #include <nrf_uarte.h>
 #endif
 
-void *memcpy32(void *restrict d, const void *restrict s, size_t n)
-{
-	size_t len_words = ROUND_UP(n, 4) / 4;
-	for (size_t i = 0; i < len_words; i++) {
-		((u32_t *)d)[i] = ((u32_t *)s)[i];
-	}
-	return d;
-}
-
 static bool verify_firmware(u32_t address)
 {
 	/* Some key data storage backends require word sized reads, hence

--- a/subsys/bootloader/bl_crypto/bl_crypto_cc310_common.h
+++ b/subsys/bootloader/bl_crypto/bl_crypto_cc310_common.h
@@ -15,6 +15,4 @@ void cc310_bl_backend_enable(void);
 
 void cc310_bl_backend_disable(void);
 
-void *memcpy32(void *d, const void *s, size_t n);
-
 #endif

--- a/subsys/bootloader/bl_crypto/bl_crypto_cc310_hash.c
+++ b/subsys/bootloader/bl_crypto/bl_crypto_cc310_hash.c
@@ -41,6 +41,16 @@ static u32_t __noinit ram_buffer
 	[RAM_BUFFER_LEN_WORDS]; /* Not stack allocated because of its size. */
 
 
+static inline void *memcpy32(void *restrict d, const void *restrict s, size_t n)
+{
+	size_t len_words = ROUND_UP(n, 4) / 4;
+
+	for (size_t i = 0; i < len_words; i++) {
+		((u32_t *)d)[i] = ((u32_t *)s)[i];
+	}
+	return d;
+}
+
 int crypto_init_hash(void)
 {
 	return cc310_bl_init();


### PR DESCRIPTION
Less complexity

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>