### PR TITLE
lib: bsdlib: add missing offloading of PDN protocol

### DIFF
--- a/lib/bsdlib/nrf91_sockets.c
+++ b/lib/bsdlib/nrf91_sockets.c
@@ -254,6 +254,8 @@ static int nrf_to_z_protocol(int proto)
 		return IPPROTO_UDP;
 	case NRF_SPROTO_TLS1v2:
 		return IPPROTO_TLS_1_2;
+	case NRF_PROTO_PDN:
+		return NPROTO_PDN;
 	case NRF_PROTO_AT:
 		return NPROTO_AT;
 	case 0:


### PR DESCRIPTION
Add missing offloading of `NRF_PROTO_PDN`.

Note this is independent of any pending PR to `nrfxlib`.