### PR TITLE
drivers: lte_lc: Add function to get PSM configuration

### DIFF
--- a/drivers/lte_link_control/lte_lc.c
+++ b/drivers/lte_link_control/lte_lc.c
@@ -11,6 +11,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <device.h>
+#include <lte_lc.h>
 #include <at_cmd.h>
 #include <at_cmd_parser/at_cmd_parser.h>
 #include <at_cmd_parser/at_params.h>
@@ -18,15 +19,32 @@
 
 LOG_MODULE_REGISTER(lte_lc, CONFIG_LTE_LINK_CONTROL_LOG_LEVEL);
 
-#define LC_MAX_READ_LENGTH 128
-#define AT_CMD_SIZE(x) (sizeof(x) - 1)
+#define LC_MAX_READ_LENGTH		128
+#define AT_CMD_SIZE(x)			(sizeof(x) - 1)
+#define AT_CEREG_5			"AT+CEREG=5"
+#define AT_CEREG_READ			"AT+CEREG?"
+#define AT_CEREG_PARAMS_COUNT		10
+#define AT_CEREG_ACTIVE_TIME_INDEX	8
+#define AT_CEREG_TAU_INDEX		9
+#define AT_CEREG_RESPONSE_MAX_LEN	80
+
+/* Lookup table for T3324 timer used for PSM active time. Unit is seconds.
+ * Ref: GPRS Timer 2 IE in 3GPP TS 24.008 Table 10.5.163/3GPP TS 24.008.
+ */
+static const u32_t t3324_lookup[8] = {2, 60, 600, 60, 60, 60, 60, 0};
+
+/* Lookup table for T3412 timer used for periodic TAU. Unit is seconds.
+ * Ref: GPRS Timer 3 IE in 3GPP TS 24.008 Table 10.5.163a/3GPP TS 24.008.
+ */
+static const u32_t t3412_lookup[8] = {600, 3600, 36000, 2, 30, 60,
+				      1152000, 0};
 
 #if defined(CONFIG_BSD_LIBRARY_TRACE_ENABLED)
 /* Enable modem trace */
 static const char mdm_trace[] = "AT%XMODEMTRACE=1,2";
 #endif
-/* Subscribes to notifications with level 2 */
-static const char subscribe[] = "AT+CEREG=5";
+/* Subscribes to notifications with level 5 */
+static const char cereg_5_subscribe[] = AT_CEREG_5;
 
 #if defined(CONFIG_LTE_LOCK_BANDS)
 /* Lock LTE bands 3, 4, 13 and 20 (volatile setting) */
@@ -130,7 +148,7 @@ static int w_lte_lc_init(void)
 		return -EIO;
 	}
 #endif
-	if (at_cmd_write(subscribe, NULL, 0, NULL) != 0) {
+	if (at_cmd_write(cereg_5_subscribe, NULL, 0, NULL) != 0) {
 		return -EIO;
 	}
 
@@ -294,6 +312,105 @@ int lte_lc_psm_req(bool enable)
 	}
 
 	return 0;
+}
+
+int lte_lc_psm_get(int *tau, int *active_time)
+{
+	int err;
+	struct at_param_list at_resp_list = {0};
+	char buf[AT_CEREG_RESPONSE_MAX_LEN] = {0};
+	char timer_str[9] = {0};
+	char unit_str[4] = {0};
+	size_t timer_str_len = sizeof(timer_str) - 1;
+	size_t unit_str_len = sizeof(unit_str) - 1;
+	size_t index;
+	u32_t timer_unit, timer_value;
+
+	if ((tau == NULL) || (active_time == NULL)) {
+		return -EINVAL;
+	}
+
+	/* Enable network registration status with PSM information */
+	err = at_cmd_write(AT_CEREG_5, NULL, 0, NULL);
+	if (err) {
+		LOG_ERR("Could not set CEREG, error: %d", err);
+		return err;
+	}
+
+	/* Read network registration status */
+	err = at_cmd_write(AT_CEREG_READ, buf, sizeof(buf), NULL);
+	if (err) {
+		LOG_ERR("Could not get CEREG response, error: %d", err);
+		return err;
+	}
+
+	err = at_params_list_init(&at_resp_list, AT_CEREG_PARAMS_COUNT);
+	if (err) {
+		LOG_ERR("Could not init AT params list, error: %d", err);
+		return err;
+	}
+
+	err = at_parser_max_params_from_str(buf,
+					    NULL,
+					    &at_resp_list,
+					    AT_CEREG_PARAMS_COUNT);
+	if (err) {
+		LOG_ERR("Could not parse AT+CEREG response, error: %d", err);
+		goto parse_psm_clean_exit;
+	}
+
+	/* Parse periodic TAU string */
+	err = at_params_string_get(&at_resp_list,
+				   AT_CEREG_TAU_INDEX,
+				   timer_str,
+				   &timer_str_len);
+	if (err) {
+		LOG_ERR("Could not get TAU, error: %d", err);
+		goto parse_psm_clean_exit;
+	}
+
+	memcpy(unit_str, timer_str, unit_str_len);
+
+	index = strtoul(unit_str, NULL, 2);
+	if (index > (ARRAY_SIZE(t3412_lookup) - 1)) {
+		LOG_ERR("Unable to parse periodic TAU string");
+		err = -EINVAL;
+		goto parse_psm_clean_exit;
+	}
+
+	timer_unit = t3412_lookup[index];
+	timer_value = strtoul(timer_str + unit_str_len, NULL, 2);
+	*tau = timer_unit ? timer_unit * timer_value : -1;
+
+	/* Parse active time string */
+	err = at_params_string_get(&at_resp_list,
+				   AT_CEREG_ACTIVE_TIME_INDEX,
+				   timer_str,
+				   &timer_str_len);
+	if (err) {
+		LOG_ERR("Could not get TAU, error: %d", err);
+		goto parse_psm_clean_exit;
+	}
+
+	memcpy(unit_str, timer_str, unit_str_len);
+
+	index = strtoul(unit_str, NULL, 2);
+	if (index > (ARRAY_SIZE(t3324_lookup) - 1)) {
+		LOG_ERR("Unable to parse active time string");
+		err = -EINVAL;
+		goto parse_psm_clean_exit;
+	}
+
+	timer_unit = t3324_lookup[index];
+	timer_value = strtoul(timer_str + unit_str_len, NULL, 2);
+	*active_time = timer_unit ? timer_unit * timer_value : -1;
+
+	LOG_DBG("TAU: %d sec, active time: %d sec\n", *tau, *active_time);
+
+parse_psm_clean_exit:
+	at_params_list_free(&at_resp_list);
+
+	return err;
 }
 
 int lte_lc_edrx_req(bool enable)

--- a/include/lte_lc.h
+++ b/include/lte_lc.h
@@ -61,6 +61,19 @@ int lte_lc_normal(void);
  */
 int lte_lc_psm_req(bool enable);
 
+/* @brief Function for getting the current PSM (Power Saving Mode)
+ *	  configurations for periodic TAU (Tracking Area Update) and
+ *	  active time, both in units of seconds.
+ *
+ * @param tau Pointer to the variable for parsed periodic TAU interval in
+ *	      seconds. Positive integer, or -1 if timer is deactivated.
+ * @param active_time Pointer to the variable for parsed active time in seconds.
+ *		      Positive integer, or -1 if timer is deactivated.
+ *
+ * @return Zero on success or (negative) error code otherwise.
+ */
+int lte_lc_psm_get(int *tau, int *active_time);
+
 /** @brief Function for requesting modem to use eDRX or disable
  * use of values defined in kconfig.
  * For reference see 3GPP 27.007 Ch. 7.40.


### PR DESCRIPTION
Adds a function to get the periodic TAU and active time
settings from the current network registration status.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>