### PR TITLE
Fix modem_info memory leak

### DIFF
--- a/ext/cjson/cJSON_os.c
+++ b/ext/cjson/cJSON_os.c
@@ -25,3 +25,8 @@ void cJSON_Init(void)
 
 	cJSON_InitHooks(&_cjson_hooks);
 }
+
+void cJSON_FreeString(char *ptr)
+{
+	free_fn_hook(ptr);
+}

--- a/ext/cjson/cJSON_os.h
+++ b/ext/cjson/cJSON_os.h
@@ -14,4 +14,11 @@
  */
 void cJSON_Init(void);
 
+/**
+ * @brief Free a string created and returned by cJSON.
+ * @return returns the return value of the free implementation.
+ * @param ptr IN -- pointer to string to free
+ */
+void cJSON_FreeString(char *ptr);
+
 #endif /* cJSON_OS_H__ */

--- a/lib/modem_info/modem_info_json.c
+++ b/lib/modem_info/modem_info_json.c
@@ -8,6 +8,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <cJSON.h>
+#include <cJSON_os.h>
 #include <modem_info.h>
 #include <at_cmd_parser/at_params.h>
 #include <logging/log.h>
@@ -292,9 +293,11 @@ int modem_info_json_string_encode(struct modem_param_info *modem,
 	}
 
 	if (total_len > 0) {
-		memcpy(buf,
-		       cJSON_PrintUnformatted(root_obj),
+		char *root_obj_string = cJSON_PrintUnformatted(root_obj);
+
+		memcpy(buf, root_obj_string,
 		       MODEM_INFO_JSON_STRING_SIZE);
+		cJSON_FreeString(root_obj_string);
 	}
 
 delete_object:


### PR DESCRIPTION
Adds a  CJSON_FreeString and uses it to fix a memory leak. Resolves NCSDK-3034.