### PR TITLE
manifest: Update manifest to include nrf cc310 crypto v0.9.0.

### DIFF
--- a/subsys/spm/secure_services.c
+++ b/subsys/spm/secure_services.c
@@ -32,10 +32,6 @@
 
 #include <mbedtls/platform.h>
 #include <mbedtls/entropy_poll.h>
-
-/** @brief Structure holding the memory required to generate entropy
- */
-static mbedtls_rng_workbuf_internal rng_workbuf;
 #endif /* CONFIG_SPM_SERVICE_RNG */
 
 
@@ -44,9 +40,7 @@ int spm_secure_services_init(void)
 	int err = 0;
 
 #ifdef CONFIG_SPM_SERVICE_RNG
-	mbedtls_platform_context platform_ctx = {
-		.p_rnd_workbuf = &rng_workbuf
-	};
+	mbedtls_platform_context platform_ctx = {0};
 	err = mbedtls_platform_setup(&platform_ctx);
 #endif
 	return err;
@@ -107,7 +101,7 @@ int spm_request_random_number(u8_t *output, size_t len, size_t *olen)
 		return -EINVAL;
 	}
 
-	err = mbedtls_hardware_poll(&rng_workbuf, output, len, olen);
+	err = mbedtls_hardware_poll(NULL, output, len, olen);
 	return err;
 }
 #endif /* CONFIG_SPM_SERVICE_RNG */

--- a/west.yml
+++ b/west.yml
@@ -72,7 +72,7 @@ manifest:
       revision: 30b7efa827b04d2e47840716b0372737fe7d6c92
     - name: nrfxlib
       path: nrfxlib
-      revision: 550c8a937cdc79e28ffefc070746a9fda694d4c4
+      revision: 4d3fa41a8ded0808242a3cb3edca3bc29c04e5e3
     - name: cmock
       path: test/cmock
       revision: c243b9a7a7b3c471023193992b46cf1bd1910450


### PR DESCRIPTION
Update nrfxlib revision to 4d3fa41a8ded0808242a3cb3edca3bc29c04e5e3 to support use of nrf cc310
crypto v0.9.0.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>