### PR TITLE
west: manifest update for zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -38,7 +38,7 @@ manifest:
     - name: zephyr
       repo-path: fw-nrfconnect-zephyr
       west-commands: scripts/west-commands.yml
-      revision: pull/198/head
+      revision: 7bdbccb96778d4dcd041e57a1eaa30dd86f75386
     - name: nffs
       revision: bc62a2fa9d98ddb5d633c932ea199bc68e10f194
       path: modules/fs/nffs


### PR DESCRIPTION
Update Zephyr revision to point to a SHA instead of a PR.

Signed-off-by: Emanuele Di Santo <emdi@nordicsemi.no>