### PR TITLE
applications: nrf_desktop: Send wheel data only when accumulated

### DIFF
--- a/applications/nrf_desktop/src/modules/hid_state.c
+++ b/applications/nrf_desktop/src/modules/hid_state.c
@@ -680,7 +680,8 @@ static bool update_report(enum in_report tr)
 	if (tr == IN_REPORT_MOUSE) {
 		if ((state.last_dx != 0) ||
 		    (state.last_dy != 0) ||
-		    (state.wheel_acc != 0)) {
+		    (state.wheel_acc < -1) ||
+		    (state.wheel_acc > 1)) {
 			update_needed = true;
 		}
 	}


### PR DESCRIPTION
Send wheel data only when enough rotation points are accumulated.

Jira:DESK-694

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>