### PR TITLE
lib: modem_info: add modem info as JSON objects

### DIFF
--- a/include/modem_info.h
+++ b/include/modem_info.h
@@ -187,9 +187,10 @@ enum at_param_type modem_info_type_get(enum modem_info info);
 #ifdef CONFIG_CJSON_LIB
 /** @brief Encode the modem parameters.
  *
- * The data is stored to a JSON object.
+ * The data is added to the string buffer with JSON formatting.
  *
- * @param buf  The JSON object where the data is stored.
+ * @param modem_param Pointer to the modem parameter structure.
+ * @param buf         The buffer where the string will be written.
  *
  * @return Length of the string buffer data if the operation was
  *         successful.
@@ -201,12 +202,13 @@ int modem_info_json_string_encode(struct modem_param_info *modem_param,
 
 /** @brief Encode the modem parameters.
  *
- * The data is added to the string buffer with JSON formatting.
+ * The data is stored to a JSON object.
  *
- * @param root_obj  The JSON object where to store the data.
+ * @param modem_param Pointer to the modem parameter structure.
+ * @param root_obj    The JSON object where to store the data.
  *
- * @return Length of the string buffer data if the operation was
- *         successful.
+ * @return Number of JSON objects added to root_obj if the
+ *         operation was successful.
  *         Otherwise, a (negative) error code is returned.
  */
 int modem_info_json_object_encode(struct modem_param_info *modem,

--- a/lib/modem_info/modem_info_json.c
+++ b/lib/modem_info/modem_info_json.c
@@ -180,59 +180,40 @@ static int device_data_add(struct device_param *device, cJSON *json_obj)
 int modem_info_json_object_encode(struct modem_param_info *modem,
 				  cJSON *root_obj)
 {
-	int total_len = 0;
-	int ret;
-
 	if (root_obj == NULL || modem == NULL) {
 		return -EINVAL;
 	}
+
+	int obj_count = cJSON_GetArraySize(root_obj);
 
 	cJSON *network_obj	= cJSON_CreateObject();
 	cJSON *sim_obj		= cJSON_CreateObject();
 	cJSON *device_obj	= cJSON_CreateObject();
 
 	if (network_obj == NULL || sim_obj == NULL || device_obj == NULL) {
-		total_len = -ENOMEM;
+		obj_count = -ENOMEM;
 		goto delete_object;
 	}
 
-	if (IS_ENABLED(CONFIG_MODEM_INFO_ADD_NETWORK)) {
-		ret = network_data_add(&modem->network, network_obj);
+	if (IS_ENABLED(CONFIG_MODEM_INFO_ADD_NETWORK) &&
+	    (network_data_add(&modem->network, network_obj) > 0)) {
 
-		if (ret < 0) {
-			total_len = ret;
-			goto delete_object;
-		}
-
-		total_len += ret;
-		json_add_str(root_obj, "networkInfo",
-			     cJSON_PrintUnformatted(network_obj));
+		json_add_obj(root_obj, "networkInfo", network_obj);
+		network_obj = NULL;
 	}
 
-	if (IS_ENABLED(CONFIG_MODEM_INFO_ADD_SIM)) {
-		ret = sim_data_add(&modem->sim, sim_obj);
+	if (IS_ENABLED(CONFIG_MODEM_INFO_ADD_SIM) &&
+	    (sim_data_add(&modem->sim, sim_obj) > 0)) {
 
-		if (ret < 0) {
-			total_len = ret;
-			goto delete_object;
-		}
-
-		total_len += ret;
-		json_add_str(root_obj, "simInfo",
-			     cJSON_PrintUnformatted(sim_obj));
+		json_add_obj(root_obj, "simInfo", sim_obj);
+		sim_obj = NULL;
 	}
 
-	if (IS_ENABLED(CONFIG_MODEM_INFO_ADD_DEVICE)) {
-		ret = device_data_add(&modem->device, device_obj);
+	if (IS_ENABLED(CONFIG_MODEM_INFO_ADD_DEVICE) &&
+	    (device_data_add(&modem->device, device_obj) > 0)) {
 
-		if (ret < 0) {
-			total_len = ret;
-			goto delete_object;
-		}
-
-		total_len += ret;
-		json_add_str(root_obj, "deviceInfo",
-			     cJSON_PrintUnformatted(device_obj));
+		json_add_obj(root_obj, "deviceInfo", device_obj);
+		device_obj = NULL;
 	}
 
 delete_object:
@@ -240,7 +221,11 @@ delete_object:
 	cJSON_Delete(sim_obj);
 	cJSON_Delete(device_obj);
 
-	return total_len;
+	if (obj_count >= 0) {
+		obj_count = cJSON_GetArraySize(root_obj) - obj_count;
+	}
+
+	return obj_count;
 }
 
 int modem_info_json_string_encode(struct modem_param_info *modem,


### PR DESCRIPTION
modem info should be added as JSON objects instead of strings so that proper JSON format (e.g. no escaped double quotes) is produced when printed.
fixed function descriptions.

Signed-off-by: Justin Morton <justin.morton@nordicsemi.no>