### PR TITLE
Bluetooth: gatt_pool: Save UUID storage for common UUIDs

### DIFF
--- a/include/bluetooth/gatt_pool.h
+++ b/include/bluetooth/gatt_pool.h
@@ -66,17 +66,19 @@ extern "C" {
 /** @brief Register a characteristic descriptor.
  *
  *  @param _gp GATT service object with dynamic attribute allocation.
- *  @param _chrc_uuid_init Characteristic UUID.
- *  @param _char_props Properties of the characteristic.
+ *  @param _uuid Characteristic UUID.
+ *  @param _props Characteristic properties.
+ *  @param _perm Characteristic access permissions.
+ *  @param _read Characteristic read callback.
+ *  @param _write Characteristic write callback.
+ *  @param _value Characteristic value.
  */
-#define BT_GATT_POOL_CHRC(_gp, _chrc_uuid_init, _char_props)                   \
+#define BT_GATT_POOL_CHRC(_gp, _uuid, _props, _perm, _read, _write, _value)    \
 	do {                                                                   \
 		int _ret;                                                      \
-		const struct bt_gatt_chrc _chrc = {                            \
-		    .uuid = _chrc_uuid_init,                                   \
-		    .properties = _char_props,                                 \
-		};                                                             \
-		_ret = bt_gatt_pool_chrc_alloc(_gp, &_chrc);                   \
+		const struct bt_gatt_attr _attr = BT_GATT_ATTRIBUTE(           \
+			_uuid, _perm, _read, _write, _value);                  \
+		_ret = bt_gatt_pool_chrc_alloc(_gp, _props, &_attr);           \
 		__ASSERT_NO_MSG(!_ret);                                        \
 		(void)_ret;                                                    \
 	} while (0)
@@ -84,12 +86,17 @@ extern "C" {
 /** @brief Register an attribute descriptor.
  *
  *  @param _gp GATT service object with dynamic attribute allocation.
- *  @param _descriptor_init Attribute descriptor.
+ *  @param _uuid Descriptor UUID.
+ *  @param _perm Descriptor access permissions.
+ *  @param _read Descriptor read callback.
+ *  @param _write Descriptor write callback.
+ *  @param _value Descriptor value.
  */
-#define BT_GATT_POOL_DESC(_gp, _descriptor_init)                               \
+#define BT_GATT_POOL_DESC(_gp, _uuid, _perm, _read, _write, _value)            \
 	do {                                                                   \
 		int _ret;                                                      \
-		const struct bt_gatt_attr _descriptor = _descriptor_init;      \
+		const struct bt_gatt_attr _descriptor = BT_GATT_DESCRIPTOR(    \
+			_uuid, _perm, _read, _write, _value);                  \
 		_ret = bt_gatt_pool_desc_alloc(_gp, &_descriptor);             \
 		__ASSERT_NO_MSG(!_ret);                                        \
 		(void)_ret;                                                    \
@@ -141,12 +148,14 @@ int bt_gatt_pool_svc_alloc(struct bt_gatt_pool *gp,
 /** @brief Take a characteristic descriptor from the pool.
  *
  *  @param gp   GATT service object with dynamic attribute allocation.
- *  @param chrc Characteristic descriptor.
+ *  @param _chrc_uuid Characteristic UUID.
+ *  @param _char_props Properties of the characteristic.
+ *  @param _attr Characteristic value attribute.
  *
  *  @return 0 or a negative error code.
  */
-int bt_gatt_pool_chrc_alloc(struct bt_gatt_pool *gp,
-			    struct bt_gatt_chrc const *chrc);
+int bt_gatt_pool_chrc_alloc(struct bt_gatt_pool *gp, u8_t props,
+			    struct bt_gatt_attr const *attr);
 
 /** @brief Take an attribute descriptor from the pool.
  *

--- a/subsys/bluetooth/gatt_pool.c
+++ b/subsys/bluetooth/gatt_pool.c
@@ -73,6 +73,10 @@ static struct svc_el_pool chrc_pool = {
 	.locks = BT_GATT_CHRC_LOCKS,
 };
 
+static struct bt_uuid const * const uuid_primary = BT_UUID_GATT_PRIMARY;
+static struct bt_uuid const * const uuid_chrc = BT_UUID_GATT_CHRC;
+static struct bt_uuid const * const uuid_ccc = BT_UUID_GATT_CCC;
+
 #define EL_IN_POOL_VERIFY(pool, el)                                            \
 	do {                                                                   \
 		__ASSERT(pool != NULL, "Pool is uninitialized");               \
@@ -164,7 +168,7 @@ static void chrc_release(struct bt_gatt_chrc const *chrc)
 }
 
 static int uuid_register(struct bt_uuid **dest_uuid,
-			  struct bt_uuid const *src_uuid)
+			 struct bt_uuid const *src_uuid)
 {
 	int ret = -EINVAL;
 
@@ -250,17 +254,16 @@ static void bt_gatt_pool_attr_free(struct bt_gatt_attr const *attr)
 		return;
 	}
 
-	if (!bt_uuid_cmp(attr->uuid, BT_UUID_GATT_PRIMARY)) {
-		uuid_unregister(attr->uuid);
+	if (!bt_uuid_cmp(attr->uuid, uuid_primary)) {
 		uuid_unregister(attr->user_data);
-	} else if (!bt_uuid_cmp(attr->uuid, BT_UUID_GATT_CHRC)) {
-		uuid_unregister(((struct bt_gatt_chrc *)attr->user_data)->uuid);
+	} else if (!bt_uuid_cmp(attr->uuid, uuid_chrc)) {
 		chrc_release(attr->user_data);
-		uuid_unregister(attr->uuid);
-	} else if (!bt_uuid_cmp(attr->uuid, BT_UUID_GATT_CCC)) {
-		uuid_unregister(attr->uuid);
+	} else if (!bt_uuid_cmp(attr->uuid, uuid_ccc)) {
+		/* Nothing to release */
 	} else {
-		/* Just a descriptor created using bt_gatt_pool_desc_alloc */
+		/* Either the characteristic value UUID or a descriptor
+		 * created using bt_gatt_pool_desc_alloc.
+		 */
 		uuid_unregister(attr->uuid);
 	}
 }
@@ -270,7 +273,7 @@ int bt_gatt_pool_svc_alloc(struct bt_gatt_pool *gp,
 {
 	int ret;
 	struct bt_gatt_attr *attr;
-	struct bt_uuid      *uuid_gatt_primary = BT_UUID_GATT_PRIMARY;
+	struct bt_uuid *uuid = NULL;
 
 	if (!gp || !gp->svc.attrs || !svc_uuid) {
 		LOG_ERR("Invalid attribute");
@@ -281,65 +284,63 @@ int bt_gatt_pool_svc_alloc(struct bt_gatt_pool *gp,
 		return -ENOSPC;
 	}
 
-	attr = &gp->svc.attrs[gp->svc.attr_count];
-	memset(attr, 0, sizeof(*attr));
-
-	ret = uuid_register((struct bt_uuid **) &attr->uuid, uuid_gatt_primary);
+	ret = uuid_register(&uuid, svc_uuid);
 	if (ret) {
 		return ret;
 	}
-	ret = uuid_register((struct bt_uuid **) &attr->user_data, svc_uuid);
-	if (ret) {
-		return ret;
-	}
-	attr->perm = BT_GATT_PERM_READ;
-	attr->read = bt_gatt_attr_read_service;
 
-	gp->svc.attr_count++;
+	attr = &gp->svc.attrs[gp->svc.attr_count++];
+	*attr = (struct bt_gatt_attr)BT_GATT_ATTRIBUTE(uuid_primary,
+			BT_GATT_PERM_READ, bt_gatt_attr_read_service, NULL,
+			uuid);
+
 	return 0;
 }
 
-int bt_gatt_pool_chrc_alloc(struct bt_gatt_pool *gp,
-			    struct bt_gatt_chrc const *chrc)
+int bt_gatt_pool_chrc_alloc(struct bt_gatt_pool *gp, u8_t props,
+			    struct bt_gatt_attr const *attr)
 {
 	int ret;
-	struct bt_gatt_attr *attr;
-	struct bt_uuid      *uuid_gatt_chrc = BT_UUID_GATT_CHRC;
-	struct bt_gatt_chrc *dest_chrc;
+	struct bt_gatt_attr *chrc_decl, *chrc_value;
+	struct bt_gatt_chrc *chrc;
+	struct bt_uuid *uuid = NULL;
 
-	if (!gp || !gp->svc.attrs || !chrc) {
+	if (!gp || !gp->svc.attrs || !attr) {
 		LOG_ERR("Invalid attribute");
 		return -EINVAL;
 	}
-	if (gp->svc.attr_count >= gp->attr_array_size) {
+	if ((gp->svc.attr_count + 2) > gp->attr_array_size) {
 		LOG_ERR("No space left on given svc");
 		return -ENOSPC;
 	}
 
-	attr = &gp->svc.attrs[gp->svc.attr_count];
-	memset(attr, 0, sizeof(*attr));
-
-	ret = uuid_register((struct bt_uuid **) &attr->uuid, uuid_gatt_chrc);
-	if (ret) {
-		return ret;
-	}
-	attr->perm = BT_GATT_PERM_READ;
-	attr->read = bt_gatt_attr_read_chrc;
-
-	/* Register user data for characteristic. */
-	ret = chrc_get((struct bt_gatt_chrc **) &attr->user_data);
-	if (ret) {
-		return ret;
-	}
-	dest_chrc = (struct bt_gatt_chrc *) attr->user_data;
-	memset(dest_chrc, 0, sizeof(*dest_chrc));
-	dest_chrc->properties = chrc->properties;
-	ret = uuid_register((struct bt_uuid **) &dest_chrc->uuid, chrc->uuid);
+	ret = chrc_get(&chrc);
 	if (ret) {
 		return ret;
 	}
 
-	gp->svc.attr_count++;
+	ret = uuid_register(&uuid, attr->uuid);
+	if (ret) {
+		chrc_release(chrc);
+		return ret;
+	}
+
+	/* Characteristic declaration attribute value */
+	*chrc = (struct bt_gatt_chrc) { .uuid = uuid,
+				       .value_handle = 0U,
+				       .properties = props };
+
+	/* Characteristic declaration attribute. */
+	chrc_decl = &gp->svc.attrs[gp->svc.attr_count++];
+	*chrc_decl = (struct bt_gatt_attr)BT_GATT_ATTRIBUTE(uuid_chrc,
+			BT_GATT_PERM_READ, bt_gatt_attr_read_chrc, NULL,
+			chrc);
+
+	/* Characteristic value attribute. */
+	chrc_value = &gp->svc.attrs[gp->svc.attr_count++];
+	*chrc_value = *attr;
+	chrc_value->uuid = uuid;
+
 	return 0;
 }
 
@@ -348,14 +349,15 @@ int bt_gatt_pool_desc_alloc(struct bt_gatt_pool *gp,
 {
 	int ret;
 	struct bt_gatt_attr *attr;
+	struct bt_uuid *uuid = NULL;
 
 	if (!gp || !gp->svc.attrs || !descriptor) {
 		LOG_ERR("Invalid attribute");
 		return -EINVAL;
 	}
-	if (!bt_uuid_cmp(descriptor->uuid, BT_UUID_GATT_PRIMARY) ||
-	    !bt_uuid_cmp(descriptor->uuid, BT_UUID_GATT_CHRC)    ||
-	    !bt_uuid_cmp(descriptor->uuid, BT_UUID_GATT_CCC)) {
+	if (!bt_uuid_cmp(descriptor->uuid, uuid_primary) ||
+	    !bt_uuid_cmp(descriptor->uuid, uuid_chrc)    ||
+	    !bt_uuid_cmp(descriptor->uuid, uuid_ccc)) {
 		LOG_ERR("Wrong function used for special attribute allocation");
 		return -EINVAL;
 	}
@@ -364,17 +366,15 @@ int bt_gatt_pool_desc_alloc(struct bt_gatt_pool *gp,
 		return -ENOSPC;
 	}
 
-	attr = &gp->svc.attrs[gp->svc.attr_count];
-	memset(attr, 0, sizeof(*attr));
-
-	memcpy(attr, descriptor, sizeof(*attr));
-	attr->uuid = NULL;
-	ret = uuid_register((struct bt_uuid **) &attr->uuid, descriptor->uuid);
+	ret = uuid_register(&uuid, descriptor->uuid);
 	if (ret) {
 		return ret;
 	}
 
-	gp->svc.attr_count++;
+	attr = &gp->svc.attrs[gp->svc.attr_count++];
+	*attr = *descriptor;
+	attr->uuid = uuid;
+
 	return 0;
 }
 
@@ -382,9 +382,7 @@ int bt_gatt_pool_ccc_alloc(struct bt_gatt_pool *gp,
 			   struct _bt_gatt_ccc *ccc,
 			   u8_t perm)
 {
-	int ret;
 	struct bt_gatt_attr *attr;
-	struct bt_uuid      *uuid_gatt_ccc = BT_UUID_GATT_CCC;
 
 	if (!gp || !gp->svc.attrs || !ccc || !perm) {
 		LOG_ERR("Invalid attribute");
@@ -397,14 +395,8 @@ int bt_gatt_pool_ccc_alloc(struct bt_gatt_pool *gp,
 
 	attr = &gp->svc.attrs[gp->svc.attr_count];
 	*attr = (struct bt_gatt_attr)BT_GATT_CCC_MANAGED(ccc, perm);
+	attr->uuid = uuid_ccc;
 
-	attr->uuid = NULL;
-	ret = uuid_register((struct bt_uuid **) &attr->uuid, uuid_gatt_ccc);
-	if (ret) {
-		return ret;
-	}
-
-	gp->svc.attr_count++;
 	return 0;
 }
 
@@ -484,5 +476,5 @@ void bt_gatt_pool_stats_print(void)
 	printk("\nPool element usage: %d out of %d\n\n", used_el_cnt,
 	       CONFIG_BT_GATT_CHRC_POOL_SIZE);
 #endif
-
+}
 #endif /* CONFIG_BT_GATT_POOL_STATS */

--- a/subsys/bluetooth/services/hids.c
+++ b/subsys/bluetooth/services/hids.c
@@ -760,25 +760,19 @@ hids_input_reports_register(struct bt_gatt_hids *hids_obj,
 
 		BT_GATT_POOL_CHRC(&hids_obj->gp,
 				  BT_UUID_HIDS_REPORT,
-				  BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY);
+				  BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY,
+				  rperm, hids_inp_rep_read, NULL,
+				  hids_inp_rep);
 
 		hids_inp_rep->att_ind = hids_obj->gp.svc.attr_count;
 		hids_inp_rep->offset = offset;
 		hids_inp_rep->idx = i;
 
-		BT_GATT_POOL_DESC(
-		    &hids_obj->gp,
-		    BT_GATT_DESCRIPTOR(BT_UUID_HIDS_REPORT,
-				       rperm,
-				       hids_inp_rep_read, NULL, hids_inp_rep));
-
 		BT_GATT_POOL_CCC(&hids_obj->gp, hids_inp_rep->ccc,
-				 hids_input_report_ccc_changed, wperm | rperm);
-		BT_GATT_POOL_DESC(
-		    &hids_obj->gp,
-		    BT_GATT_DESCRIPTOR(BT_UUID_HIDS_REPORT_REF,
-				       BT_GATT_PERM_READ, hids_inp_rep_ref_read,
-				       NULL, &hids_inp_rep->id));
+				 hids_input_report_ccc_changed,  wperm | rperm);
+		BT_GATT_POOL_DESC(&hids_obj->gp, BT_UUID_HIDS_REPORT_REF,
+				  BT_GATT_PERM_READ, hids_inp_rep_ref_read,
+				  NULL, &hids_inp_rep->id);
 		offset += hids_inp_rep->size;
 	}
 }
@@ -809,22 +803,17 @@ static void hids_outp_reports_register(struct bt_gatt_hids *hids_obj,
 		BT_GATT_POOL_CHRC(&hids_obj->gp,
 				  BT_UUID_HIDS_REPORT,
 				  BT_GATT_CHRC_READ | BT_GATT_CHRC_WRITE |
-				  BT_GATT_CHRC_WRITE_WITHOUT_RESP);
+				  BT_GATT_CHRC_WRITE_WITHOUT_RESP, perm,
+				  hids_outp_rep_read, hids_outp_rep_write,
+				  hids_outp_rep);
 
 		hids_outp_rep->att_ind = hids_obj->gp.svc.attr_count;
 		hids_outp_rep->offset = offset;
 		hids_outp_rep->idx = i;
 
-		BT_GATT_POOL_DESC(
-		    &hids_obj->gp,
-		    BT_GATT_DESCRIPTOR(BT_UUID_HIDS_REPORT, perm,
-				       hids_outp_rep_read, hids_outp_rep_write,
-				       hids_outp_rep));
-		BT_GATT_POOL_DESC(
-		    &hids_obj->gp,
-		    BT_GATT_DESCRIPTOR(
-			BT_UUID_HIDS_REPORT_REF, BT_GATT_PERM_READ,
-			hids_outp_rep_ref_read, NULL, &hids_outp_rep->id));
+		BT_GATT_POOL_DESC(&hids_obj->gp, BT_UUID_HIDS_REPORT_REF,
+				  BT_GATT_PERM_READ, hids_outp_rep_ref_read,
+				  NULL, &hids_outp_rep->id);
 
 		offset += hids_outp_rep->size;
 	}
@@ -855,22 +844,17 @@ static void hids_feat_reports_register(struct bt_gatt_hids *hids_obj,
 
 		BT_GATT_POOL_CHRC(&hids_obj->gp,
 				  BT_UUID_HIDS_REPORT,
-				  BT_GATT_CHRC_READ | BT_GATT_CHRC_WRITE);
+				  BT_GATT_CHRC_READ | BT_GATT_CHRC_WRITE, perm,
+				  hids_feat_rep_read, hids_feat_rep_write,
+				  hids_feat_rep);
 
 		hids_feat_rep->att_ind = hids_obj->gp.svc.attr_count;
 		hids_feat_rep->offset = offset;
 		hids_feat_rep->idx = i;
 
-		BT_GATT_POOL_DESC(
-		    &hids_obj->gp,
-		    BT_GATT_DESCRIPTOR(BT_UUID_HIDS_REPORT, perm,
-				       hids_feat_rep_read, hids_feat_rep_write,
-				       hids_feat_rep));
-		BT_GATT_POOL_DESC(
-		    &hids_obj->gp,
-		    BT_GATT_DESCRIPTOR(
-			BT_UUID_HIDS_REPORT_REF, BT_GATT_PERM_READ,
-			hids_feat_rep_ref_read, NULL, &hids_feat_rep->id));
+		BT_GATT_POOL_DESC(&hids_obj->gp, BT_UUID_HIDS_REPORT_REF,
+				  BT_GATT_PERM_READ, hids_feat_rep_ref_read,
+				  NULL, &hids_feat_rep->id);
 
 		offset += hids_feat_rep->size;
 	}
@@ -891,13 +875,10 @@ int bt_gatt_hids_init(struct bt_gatt_hids *hids_obj,
 	BT_GATT_POOL_CHRC(&hids_obj->gp,
 			  BT_UUID_HIDS_PROTOCOL_MODE,
 			  BT_GATT_CHRC_READ |
-			  BT_GATT_CHRC_WRITE_WITHOUT_RESP);
-	BT_GATT_POOL_DESC(
-	    &hids_obj->gp,
-	    BT_GATT_DESCRIPTOR(BT_UUID_HIDS_PROTOCOL_MODE,
-			       BT_GATT_PERM_READ | BT_GATT_PERM_WRITE,
-			       hids_protocol_mode_read,
-			       hids_protocol_mode_write, &hids_obj->pm));
+			  BT_GATT_CHRC_WRITE_WITHOUT_RESP,
+			  BT_GATT_PERM_READ | BT_GATT_PERM_WRITE,
+			  hids_protocol_mode_read, hids_protocol_mode_write,
+			  &hids_obj->pm);
 
 	/* Register Input Report characteristics. */
 	hids_input_reports_register(hids_obj, init_param);
@@ -914,11 +895,8 @@ int bt_gatt_hids_init(struct bt_gatt_hids *hids_obj,
 
 	BT_GATT_POOL_CHRC(&hids_obj->gp,
 			  BT_UUID_HIDS_REPORT_MAP,
-			  BT_GATT_CHRC_READ);
-	BT_GATT_POOL_DESC(
-	    &hids_obj->gp,
-	    BT_GATT_DESCRIPTOR(BT_UUID_HIDS_REPORT_MAP, BT_GATT_PERM_READ,
-			       hids_report_map_read, NULL, &hids_obj->rep_map));
+			  BT_GATT_CHRC_READ, BT_GATT_PERM_READ,
+			  hids_report_map_read, NULL, &hids_obj->rep_map);
 
 	/* Register HID Boot Mouse Input Report characteristic, its descriptor
 	 * and CCC.
@@ -928,20 +906,15 @@ int bt_gatt_hids_init(struct bt_gatt_hids *hids_obj,
 
 		BT_GATT_POOL_CHRC(&hids_obj->gp,
 				  BT_UUID_HIDS_BOOT_MOUSE_IN_REPORT,
-				  BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY);
+				  BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY,
+				  HIDS_GATT_PERM_DEFAULT & GATT_PERM_READ_MASK,
+				  hids_boot_mouse_inp_report_read, NULL,
+				  &hids_obj->boot_mouse_inp_rep);
 
 		hids_obj->boot_mouse_inp_rep.att_ind =
 			hids_obj->gp.svc.attr_count;
 		hids_obj->boot_mouse_inp_rep.handler =
 			init_param->boot_mouse_notif_handler;
-
-		BT_GATT_POOL_DESC(
-		    &hids_obj->gp,
-		    BT_GATT_DESCRIPTOR(
-			BT_UUID_HIDS_BOOT_MOUSE_IN_REPORT,
-			HIDS_GATT_PERM_DEFAULT & GATT_PERM_READ_MASK,
-			hids_boot_mouse_inp_report_read, NULL,
-			&hids_obj->boot_mouse_inp_rep));
 
 		BT_GATT_POOL_CCC(&hids_obj->gp,
 				 hids_obj->boot_mouse_inp_rep.ccc,
@@ -957,19 +930,14 @@ int bt_gatt_hids_init(struct bt_gatt_hids *hids_obj,
 
 		BT_GATT_POOL_CHRC(&hids_obj->gp,
 				  BT_UUID_HIDS_BOOT_KB_IN_REPORT,
-				  BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY);
+				  BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY,
+				  HIDS_GATT_PERM_DEFAULT & GATT_PERM_READ_MASK,
+				  hids_boot_kb_inp_report_read, NULL,
+				  &hids_obj->boot_kb_inp_rep);
 
 		hids_obj->boot_kb_inp_rep.att_ind = hids_obj->gp.svc.attr_count;
 		hids_obj->boot_kb_inp_rep.handler =
 		    init_param->boot_kb_notif_handler;
-
-		BT_GATT_POOL_DESC(
-		    &hids_obj->gp,
-		    BT_GATT_DESCRIPTOR(
-			BT_UUID_HIDS_BOOT_KB_IN_REPORT,
-			HIDS_GATT_PERM_DEFAULT & GATT_PERM_READ_MASK,
-			hids_boot_kb_inp_report_read, NULL,
-			&hids_obj->boot_kb_inp_rep));
 
 		BT_GATT_POOL_CCC(&hids_obj->gp,
 				 hids_obj->boot_kb_inp_rep.ccc,
@@ -979,20 +947,16 @@ int bt_gatt_hids_init(struct bt_gatt_hids *hids_obj,
 		BT_GATT_POOL_CHRC(&hids_obj->gp,
 				  BT_UUID_HIDS_BOOT_KB_OUT_REPORT,
 				  BT_GATT_CHRC_READ | BT_GATT_CHRC_WRITE |
-				  BT_GATT_CHRC_WRITE_WITHOUT_RESP);
+				  BT_GATT_CHRC_WRITE_WITHOUT_RESP,
+				  HIDS_GATT_PERM_DEFAULT,
+				  hids_boot_kb_outp_report_read,
+				  hids_boot_kb_outp_report_write,
+				  &hids_obj->boot_kb_outp_rep);
 
 		hids_obj->boot_kb_outp_rep.att_ind =
 			hids_obj->gp.svc.attr_count;
 		hids_obj->boot_kb_outp_rep.handler =
 			init_param->boot_kb_outp_rep_handler;
-
-		BT_GATT_POOL_DESC(
-		    &hids_obj->gp,
-		    BT_GATT_DESCRIPTOR(BT_UUID_HIDS_BOOT_KB_OUT_REPORT,
-				       HIDS_GATT_PERM_DEFAULT,
-				       hids_boot_kb_outp_report_read,
-				       hids_boot_kb_outp_report_write,
-				       &hids_obj->boot_kb_outp_rep));
 	}
 
 	/* Register HID Information characteristic and its descriptor. */
@@ -1000,20 +964,15 @@ int bt_gatt_hids_init(struct bt_gatt_hids *hids_obj,
 
 	BT_GATT_POOL_CHRC(&hids_obj->gp,
 			  BT_UUID_HIDS_INFO,
-			  BT_GATT_CHRC_READ);
-	BT_GATT_POOL_DESC(
-	    &hids_obj->gp,
-	    BT_GATT_DESCRIPTOR(BT_UUID_HIDS_INFO, BT_GATT_PERM_READ,
-			       hids_info_read, NULL, hids_obj->info));
+			  BT_GATT_CHRC_READ, BT_GATT_PERM_READ,
+			  hids_info_read, NULL, hids_obj->info);
 
 	/* Register HID Control Point characteristic and its descriptor. */
 	BT_GATT_POOL_CHRC(&hids_obj->gp,
 			  BT_UUID_HIDS_CTRL_POINT,
-			  BT_GATT_CHRC_WRITE_WITHOUT_RESP);
-	BT_GATT_POOL_DESC(
-	    &hids_obj->gp,
-	    BT_GATT_DESCRIPTOR(BT_UUID_HIDS_CTRL_POINT, BT_GATT_PERM_WRITE,
-			       NULL, hids_ctrl_point_write, &hids_obj->cp));
+			  BT_GATT_CHRC_WRITE_WITHOUT_RESP,
+			  BT_GATT_PERM_WRITE,
+			  NULL, hids_ctrl_point_write, &hids_obj->cp);
 
 	/* Register HIDS attributes in GATT database. */
 	return bt_gatt_service_register(&hids_obj->gp.svc);


### PR DESCRIPTION
Save UUID storage by using statically allocated UUIDs for services,
characteristics and CCC descriptor. Since these are very common is
wasteful to dynamcially allocate a copy for each instance required.
Also change signature of registering a characteristic. This avoids
having to register the same UUID twice for one characteristic.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>