### PR TITLE
bootloader: pm.yml: Move provision into b0 region

### DIFF
--- a/samples/bootloader/pm.yml
+++ b/samples/bootloader/pm.yml
@@ -1,11 +1,13 @@
 #include <autoconf.h>
 #include <generated_dts_board_unfixed.h>
 
-b0:
-  size: CONFIG_PM_PARTITION_SIZE_B0
+b0_image:
+  size: CONFIG_PM_PARTITION_SIZE_B0_IMAGE
   placement:
     after: start
-    align: {end: 0x8000}
+
+b0:
+  span: [b0_image, provision]
 
 s0_pad:
   share_size: mcuboot_pad
@@ -40,5 +42,5 @@ s1:
 provision:
   size: 0x1000
   placement:
-    before: end
+    after: b0_image
     align: {start: 0x1000}

--- a/samples/bootloader/src/main.c
+++ b/samples/bootloader/src/main.c
@@ -181,14 +181,6 @@ void main(void)
 		return;
 	}
 
-#ifndef CONFIG_SOC_NRF9160
-	err = fprotect_area(PM_PROVISION_ADDRESS, PM_PROVISION_SIZE);
-	if (err) {
-		printk("Protect provision data failed, cancel startup.\n\r");
-		return;
-	}
-#endif /* CONFIG_SOC_NRF9160 */
-
 	u32_t s0_addr = s0_address_read();
 	u32_t s1_addr = s1_address_read();
 	const struct fw_firmware_info *s0_info = fw_firmware_info_get(s0_addr);

--- a/subsys/bootloader/Kconfig
+++ b/subsys/bootloader/Kconfig
@@ -121,8 +121,8 @@ menuconfig IS_SECURE_BOOTLOADER
 
 if IS_SECURE_BOOTLOADER
 
-partition=B0
-partition-size=0x8000
+partition=B0_IMAGE
+partition-size=0x7000
 source "${ZEPHYR_BASE}/../nrf/subsys/partition_manager/Kconfig.template.partition_size"
 
 menuconfig SECURE_BOOT_DEBUG


### PR DESCRIPTION
Since it needs to be protected, this works better in both nrf91 and
nrf5x.

The nrf91 part will eventually be moved to the OTP instead.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>