### PR TITLE
fw_metadata: Restrict possible offsets to 0x200, 0x400, and 0x800.

### DIFF
--- a/samples/bootloader/src/main.c
+++ b/samples/bootloader/src/main.c
@@ -36,7 +36,7 @@ static bool verify_firmware(u32_t address)
 	const struct fw_firmware_info *fw_info;
 	const struct fw_validation_info *fw_ver_info;
 
-	fw_info = fw_firmware_info_get(address);
+	fw_info = fw_find_firmware_info(address);
 
 	if (!fw_info) {
 		printk("Could not find valid firmware info inside "
@@ -161,7 +161,7 @@ static void boot_from(const struct fw_firmware_info *fw_info)
 
 	VTOR = fw_info->firmware_address;
 
-	fw_abi_provide(fw_info->firmware_address);
+	fw_abi_provide(fw_info);
 
 	/* Set MSP to the new address and clear any information from PSP */
 	__set_MSP(vector_table[0]);
@@ -183,8 +183,8 @@ void main(void)
 
 	u32_t s0_addr = s0_address_read();
 	u32_t s1_addr = s1_address_read();
-	const struct fw_firmware_info *s0_info = fw_firmware_info_get(s0_addr);
-	const struct fw_firmware_info *s1_info = fw_firmware_info_get(s1_addr);
+	const struct fw_firmware_info *s0_info = fw_find_firmware_info(s0_addr);
+	const struct fw_firmware_info *s1_info = fw_find_firmware_info(s1_addr);
 
 	if (!s1_info || (s0_info->firmware_version >=
 			 s1_info->firmware_version)) {

--- a/subsys/fw_metadata/Kconfig
+++ b/subsys/fw_metadata/Kconfig
@@ -18,11 +18,13 @@ config FW_VALIDATION_METADATA_OFFSET
 	  aligned to closest word.
 
 config FW_FIRMWARE_INFO_OFFSET
-	hex "The location of firmware info inside firmware."
-	default 0x800
+	hex "The location of firmware info inside this firmware."
+	default 0x200
 	help
-	  Note that all space between the vector table and this address will be
-	  unused.
+	  The location of firmware info inside the current firmware image. Valid
+	  values are 0x200, 0x400 and 0x800. Compatible readers of FW info
+	  should search all the possible offsets. Note that all space between
+	  the vector table and this address is unused.
 
 config FW_FIRMWARE_VERSION
 	int "Version number of the firmware."

--- a/subsys/fw_metadata/fw_metadata.c
+++ b/subsys/fw_metadata/fw_metadata.c
@@ -49,12 +49,10 @@ __fw_info struct fw_firmware_info m_firmware_info =
 	.abi_out = &abi_getter,
 };
 
-void fw_abi_provide(u32_t address)
+void fw_abi_provide(const struct fw_firmware_info *fw_info)
 {
-	const struct fw_firmware_info *their_fw_info = fw_firmware_info_get(address);
-
-	if (their_fw_info != NULL && their_fw_info->abi_in != NULL) {
-		*(their_fw_info->abi_in) = &abi_getter;
+	if (fw_info->abi_in != NULL) {
+		*(fw_info->abi_in) = &abi_getter;
 	}
 }
 


### PR DESCRIPTION
When getting the fw_info, search all possible locations.
Make 0x200 the default.
Rename fw_firmware_info_get() -> fw_firmware_info_find().
Change fw_abi_provide to take fw_info instead of address.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>