### PR TITLE
applications: nrf_desktop: Fix storing Fn lock state

### DIFF
--- a/applications/nrf_desktop/src/modules/Kconfig.fn_keys
+++ b/applications/nrf_desktop/src/modules/Kconfig.fn_keys
@@ -28,6 +28,7 @@ config DESKTOP_FN_KEYS_LOCK
 config DESKTOP_STORE_FN_LOCK
 	bool "Store Fn lock state"
 	default y
+	depends on SETTINGS
 	help
 	  Define if device should store Fn lock state after reboot.
 

--- a/applications/nrf_desktop/src/modules/fn_keys.c
+++ b/applications/nrf_desktop/src/modules/fn_keys.c
@@ -101,8 +101,7 @@ static bool fn_key_enabled(u16_t key_id)
 
 static void store_fn_lock(void)
 {
-	if (IS_ENABLED(CONFIG_SETTINGS) &&
-	    IS_ENABLED(CONFIG_DESKTOP_STORE_FN_LOCK)) {
+	if (IS_ENABLED(CONFIG_DESKTOP_STORE_FN_LOCK)) {
 		char key[] = MODULE_NAME "/" FN_LOCK_STORAGE_NAME;
 
 		int err = settings_save_one(key, &fn_lock_active,
@@ -206,8 +205,7 @@ static int settings_set(const char *key, size_t len_rd,
 
 static int init_settings(void)
 {
-	if (IS_ENABLED(CONFIG_SETTINGS) &&
-	    IS_ENABLED(CONFIG_DESKTOP_STORE_FN_LOCK)) {
+	if (IS_ENABLED(CONFIG_DESKTOP_STORE_FN_LOCK)) {
 		static struct settings_handler sh = {
 			.name = MODULE_NAME,
 			.h_set = settings_set,


### PR DESCRIPTION
Change makes DESKTOP_STORE_FN_LOCK option depend on SETTINGS.
Selecting the option without SETTINGS enabled would have no effect.