### PR TITLE
Add support for Nordic proprietary BLE Controller v0.3.0-2.prealpha

### DIFF
--- a/doc/nrfxlib/nrfxlib.doxyfile.in
+++ b/doc/nrfxlib/nrfxlib.doxyfile.in
@@ -1965,6 +1965,7 @@ PREDEFINED             = "MBEDTLS_CONFIG_FILE=\"@NRFXLIB_BINARY_DIR@/mbedtls_dox
                          "BUILD_ASSERT_MSG()=" \
                          "BUILD_ASSERT()=" \
                          "__deprecated=" \
+                         "__PACKED_STRUCT=struct" \
                          "__packed=" \
                          "__aligned(x)=" \
                          "__printf_like(x, y)=" \

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -34,12 +34,4 @@ choice BLE_CONTROLLER_VARIANT
 
 endchoice
 
-config BLECTRL_MEMPOOL_SIZE
-	int "Reserved RAM for the BLE controller"
-	default 5344
-	help
-	  Reserved RAM for the BLE Controller. This size is dependent on the
-	  configuration set before the controller is enabled. If the size is too
-	  small, the HCI driver initialization will return an error.
-
 endmenu

--- a/west.yml
+++ b/west.yml
@@ -72,7 +72,7 @@ manifest:
       revision: 30b7efa827b04d2e47840716b0372737fe7d6c92
     - name: nrfxlib
       path: nrfxlib
-      revision: 0f140413f675b802f408a547bf66e74ae6ac4ed1
+      revision: 550c8a937cdc79e28ffefc070746a9fda694d4c4
     - name: cmock
       path: test/cmock
       revision: c243b9a7a7b3c471023193992b46cf1bd1910450


### PR DESCRIPTION
Use the new API to determine additional memory requirements per link,
instead of relying on the user to determine `BLECTRL_MEMPOOL_SIZE`

I did a basic smoke-test on the following examples:

sample_name |KConfig changes
----------------|------------------
nrf/samples/bluetooth/throughput|Selected "Nordic proprietary BLE Link Layer"
nrf/samples/bluetooth/central_uart|Selected "Nordic proprietary BLE Link Layer"
nrf/samples/bluetooth/peripheral_uart|Selected "Nordic proprietary BLE Link Layer", changed "BT_HCI_TX_STACK_SIZE" to 1024
zephyr/samples/bluetooth/peripheral_hr|Selected "Nordic proprietary BLE Link Layer", changed "BT_HCI_TX_STACK_SIZE" to 1024