### PR TITLE
secure_services: add function to read fw_metadata

### DIFF
--- a/include/fw_metadata.h
+++ b/include/fw_metadata.h
@@ -24,9 +24,11 @@
 #include <stddef.h>
 #include <toolchain.h>
 #include <sys/util.h>
-#include <assert.h>
+#include <sys/__assert.h>
 #include <string.h>
+#if USE_PARTITION_MANAGER
 #include <pm_config.h>
+#endif
 
 #define MAGIC_LEN_WORDS (CONFIG_FW_MAGIC_LEN / sizeof(u32_t))
 

--- a/include/secure_services.h
+++ b/include/secure_services.h
@@ -22,6 +22,7 @@
 
 #include <stddef.h>
 #include <zephyr/types.h>
+#include <fw_metadata.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -65,6 +66,16 @@ int spm_request_random_number(u8_t *output, size_t len, size_t *olen);
  */
 int spm_request_read(void *destination, u32_t addr, size_t len);
 
+/** Search for the firmware_info structure in firmware image located at address.
+ *
+ * @param[in]   firmware_address Address where firmware image is stored.
+ * @param[out]  info		 Pointer to where found info is stored.
+ *
+ * @retval 0        If successful.
+ * @retval -EINVAL  If info is NULL.
+ * @retval -EFAULT  If no info is found.
+ */
+int spm_firmware_info(u32_t fw_address, struct fw_firmware_info *info);
 
 #ifdef __cplusplus
 }

--- a/samples/nrf9160/secure_services/src/main.c
+++ b/samples/nrf9160/secure_services/src/main.c
@@ -10,6 +10,7 @@
 #include <secure_services.h>
 #include <kernel.h>
 #include <pm_config.h>
+#include <fw_metadata.h>
 
 void print_hex_number(u8_t *num, size_t len)
 {
@@ -28,6 +29,7 @@ void print_random_number(u8_t *num, size_t len)
 
 void main(void)
 {
+	struct fw_firmware_info info_app;
 	const int sleep_time_s = 5;
 	const int random_number_count = 16;
 	const int random_number_len = 144;
@@ -49,6 +51,13 @@ void main(void)
 		}
 		print_random_number(random_number, olen);
 	}
+
+	ret = spm_firmware_info(PM_APP_ADDRESS, &info_app);
+	if (ret != 0) {
+		printk("Could find firmware info (err: %d)\n", ret);
+	}
+
+	printk("App FW version: %d\n", info_app.firmware_version);
 
 #ifdef CONFIG_BOOTLOADER_MCUBOOT
 	const int num_bytes_to_read = PM_MCUBOOT_PAD_SIZE;

--- a/samples/nrf9160/spm/prj.conf
+++ b/samples/nrf9160/spm/prj.conf
@@ -4,4 +4,5 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 CONFIG_IS_SPM=y
+CONFIG_FW_METADATA=y
 CONFIG_GPIO=n

--- a/subsys/spm/Kconfig
+++ b/subsys/spm/Kconfig
@@ -9,6 +9,7 @@ menu "SPM"
 config SPM
 	bool "Use Secure Partition Manager"
 	default y if TRUSTED_EXECUTION_NONSECURE
+	select FW_METADATA
 	imply ARM_FIRMWARE_USES_SECURE_ENTRY_FUNCS
 
 if SPM

--- a/subsys/spm/Kconfig
+++ b/subsys/spm/Kconfig
@@ -74,7 +74,16 @@ config SPM_SERVICE_REBOOT
 	  If Non-Secure Firmware is blocked from issuing system reset, this
 	  service will allow it to issue a request to do a system reset through
 	  a secure service.
-endif
+
+config SPM_SERVICE_FIND_FIRMWARE_INFO
+	bool "Find firmware info"
+	default y
+	help
+	  The Non-Secure Firmware is not allowed to read the memory
+	  marked as secure. This service allows it to request firmware info
+	  about image stored at a given address.
+
+endif # SPM_SECURE_SERVICES
 
 config SPM_BLOCK_NON_SECURE_RESET
 	bool "Block system reset calls from Non-Secure domain"

--- a/subsys/spm/secure_services.c
+++ b/subsys/spm/secure_services.c
@@ -14,6 +14,9 @@
 #if USE_PARTITION_MANAGER
 #include <pm_config.h>
 #endif
+#ifdef CONFIG_SPM_SERVICE_FIND_FIRMWARE_INFO
+#include <fw_metadata.h>
+#endif
 
 /*
  * Secure Entry functions to allow access to secure services from non-secure
@@ -45,7 +48,6 @@ int spm_secure_services_init(void)
 #endif
 	return err;
 }
-
 
 #ifdef CONFIG_SPM_SERVICE_READ
 struct read_range {
@@ -105,3 +107,24 @@ int spm_request_random_number(u8_t *output, size_t len, size_t *olen)
 	return err;
 }
 #endif /* CONFIG_SPM_SERVICE_RNG */
+
+#ifdef CONFIG_SPM_SERVICE_FIND_FIRMWARE_INFO
+__TZ_NONSECURE_ENTRY_FUNC
+int spm_firmware_info(u32_t fw_address, struct fw_firmware_info *info)
+{
+	const struct fw_firmware_info *tmp_info;
+
+	if (info == NULL) {
+		return -EINVAL;
+	}
+
+	tmp_info = fw_find_firmware_info(fw_address);
+
+	if (tmp_info != NULL) {
+		memcpy(info, tmp_info, sizeof(*tmp_info));
+		return 0;
+	}
+
+	return -EFAULT;
+}
+#endif


### PR DESCRIPTION
This will be used to check what slot of B1 is active.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>