### PR TITLE
Bluetooth: Mesh: Generic models

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -32,6 +32,7 @@
 /include/debug/ppi_trace.h                @nordic-krch
 /include/                                 @anangl @rlubos @pizi-nordic
 /include/bluetooth/                       @joerchan
+/include/bluetooth/mesh/                  @trond-snekvik @joerchan
 /include/drivers/                         @anangl
 /include/net/                             @rlubos
 /include/nfc/                             @anangl @grochu
@@ -57,6 +58,7 @@ subsys/debug/CMakeLists.txt               @nordic-krch
 /scripts/                                 @mbolivar @tejlmand
 /scripts/hid_configurator/                @pdunaj
 /subsys/bluetooth/                        @joerchan @carlescufi
+/subsys/bluetooth/mesh/                   @trond-snekvik @joerchan
 /subsys/bootloader/                       @hakonfam @ioannisg
 /subsys/enhanced_shockburst/              @Raane @lemrey
 /subsys/event_manager/                    @pdunaj

--- a/include/bluetooth/mesh.rst
+++ b/include/bluetooth/mesh.rst
@@ -1,33 +1,17 @@
 .. _bt_mesh:
 
-Bluetooth Mesh Models
-######################
+Bluetooth Mesh Profile
+#######################
 
-Nordic Semiconductor provides a variety of model implementations from the Mesh
-Model Specification.
+The nRF Connect SDK has experimental support for the Bluetooth Mesh
+Specification through the Zephyr :ref:`zephyr:bluetooth_mesh` implementation.
 
-Here you can find documentation for these model implementations, including API
-documentation.
+Nordic Semiconductor additionally provides some modules to aid in the
+development of Bluetooth Mesh-based applications:
 
 .. toctree::
    :maxdepth: 1
-   :caption: Model implementations:
-   :glob:
 
-   ../../include/bluetooth/mesh/*
+   mesh/models.rst
+   mesh/properties.rst
 
-
-Common model types
-===================
-
-Models in the Bluetooth Mesh Model Specification share some common types, that
-are collected in a single header file.
-
-API documentation
-******************
-
-| Header file: :file:`include/bluetooth/mesh/model_types.h`
-
-.. doxygengroup:: bt_mesh_model_types
-   :project: nrf
-   :members:

--- a/include/bluetooth/mesh.rst
+++ b/include/bluetooth/mesh.rst
@@ -1,0 +1,33 @@
+.. _bt_mesh:
+
+Bluetooth Mesh Models
+######################
+
+Nordic Semiconductor provides a variety of model implementations from the Mesh
+Model Specification.
+
+Here you can find documentation for these model implementations, including API
+documentation.
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Model implementations:
+   :glob:
+
+   ../../include/bluetooth/mesh/*
+
+
+Common model types
+===================
+
+Models in the Bluetooth Mesh Model Specification share some common types, that
+are collected in a single header file.
+
+API documentation
+******************
+
+| Header file: :file:`include/bluetooth/mesh/model_types.h`
+
+.. doxygengroup:: bt_mesh_model_types
+   :project: nrf
+   :members:

--- a/include/bluetooth/mesh/gen_battery.h
+++ b/include/bluetooth/mesh/gen_battery.h
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/**
+ * @file
+ * @defgroup bt_mesh_battery Generic Battery models
+ * @{
+ * @brief API for the Generic Battery models.
+ */
+
+#ifndef BT_MESH_GEN_BATTERY_H__
+#define BT_MESH_GEN_BATTERY_H__
+
+#include <bluetooth/mesh.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @cond INTERNAL_HIDDEN */
+#define BT_MESH_BATTERY_OP_GET BT_MESH_MODEL_OP_2(0x82, 0x23)
+#define BT_MESH_BATTERY_OP_STATUS BT_MESH_MODEL_OP_2(0x82, 0x24)
+
+#define BT_MESH_BATTERY_MSG_LEN_GET 0
+#define BT_MESH_BATTERY_MSG_LEN_STATUS 8
+/** @endcond */
+
+/** Unknown battery level. */
+#define BT_MESH_BATTERY_LVL_UNKNOWN 0xff
+
+/** Longest acceptable charge and discharge time in minutes */
+#define BT_MESH_BATTERY_TIME_MAX 0xfffffe
+/** Unknown discharge time */
+#define BT_MESH_BATTERY_TIME_UNKNOWN 0xffffff
+
+/** Battery presence state. */
+enum bt_mesh_battery_presence {
+	/** The battery is not present. */
+	BT_MESH_BATTERY_PRESENCE_NOT_PRESENT,
+	/** The battery is present and is removable. */
+	BT_MESH_BATTERY_PRESENCE_PRESENT_REMOVABLE,
+	/** The battery is present and is non-removable. */
+	BT_MESH_BATTERY_PRESENCE_PRESENT_NOT_REMOVABLE,
+	/** The battery presence is unknown. */
+	BT_MESH_BATTERY_PRESENCE_UNKNOWN,
+};
+
+/** Indicator for the charge level of the battery. */
+enum bt_mesh_battery_indicator {
+	/** The battery charge is Critically Low Level. */
+	BT_MESH_BATTERY_INDICATOR_CRITICALLY_LOW,
+	/** The battery charge is Low Level. */
+	BT_MESH_BATTERY_INDICATOR_LOW,
+	/** The battery charge is Good Level. */
+	BT_MESH_BATTERY_INDICATOR_GOOD,
+	/** The battery charge is unknown. */
+	BT_MESH_BATTERY_INDICATOR_UNKNOWN,
+};
+
+/** Battery charging state. */
+enum bt_mesh_battery_charging {
+	/** The battery is not chargeable. */
+	BT_MESH_BATTERY_CHARGING_NOT_CHARGEABLE,
+	/** The battery is chargeable and is not charging. */
+	BT_MESH_BATTERY_CHARGING_CHARGEABLE_NOT_CHARGING,
+	/** The battery is chareable and is charging. */
+	BT_MESH_BATTERY_CHARGING_CHARGEABLE_CHARGING,
+	/** The battery charging state is unknown. */
+	BT_MESH_BATTERY_CHARGING_UNKNOWN,
+};
+
+/** Battery service state. */
+enum bt_mesh_battery_service {
+	/** Reserved for future use. */
+	BT_MESH_BATTERY_SERVICE_INVALID,
+	/** The battery does not require service. */
+	BT_MESH_BATTERY_SERVICE_NOT_REQUIRED,
+	/** The battery requires service. */
+	BT_MESH_BATTERY_SERVICE_REQUIRED,
+	/** The battery servicability is unknown. */
+	BT_MESH_BATTERY_SERVICE_UNKNOWN,
+};
+
+struct bt_mesh_battery_status {
+	/**
+	 * Current battery level in percent, or
+	 * @ref BT_MESH_BATTERY_LVL_UNKNOWN.
+	 */
+	u8_t battery_lvl;
+	/** Minutes until discharged, or @ref BT_MESH_BATTERY_TIME_UNKNOWN. */
+	u32_t discharge_minutes;
+	/** Minutes until discharged, or @ref BT_MESH_BATTERY_TIME_UNKNOWN. */
+	u32_t charge_minutes;
+	/** Presence state. */
+	enum bt_mesh_battery_presence presence;
+	/** Charge level indicator. */
+	enum bt_mesh_battery_indicator indicator;
+	/** Charging state. */
+	enum bt_mesh_battery_charging charging;
+	/** Service state. */
+	enum bt_mesh_battery_service service;
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BT_MESH_GEN_BATTERY_H__ */
+
+/** @} */

--- a/include/bluetooth/mesh/gen_battery.rst
+++ b/include/bluetooth/mesh/gen_battery.rst
@@ -1,0 +1,96 @@
+.. _bt_mesh_battery_readme:
+
+Generic Battery models
+######################
+
+The Generic Battery models allow remote monitoring of the battery status of
+a mesh device.
+
+There are two Generic Battery models:
+
+- :ref:`bt_mesh_battery_srv_readme`
+- :ref:`bt_mesh_battery_cli_readme`
+
+.. _bt_mesh_battery_srv_readme:
+
+Generic Battery Server
+======================
+
+The Generic Battery Server model provides information about the current battery
+status of the device.
+
+States
+*******
+
+**Generic Battery Status**: :cpp:type:`bt_mesh_battery_status`
+
+The Generic Battery Status is a composite state, containing various information
+about the battery state. The battery state can only be changed locally, so a
+Generic Battery Client is only able to observe it.
+
+The user is expected to hold the Generic Battery Status state memory and
+provide access to the state through the :cpp:member:`bt_mesh_battery_srv::get`
+handler function. All the fields in the Generic Battery Status have special
+*unknown* values, which are used by default.
+
+Extended models
+****************
+
+None.
+
+Persistent storage
+*******************
+
+None.
+
+API documentation
+******************
+
+| Header file: :file:`include/bluetooth/mesh/gen_battery_srv.h`
+| Source file: :file:`subsys/bluetooth/mesh/gen_battery_srv.c`
+
+.. doxygengroup:: bt_mesh_battery_srv
+   :project: nrf
+   :members:
+
+----
+
+.. _bt_mesh_battery_cli_readme:
+
+Generic Battery Client
+======================
+
+The Generic Battery Client model can query the state of a Generic Battery
+Server model remotely, but does not have any ability to control the Battery
+state.
+
+Extended models
+****************
+
+None.
+
+Persistent storage
+*******************
+
+None.
+
+API documentation
+******************
+
+| Header file: :file:`include/bluetooth/mesh/gen_battery_cli.h`
+| Source file: :file:`subsys/bluetooth/mesh/gen_battery_cli.c`
+
+.. doxygengroup:: bt_mesh_battery_cli
+   :project: nrf
+   :members:
+
+----
+
+Common types
+=============
+
+| Header file: :file:`include/bluetooth/mesh/gen_battery.h`
+
+.. doxygengroup:: bt_mesh_battery
+   :project: nrf
+   :members:

--- a/include/bluetooth/mesh/gen_battery_cli.h
+++ b/include/bluetooth/mesh/gen_battery_cli.h
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/**
+ * @file
+ * @defgroup bt_mesh_battery_cli Generic Battery Client model
+ * @{
+ * @brief API for the Generic Battery Client model.
+ */
+
+#ifndef BT_MESH_GEN_BATTERY_CLI_H__
+#define BT_MESH_GEN_BATTERY_CLI_H__
+
+#include <bluetooth/mesh/gen_battery.h>
+#include <bluetooth/mesh/model_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct bt_mesh_battery_cli;
+
+/** @def BT_MESH_BATTERY_CLI_INIT
+ *
+ * @brief Initialization parameters for a @ref bt_mesh_battery_cli instance.
+ *
+ * @param[in] _status_handler Optional status message handler.
+ */
+#define BT_MESH_BATTERY_CLI_INIT(_status_handler)                              \
+	{                                                                      \
+		.status_handler = _status_handler,                             \
+		.pub = {.msg = NET_BUF_SIMPLE(BT_MESH_MODEL_BUF_LEN(           \
+				BT_MESH_BATTERY_OP_GET,                        \
+				BT_MESH_BATTERY_MSG_LEN_GET)) }                \
+	}
+
+/** @def BT_MESH_MODEL_BATTERY_CLI
+ *
+ * @brief Generic Battery Client model composition data entry.
+ *
+ * @param[in] _cli Pointer to a @ref bt_mesh_battery_cli instance.
+ */
+#define BT_MESH_MODEL_BATTERY_CLI(_cli)                                        \
+	BT_MESH_MODEL_CB(BT_MESH_MODEL_ID_GEN_BATTERY_CLI,                     \
+			 _bt_mesh_battery_cli_op, &(_cli)->pub,                \
+			 BT_MESH_MODEL_USER_DATA(struct bt_mesh_battery_cli,   \
+						 _cli),                        \
+			 &_bt_mesh_battery_cli_cb)
+
+/**
+ * Generic Battery Client structure.
+ *
+ * Should be initialized with the @ref BT_MESH_BATTERY_CLI_INIT macro.
+ */
+struct bt_mesh_battery_cli {
+	/** @brief Battery status message handler.
+	 *
+	 * @param[in] cli Client that received the status message.
+	 * @param[in] ctx Context of the incoming message.
+	 * @param[in] status Battery Status of the Generic Battery Server that
+	 * published the message.
+	 */
+	void (*const status_handler)(
+		struct bt_mesh_battery_cli *cli, struct bt_mesh_msg_ctx *ctx,
+		const struct bt_mesh_battery_status *status);
+
+	/** Response context for tracking acknowledged messages. */
+	struct bt_mesh_model_ack_ctx ack_ctx;
+	/** Publish parameters. */
+	struct bt_mesh_model_pub pub;
+	/** Composition data model entry pointer. */
+	struct bt_mesh_model *model;
+};
+
+/** @brief Get the status of the bound srv.
+ *
+ * This call is blocking if the @p rsp buffer is non-NULL. Otherwise, this
+ * function will return, and the response will be passed to the
+ * @ref bt_mesh_battery_cli::status_handler callback.
+ *
+ * @param[in] cli Client model to send on.
+ * @param[in] ctx Message context, or NULL to use the configured publish
+ * parameters.
+ * @param[out] rsp Status response buffer, or NULL to keep from blocking.
+ *
+ * @retval 0 Successfully sent the message and populated the @p rsp buffer.
+ * @retval -EALREADY A blocking request is already in progress.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
+ */
+int bt_mesh_battery_cli_get(struct bt_mesh_battery_cli *cli,
+			    struct bt_mesh_msg_ctx *ctx,
+			    struct bt_mesh_battery_status *rsp);
+
+/** @cond INTERNAL_HIDDEN */
+extern const struct bt_mesh_model_op _bt_mesh_battery_cli_op[];
+extern const struct bt_mesh_model_cb _bt_mesh_battery_cli_cb;
+/** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BT_MESH_GEN_BATTERY_CLI_H__ */
+
+/* @} */

--- a/include/bluetooth/mesh/gen_battery_srv.h
+++ b/include/bluetooth/mesh/gen_battery_srv.h
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/**
+ * @file
+ * @defgroup bt_mesh_battery_srv Generic Battery Server model
+ * @ingroup bt_mesh_battery
+ * @{
+ * @brief API for the Generic Battery Server model.
+ */
+
+#ifndef BT_MESH_GEN_BATTERY_SRV_H__
+#define BT_MESH_GEN_BATTERY_SRV_H__
+
+#include <bluetooth/mesh/gen_battery.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct bt_mesh_battery_srv;
+
+/** @def BT_MESH_BATTERY_SRV_INIT
+ *
+ * @brief Init parameters for a @ref bt_mesh_battery_srv instance.
+ *
+ * @param[in] _get_handler Get handler function for the Battery state.
+ */
+#define BT_MESH_BATTERY_SRV_INIT(_get_handler)                                 \
+	{                                                                      \
+		.get = _get_handler,                                           \
+		.pub = {                                                       \
+			.update = _bt_mesh_battery_srv_update_handler,         \
+			.msg = NET_BUF_SIMPLE(BT_MESH_MODEL_BUF_LEN(           \
+				BT_MESH_BATTERY_OP_STATUS,                     \
+				BT_MESH_BATTERY_MSG_LEN_STATUS)),              \
+		},                                                             \
+	}
+
+/** @def BT_MESH_MODEL_BATTERY_SRV
+ *
+ * @brief Generic Battery Server model composition data entry.
+ *
+ * @param[in] _srv Pointer to a @ref bt_mesh_battery_srv instance.
+ */
+#define BT_MESH_MODEL_BATTERY_SRV(_srv)                                        \
+	BT_MESH_MODEL_CB(BT_MESH_MODEL_ID_GEN_BATTERY_SRV,                     \
+			 _bt_mesh_battery_srv_op, &(_srv)->pub,                \
+			 BT_MESH_MODEL_USER_DATA(struct bt_mesh_battery_srv,   \
+						 _srv),                        \
+			 &_bt_mesh_battery_srv_cb)
+
+/**
+ * Generic Battery Server instance. Should primarily be initialized with the
+ * @ref BT_MESH_BATTERY_SRV_INIT macro.
+ */
+struct bt_mesh_battery_srv {
+	/** Pointer to the model entry in the composition data. */
+	struct bt_mesh_model *model;
+	/** Publication parameters. */
+	struct bt_mesh_model_pub pub;
+
+	/** @brief Get the Battery state.
+	 *
+	 * @note This handler is mandatory.
+	 *
+	 * @param[in] srv Server instance to get the state of.
+	 * @param[in] ctx Message context for the message that triggered the
+	 * change, or NULL if the change is not coming from a message.
+	 * @param[out] rsp Response structure to be filled. All fields are
+	 * initialized to special @em unknown values before calling, so only
+	 * states that have known values need to be filled.
+	 */
+	void (*const get)(struct bt_mesh_battery_srv *srv,
+			  struct bt_mesh_msg_ctx *ctx,
+			  struct bt_mesh_battery_status *rsp);
+};
+
+/** @brief Publish the Generic Battery Server model status.
+ *
+ * Asynchronously publishes a Generic Battery status message with the
+ * configured publish parameters.
+ *
+ * @note This API is only used publishing unprompted status messages. Response
+ * messages for get and set messages are handled internally.
+ *
+ * @param[in] srv Server instance to publish on.
+ * @param[in] ctx Message context to send with, or NULL to send with the
+ * default publish parameters.
+ * @param[in] status Current status.
+ *
+ * @retval 0 Successfully published a Generic Battery Status message.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ */
+s32_t bt_mesh_battery_srv_pub(struct bt_mesh_battery_srv *srv,
+			      struct bt_mesh_msg_ctx *ctx,
+			      const struct bt_mesh_battery_status *status);
+
+/** @cond INTERNAL_HIDDEN */
+extern const struct bt_mesh_model_op _bt_mesh_battery_srv_op[];
+extern const struct bt_mesh_model_cb _bt_mesh_battery_srv_cb;
+int _bt_mesh_battery_srv_update_handler(struct bt_mesh_model *model);
+/** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BT_MESH_GEN_BATTERY_SRV_H__ */
+
+/** @} */

--- a/include/bluetooth/mesh/gen_dtt.h
+++ b/include/bluetooth/mesh/gen_dtt.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/**
+ * @file
+ * @defgroup bt_mesh_dtt Generic Default Transition Time models
+ * @{
+ * @brief API for the Generic Default Transition Time models.
+ */
+
+#ifndef BT_MESH_GEN_DTT_H__
+#define BT_MESH_GEN_DTT_H__
+
+#include <bluetooth/mesh.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @cond INTERNAL_HIDDEN */
+#define BT_MESH_DTT_OP_GET BT_MESH_MODEL_OP_2(0x82, 0x0D)
+#define BT_MESH_DTT_OP_SET BT_MESH_MODEL_OP_2(0x82, 0x0E)
+#define BT_MESH_DTT_OP_SET_UNACK BT_MESH_MODEL_OP_2(0x82, 0x0F)
+#define BT_MESH_DTT_OP_STATUS BT_MESH_MODEL_OP_2(0x82, 0x10)
+
+#define BT_MESH_DTT_MSG_LEN_GET 0
+#define BT_MESH_DTT_MSG_LEN_SET 1
+#define BT_MESH_DTT_MSG_LEN_STATUS 1
+/** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BT_MESH_GEN_DTT_H__ */
+
+/** @} */

--- a/include/bluetooth/mesh/gen_dtt.rst
+++ b/include/bluetooth/mesh/gen_dtt.rst
@@ -1,0 +1,115 @@
+.. _bt_mesh_dtt_readme:
+
+Generic Default Transition Time models
+######################################
+
+The Generic Default Transition Time (DTT) models are used to control the
+transition of any other states on the same element as a DTT Server.
+The DTT Client can remotely control the default transition time state
+of a server.
+
+There are two Default Transition Time models:
+
+- :ref:`bt_mesh_dtt_srv_readme`
+- :ref:`bt_mesh_dtt_cli_readme`
+
+.. _bt_mesh_dtt_srv_readme:
+
+Generic Default Transition Time Server
+======================================
+
+The DTT Server provides a common way to specify the state transition time for
+other models on the same element. If other generic models on the same element
+receive state change commands without transition parameters, they will use the
+default transition time specified by the DTT Server model. This way, the DTT
+Server can define a consistent transition time for all states on their
+elements, without depending on client configurations.
+
+Configuration
+**************
+
+The Generic DTT Server has one associated configuration option:
+
+- :option:`CONFIG_BT_MESH_DTT_SRV_PERSISTENT`: Control whether changes to the
+  Generic Default Transition Time are stored persistently. Note that this
+  option is only available if :option:`CONFIG_BT_SETTINGS` is enabled.
+
+States
+*******
+
+**Generic Default Transition Time**: ``s32_t``
+
+The Default Transition Time can either be 0, a positive number of milliseconds,
+or ``K_FOREVER`` if the transition is undefined. On the air, the transition
+time is encoded into a single byte, and loses some of its granularity:
+
+- Step count: 6 bits (0-0x3e)
+- Step resolution: 2 bits
+  - Step 0: 100 millisecond resolution
+  - Step 1: 1 second resolution
+  - Step 2: 10 second resolution
+  - Step 3: 10 minutes resolution
+
+The state is encoded with the highest resolution available, and rounded to the
+nearest representation. Values lower than 100 milliseconds, but higher than 0
+are encoded as 100 milliseconds. Values higher than the max value of 620
+minutes are encoded as "undefined".
+
+The DTT Server holds the memory for this state itself, and optionally
+notifies the user of any changes through
+:cpp:member:`bt_mesh_dtt_srv::update_handler`. If the user changes the
+transition time manually, the change should be published using
+:cpp:func:`bt_mesh_dtt_srv_pub`.
+
+Extended models
+****************
+
+None.
+
+Persistent storage
+*******************
+
+The Generic Default Transition Time is stored persistently if
+:option:`CONFIG_BT_MESH_DTT_SRV_PERSISTENT` is enabled.
+
+
+API documentation
+******************
+
+| Header file: :file:`include/bluetooth/mesh/gen_dtt_srv.h`
+| Source file: :file:`subsys/bluetooth/mesh/gen_dtt_srv.c`
+
+.. doxygengroup:: bt_mesh_dtt_srv
+   :project: nrf
+   :members:
+
+----
+
+.. _bt_mesh_dtt_cli_readme:
+
+Generic Default Transition Time Client
+======================================
+
+The DTT Client remotely controls the transition time state of a DTT Server.
+This can be used to set up the server's default transition time behavior
+when changing states in other models on the same element.
+
+Extended models
+****************
+
+None.
+
+Persistent storage
+*******************
+
+None.
+
+API documentation
+******************
+
+| Header file: :file:`include/bluetooth/mesh/gen_dtt_cli.h`
+| Source file: :file:`subsys/bluetooth/mesh/gen_dtt_cli.c`
+
+.. doxygengroup:: bt_mesh_dtt_cli
+   :project: nrf
+   :members:

--- a/include/bluetooth/mesh/gen_dtt_cli.h
+++ b/include/bluetooth/mesh/gen_dtt_cli.h
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/**
+ *
+ * @file
+ * @defgroup bt_mesh_dtt_cli Generic Default Transition Time Client API
+ * @{
+ * @brief API for the Generic Default Transition Time (DTT) Client.
+ */
+
+#ifndef BT_MESH_GEN_DTT_CLI_H__
+#define BT_MESH_GEN_DTT_CLI_H__
+
+#include <bluetooth/mesh/gen_dtt.h>
+#include <bluetooth/mesh/model_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct bt_mesh_dtt_cli;
+
+/** @def BT_MESH_DTT_CLI_INIT
+ *
+ * @brief Initialization parameters for the @ref bt_mesh_dtt_cli.
+ *
+ * @param[in] _status_handler Optional status message handler.
+ * @sa bt_mesh_dtt_cli::status_handler
+ */
+#define BT_MESH_DTT_CLI_INIT(_status_handler)                                  \
+	{                                                                      \
+		.pub = { .msg = NET_BUF_SIMPLE(BT_MESH_MODEL_BUF_LEN(          \
+				 BT_MESH_DTT_OP_SET,                           \
+				 BT_MESH_DTT_MSG_LEN_SET)) },                  \
+		.status_handler = _status_handler,                             \
+	}
+
+/** @def BT_MESH_MODEL_DTT_CLI
+ *
+ * @brief Generic DTT Client model composition data entry.
+ *
+ * @param[in] _cli Pointer to a @ref bt_mesh_dtt_cli instance.
+ */
+#define BT_MESH_MODEL_DTT_CLI(_cli)                                            \
+	BT_MESH_MODEL_CB(BT_MESH_MODEL_ID_GEN_DEF_TRANS_TIME_CLI,              \
+			 _bt_mesh_dtt_cli_op, &(_cli)->pub,                    \
+			 BT_MESH_MODEL_USER_DATA(struct bt_mesh_dtt_cli,       \
+						 _cli),                        \
+			 &_bt_mesh_dtt_cli_cb)
+
+/**
+ * Generic DTT client structure.
+ *
+ * Should be initialized using the @ref BT_MESH_DTT_CLI_INIT macro.
+ */
+struct bt_mesh_dtt_cli {
+	/** @brief Default Transition Time status message handler.
+	 *
+	 * @param[in] cli Client that received the message.
+	 * @param[in] ctx Message context.
+	 * @param[in] transition_time Transition time presented in the message.
+	 */
+	void (*const status_handler)(struct bt_mesh_dtt_cli *cli,
+				     struct bt_mesh_msg_ctx *ctx,
+				     s32_t transition_time);
+
+	/** Response context for tracking acknowledged messages. */
+	struct bt_mesh_model_ack_ctx ack_ctx;
+	/** Model publish parameters. */
+	struct bt_mesh_model_pub pub;
+	/** Composition data model entry pointer. */
+	struct bt_mesh_model *model;
+};
+
+/** @brief Get the Default Transition Time of the server.
+ *
+ * This call is blocking if the @p rsp_transition_time buffer is non-NULL.
+ * Otherwise, this function will not request a response from the server, and
+ * return immediately.
+ *
+ * @param[in] cli Client making the request.
+ * @param[in] ctx Message context to use for sending, or NULL to publish with
+ * the configured parameters.
+ * @param[out] rsp_transition_time Pointer to a response buffer. Cannot be
+ * NULL. Note that the response is a signed value, that can be K_FOREVER if the
+ * current state is unknown or too large to represent.
+ *
+ * @retval 0 Successfully retrieved the status of the bound srv.
+ * @retval -EALREADY A blocking operation is already in progress in this model.
+ * @retval -EAGAIN The request timed out.
+ */
+int bt_mesh_dtt_get(struct bt_mesh_dtt_cli *cli, struct bt_mesh_msg_ctx *ctx,
+		    s32_t *rsp_transition_time);
+
+/** @brief Set the Default Transition Time of the server.
+ *
+ * This call is blocking if the @p rsp_transition_time buffer is non-NULL.
+ * Otherwise, this function will not request a response from the server, and
+ * return immediately.
+ *
+ * @param[in] cli Client model to send on.
+ * @param[in] ctx Message context to use for sending, or NULL to publish with
+ * the configured parameters.
+ * @param[in] transition_time Transition time to set (in milliseconds). Must be
+ * less than @ref BT_MESH_MODEL_TRANSITION_TIME_MAX_MS.
+ * @param[out] rsp_transition_time Response buffer, or NULL to send an
+ * unacknowledged message. Note that the response is a signed value, that can
+ * be K_FOREVER if the current state is unknown or too large to represent.
+ *
+ * @retval 0 Successfully sent the message. If the message is acknowledged,
+ * the response buffer has been set according to the srv's response.
+ * @retval -EINVAL The given transition time is invalid.
+ * @retval -EALREADY A blocking operation is already in progress in this model.
+ * @retval -EAGAIN The request timed out.
+ */
+int bt_mesh_dtt_set(struct bt_mesh_dtt_cli *cli, struct bt_mesh_msg_ctx *ctx,
+		    u32_t transition_time, s32_t *rsp_transition_time);
+
+/** @cond INTERNAL_HIDDEN */
+extern const struct bt_mesh_model_op _bt_mesh_dtt_cli_op[];
+extern const struct bt_mesh_model_cb _bt_mesh_dtt_cli_cb;
+/** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BT_MESH_GEN_DTT_CLI_H__ */
+
+/** @} */

--- a/include/bluetooth/mesh/gen_dtt_srv.h
+++ b/include/bluetooth/mesh/gen_dtt_srv.h
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/**
+ * @file
+ * @defgroup bt_mesh_dtt_srv Generic Default Transition Time Server
+ * model
+ * @{
+ * @brief API for the Generic Default Transition Time (DTT) Server model.
+ */
+
+#ifndef BT_MESH_GEN_DTT_SRV_H__
+#define BT_MESH_GEN_DTT_SRV_H__
+
+#include <bluetooth/mesh.h>
+#include <bluetooth/mesh/model_types.h>
+#include <bluetooth/mesh/gen_dtt.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct bt_mesh_dtt_srv;
+
+/** @def BT_MESH_DTT_SRV_INIT
+ *
+ * @brief Initialization parameters for @ref bt_mesh_dtt_srv.
+ *
+ * @param[in] _update Update handler called on every change to the transition
+ * time in this server.
+ */
+#define BT_MESH_DTT_SRV_INIT(_update)                                          \
+	{                                                                      \
+		.update = _update,                                             \
+		.pub = {.update = _bt_mesh_dtt_srv_update_handler,             \
+			.msg = NET_BUF_SIMPLE(BT_MESH_MODEL_BUF_LEN(           \
+				BT_MESH_DTT_OP_STATUS,                         \
+				BT_MESH_DTT_MSG_LEN_STATUS)) }                 \
+	}
+
+/** @def BT_MESH_MODEL_DTT_SRV
+ *
+ * @brief Generic Default Transition Time Server model composition data entry.
+ *
+ * @param[in] _srv Pointer to a @ref bt_mesh_dtt_srv instance.
+ */
+#define BT_MESH_MODEL_DTT_SRV(_srv)                                            \
+	BT_MESH_MODEL_CB(BT_MESH_MODEL_ID_GEN_DEF_TRANS_TIME_SRV,              \
+			 _bt_mesh_dtt_srv_op, &(_srv)->pub,                    \
+			 BT_MESH_MODEL_USER_DATA(struct bt_mesh_dtt_srv,       \
+						 _srv),                        \
+			 &_bt_mesh_dtt_srv_cb)
+
+/** Generic Default Transition Time server instance. */
+struct bt_mesh_dtt_srv {
+	/** Current transition time in milliseconds */
+	u32_t transition_time;
+
+	/** @brief Update handler for the transition time state.
+	 *
+	 * Called every time the transition time is updated.
+	 *
+	 * @param[in] srv Server instance that was updated.
+	 * @param[in] ctx Context of the set message that caused the update, or
+	 * NULL if the update was not a result of a set message.
+	 * @param[in] old_transition_time The transition time prior to the
+	 * update.
+	 * @param[in] new_transition_time The new transition time after the
+	 * update.
+	 */
+	void (*const update)(struct bt_mesh_dtt_srv *srv,
+			     struct bt_mesh_msg_ctx *ctx,
+			     u32_t old_transition_time,
+			     u32_t new_transition_time);
+	/** Composition data Model entry pointer. */
+	struct bt_mesh_model *model;
+	/** Model publish parameters. */
+	struct bt_mesh_model_pub pub;
+};
+
+/** @brief Set the Default Transition Time of the DTT server.
+ *
+ * If an update handler is set, it'll be called with the updated transition
+ * time. If publication is configured, the change will cause the server to
+ * publish.
+ *
+ * @param[in] srv Server to set the DTT of.
+ * @param[in] transition_time New Default Transition Time.
+ */
+void bt_mesh_dtt_srv_set(struct bt_mesh_dtt_srv *srv, u32_t transition_time);
+
+/** @brief Publish the current transition time.
+ *
+ * @param[in] srv Server instance to publish with.
+ * @param[in] ctx Message context to publish with, or NULL to publish with the
+ * configured parameters.
+ *
+ * @retval 0 Successfully published the current transition time.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ */
+int bt_mesh_dtt_srv_pub(struct bt_mesh_dtt_srv *srv,
+			struct bt_mesh_msg_ctx *ctx);
+
+/** @brief Find the Generic DTT server in a given element.
+ *
+ * @param[in] elem Element to find the DTT server in.
+ *
+ * @return A pointer to the DTT server instance, or NULL if no instance is
+ * found.
+ */
+static inline struct bt_mesh_dtt_srv *
+bt_mesh_dtt_srv_get(const struct bt_mesh_elem *elem)
+{
+	struct bt_mesh_model *mod = bt_mesh_model_find(
+		elem, BT_MESH_MODEL_ID_GEN_DEF_TRANS_TIME_SRV);
+
+	return (struct bt_mesh_dtt_srv *)(mod ? mod->user_data : NULL);
+}
+
+/** @brief Get the default transition parameters for the given model.
+ *
+ * @param[in] mod Model to get the DTT for.
+ * @param[out] transition Transition buffer.
+ *
+ * @return Whether the transition was set.
+ */
+static inline bool
+bt_mesh_dtt_srv_transition_get(struct bt_mesh_model *mod,
+			       struct bt_mesh_model_transition *transition)
+{
+	struct bt_mesh_dtt_srv *srv =
+		bt_mesh_dtt_srv_get(bt_mesh_model_elem(mod));
+
+	transition->time = srv ? srv->transition_time : 0;
+	transition->delay = 0;
+	return (transition->time != 0);
+}
+
+/** @cond INTERNAL_HIDDEN */
+extern const struct bt_mesh_model_op _bt_mesh_dtt_srv_op[];
+extern const struct bt_mesh_model_cb _bt_mesh_dtt_srv_cb;
+int _bt_mesh_dtt_srv_update_handler(struct bt_mesh_model *model);
+/** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BT_MESH_GEN_DTT_SRV_H__ */
+
+/** @} */

--- a/include/bluetooth/mesh/gen_loc.h
+++ b/include/bluetooth/mesh/gen_loc.h
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/**
+ * @file
+ * @defgroup bt_mesh_loc Generic Location models
+ * @{
+ * @brief API for the Generic Location models.
+ */
+
+#ifndef BT_MESH_GEN_LOC_H__
+#define BT_MESH_GEN_LOC_H__
+
+#include <bluetooth/mesh.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @cond INTERNAL_HIDDEN */
+#define BT_MESH_LOC_OP_GLOBAL_GET BT_MESH_MODEL_OP_2(0x82, 0x25)
+#define BT_MESH_LOC_OP_GLOBAL_STATUS BT_MESH_MODEL_OP_1(0x40)
+#define BT_MESH_LOC_OP_GLOBAL_SET BT_MESH_MODEL_OP_1(0x41)
+#define BT_MESH_LOC_OP_GLOBAL_SET_UNACK BT_MESH_MODEL_OP_1(0x42)
+#define BT_MESH_LOC_OP_LOCAL_GET BT_MESH_MODEL_OP_2(0x82, 0x26)
+#define BT_MESH_LOC_OP_LOCAL_STATUS BT_MESH_MODEL_OP_2(0x82, 0x27)
+#define BT_MESH_LOC_OP_LOCAL_SET BT_MESH_MODEL_OP_2(0x82, 0x28)
+#define BT_MESH_LOC_OP_LOCAL_SET_UNACK BT_MESH_MODEL_OP_2(0x82, 0x29)
+
+#define BT_MESH_LOC_MSG_LEN_GLOBAL_GET 0
+#define BT_MESH_LOC_MSG_LEN_GLOBAL_STATUS 10
+#define BT_MESH_LOC_MSG_LEN_GLOBAL_SET 10
+#define BT_MESH_LOC_MSG_LEN_LOCAL_GET 0
+#define BT_MESH_LOC_MSG_LEN_LOCAL_STATUS 9
+#define BT_MESH_LOC_MSG_LEN_LOCAL_SET 9
+/** @endcond */
+
+/**
+ * @defgroup bt_mesh_loc_altitude_defines Defines for altitude.
+ * Boundaries and special values for the altitude.
+ * @{
+ */
+/** Highest altitude that can be represented */
+#define BT_MESH_LOC_ALTITUDE_MAX 32765
+/** Altitude is unknown or not configured. */
+#define BT_MESH_LOC_ALTITUDE_UNKNOWN 0x7fff
+/** Altitude is out of bounds. */
+#define BT_MESH_LOC_ALTITUDE_TOO_LARGE 0x7ffe
+/** @} */
+
+/**
+ * @defgroup bt_mesh_loc_floor_number_defines Defines for floor number.
+ * Boundaries and special values for the local floor number.
+ * @{
+ */
+/** Lowest floor number that can be represented. */
+#define BT_MESH_LOC_FLOOR_NUMBER_MIN (-20)
+/** Highest floor number that can be represented. */
+#define BT_MESH_LOC_FLOOR_NUMBER_MAX 232
+/** Ground floor (where the ground floor is referred to as floor 0) */
+#define BT_MESH_LOC_FLOOR_NUMBER_GROUND_FLOOR_0 0xfc
+/** Ground floor (where the ground floor is referred to as floor 1) */
+#define BT_MESH_LOC_FLOOR_NUMBER_GROUND_FLOOR_1 0xfd
+/** Unknown or unconfigured floor number. */
+#define BT_MESH_LOC_FLOOR_NUMBER_UNKNOWN 0xff
+/** @} */
+
+/** Global location parameters. */
+struct bt_mesh_loc_global {
+	/** Global WGS84 North coordinate in degrees. */
+	double latitude;
+	/** Global WGS84 East coordinate in degrees. */
+	double longitude;
+	/**
+	 * Global altitude above the WGS84 datum in meters.
+	 * @sa bt_mesh_loc_altitude_defines
+	 */
+	s16_t altitude;
+};
+
+/** Local location parameters. */
+struct bt_mesh_loc_local {
+	/** Local north position in decimeters. */
+	s16_t north;
+	/** Local east position in decimeters. */
+	s16_t east;
+	/** Local altitude in decimeters. @sa bt_mesh_loc_altitude_defines */
+	s16_t altitude;
+	/** Floor number. @sa bt_mesh_loc_floor_number_defines */
+	s16_t floor_number;
+	/** Whether the device is movable. */
+	bool is_mobile;
+	/** Time since the previous position update, @ref K_FOREVER. */
+	s32_t time_delta;
+	/** Precision of the location in millimeters. */
+	u32_t precision_mm;
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BT_MESH_GEN_LOC_H__ */
+
+/** @} */

--- a/include/bluetooth/mesh/gen_loc.rst
+++ b/include/bluetooth/mesh/gen_loc.rst
@@ -1,0 +1,144 @@
+.. _bt_mesh_loc_readme:
+
+Generic Location models
+#######################
+
+The Generic Location models allow remote monitoring of the location status of
+a mesh device.
+
+There are two Generic Location models:
+
+- :ref:`bt_mesh_loc_srv_readme`
+- :ref:`bt_mesh_loc_cli_readme`
+
+.. _bt_mesh_loc_srv_readme:
+
+Generic Location Server
+=======================
+
+The Generic Location Server provides location information about the device.
+The location data is split up into two separate states: Global and Local.
+The Global Location represents the device location in the world, while the
+Local Location represents the device location relative to a local coordinate
+system, for instance inside a building.
+
+The Generic Location Server adds two model instances in the composition data:
+
+- The Generic Location Server
+- The Generic Location Setup Server
+
+The two model instances share the states of the Generic Location Server, but
+accept different messages. This allows fine-grained control of the access
+rights for the location states, as the two model instances can be bound to
+different application keys.
+
+The Generic Location Server allows observation of the location states, as it
+only exposes get-messages for the location states. This is typically the
+user facing model instance, as the device location shouldn't normally be
+configurable by the users.
+
+The Generic Location Setup Server allows configuration of the location states
+by exposing set-messages for the location states. This model instance can be
+used to configure the location information of the device, for instance during
+deployment.
+
+If the device is capable of determining its own location information, the
+Generic Location Setup Server is redundant, and can be deactivated by
+removing all bindings it has to any application keys.
+
+.. note::
+
+  The Generic Location Server does not store any of its states persistently,
+  so if the Generic Location Server is meant to get its location configured
+  during setup, this must be stored by the application.
+
+States
+*******
+
+**Global Location**: :cpp:type:`bt_mesh_loc_global`
+
+The Global Location state is a composite state representing a global location
+as a WGS84 coordinate point. The latitude and longitude (in degrees) are
+represented as a ``double``, and are each encoded as a signed 32 bit integer.
+The altitude is represented as a signed 16 bit integer, measured in meters.
+
+The memory for the Global Location state is owned by the user, and should be
+exposed to the model through the callbacks in a
+:cpp:type:`bt_mesh_loc_srv_handlers` structure.
+
+**Local Location**: :cpp:type:`bt_mesh_loc_local`
+
+The Local Location state represents the device's location within a locally
+defined coordinate system, like the inside of a building. It contains
+parameters for a three dimensional device location measured in decimeters, as
+well as a floor number and parameters to determine the precision of the
+location parameters.
+
+The memory for the Local Location state is owned by the user, and should be
+exposed to the model through the callbacks in a
+:cpp:type:`bt_mesh_loc_srv_handlers` structure.
+
+Extended models
+****************
+
+None.
+
+Persistent storage
+*******************
+
+None.
+
+API documentation
+******************
+
+| Header file: :file:`include/bluetooth/mesh/gen_loc_srv.h`
+| Source file: :file:`subsys/bluetooth/mesh/gen_loc_srv.c`
+
+.. doxygengroup:: bt_mesh_loc_srv
+   :project: nrf
+   :members:
+
+----
+
+.. _bt_mesh_loc_cli_readme:
+
+Generic Location Client
+=======================
+
+The Generic Location Client model can get and set the state of a Generic
+Location Server model remotely.
+
+Contrary to the Server model, the Client only creates a single model instance
+in the mesh composition data. The Generic Location Client may send messages to
+both the Generic Location Server and the Generic Location Setup Server, as long
+as it has the right application keys.
+
+Extended models
+****************
+
+None.
+
+Persistent storage
+*******************
+
+None.
+
+API documentation
+******************
+
+| Header file: :file:`include/bluetooth/mesh/gen_loc_cli.h`
+| Source file: :file:`subsys/bluetooth/mesh/gen_loc_cli.c`
+
+.. doxygengroup:: bt_mesh_loc_cli
+   :project: nrf
+   :members:
+
+----
+
+Common types
+=============
+
+| Header file: :file:`include/bluetooth/mesh/gen_loc.h`
+
+.. doxygenfile:: gen_loc.h
+   :project: nrf

--- a/include/bluetooth/mesh/gen_loc_cli.h
+++ b/include/bluetooth/mesh/gen_loc_cli.h
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/**
+ * @file
+ * @defgroup bt_mesh_loc_cli Generic Location Client model
+ * @{
+ * @brief API for the Generic Location Client model.
+ */
+
+#ifndef BT_MESH_GEN_LOC_CLI_H__
+#define BT_MESH_GEN_LOC_CLI_H__
+
+#include <bluetooth/mesh/gen_loc.h>
+#include <bluetooth/mesh/model_types.h>
+#include <sys/util.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct bt_mesh_loc_cli;
+
+/** @def BT_MESH_LOC_CLI_INIT
+ *
+ * @brief Initialization parameters for a @ref bt_mesh_loc_cli instance.
+ *
+ * @param[in] _handlers Pointer to a @ref bt_mesh_loc_cli_handlers instance.
+ */
+#define BT_MESH_LOC_CLI_INIT(_handlers)                                        \
+	{                                                                      \
+		.handlers = _handlers,                                         \
+		.pub = {.msg = NET_BUF_SIMPLE(MAX(                             \
+				BT_MESH_MODEL_BUF_LEN(                         \
+					BT_MESH_LOC_OP_LOCAL_SET,              \
+					BT_MESH_LOC_MSG_LEN_LOCAL_SET),        \
+				BT_MESH_MODEL_BUF_LEN(                         \
+					BT_MESH_LOC_OP_GLOBAL_SET,             \
+					BT_MESH_LOC_MSG_LEN_GLOBAL_SET))) }    \
+	}
+
+/** @def BT_MESH_MODEL_LOC_CLI
+ *
+ * @brief Generic Location Client model composition data entry.
+ *
+ * @param[in] _cli Pointer to a @ref bt_mesh_loc_cli instance.
+ */
+#define BT_MESH_MODEL_LOC_CLI(_cli)                                            \
+	BT_MESH_MODEL_CB(BT_MESH_MODEL_ID_GEN_LOCATION_CLI,                    \
+			 _bt_mesh_loc_cli_op, &(_cli)->pub,                    \
+			 BT_MESH_MODEL_USER_DATA(struct bt_mesh_loc_cli,       \
+						 _cli),                        \
+			 &_bt_mesh_loc_cli_cb)
+
+/** Location handler functions */
+struct bt_mesh_loc_cli_handlers {
+	/** @brief Global Location status message handler.
+	 *
+	 * @param[in] cli Client that received the status message.
+	 * @param[in] ctx Context of the incoming message.
+	 * @param[in] status Global Location parameters of the Generic Location
+	 * Server that published the message.
+	 */
+	void (*const global_status)(struct bt_mesh_loc_cli *cli,
+				    struct bt_mesh_msg_ctx *ctx,
+				    const struct bt_mesh_loc_global *status);
+
+	/** @brief Local Location status message handler.
+	 *
+	 * @param[in] cli Client that received the status message.
+	 * @param[in] ctx Context of the incoming message.
+	 * @param[in] status Local Location parameters of the Generic Location
+	 * Server that published the message.
+	 */
+	void (*const local_status)(struct bt_mesh_loc_cli *cli,
+				   struct bt_mesh_msg_ctx *ctx,
+				   const struct bt_mesh_loc_local *status);
+};
+
+/**
+ * Generic Location Client structure.
+ *
+ * Should be initialized with the @ref BT_MESH_LOC_CLI_INIT macro.
+ */
+struct bt_mesh_loc_cli {
+	/** Handler function structure */
+	const struct bt_mesh_loc_cli_handlers *const handlers;
+	/** Response context for tracking acknowledged messages. */
+	struct bt_mesh_model_ack_ctx ack_ctx;
+	struct bt_mesh_model_pub pub; /**< Publish parameters. */
+	struct bt_mesh_model *model; /**< Access model pointer. */
+};
+
+/** @brief Get the global location of the bound srv.
+ *
+ * This call is blocking if the @p rsp buffer is non-NULL. Otherwise, this
+ * function will return, and the response will be passed to the
+ * @ref bt_mesh_loc_cli_handlers::global_status callback.
+ *
+ * @param[in] cli Client model to send on.
+ * @param[in] ctx Message context, or NULL to use the configured publish
+ * parameters.
+ * @param[out] rsp Global Location response buffer, or NULL to keep from
+ * blocking.
+ *
+ * @retval 0 Successfully sent the message and populated the @p rsp buffer.
+ * @retval -EALREADY A blocking request is already in progress.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
+ */
+int bt_mesh_loc_cli_global_get(struct bt_mesh_loc_cli *cli,
+			       struct bt_mesh_msg_ctx *ctx,
+			       struct bt_mesh_loc_global *rsp);
+
+/** @brief Set the Global Location in the server.
+ *
+ * This call is blocking if the @p rsp buffer is non-NULL. Otherwise, this
+ * function will not request a response from the server, and return
+ * immediately.
+ *
+ * @param[in] cli Client model to send on.
+ * @param[in] ctx Message context, or NULL to use the configured publish
+ * parameters.
+ * @param[in] loc New Global Location value to set.
+ * @param[out] rsp Response status buffer, or NULL to send an unacknowledged
+ * message.
+ *
+ * @retval 0 Successfully sent the message and populated the @p rsp buffer.
+ * @retval -EALREADY A blocking request is already in progress.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
+ */
+int bt_mesh_loc_cli_global_set(struct bt_mesh_loc_cli *cli,
+			       struct bt_mesh_msg_ctx *ctx,
+			       const struct bt_mesh_loc_global *loc,
+			       struct bt_mesh_loc_global *rsp);
+
+/** @brief Get the local location of the bound srv.
+ *
+ * This call is blocking if the @p rsp buffer is non-NULL. Otherwise, this
+ * function will return, and the response will be passed to the
+ * @ref bt_mesh_loc_cli_handlers::local_status callback.
+ *
+ * @param[in] cli Client model to send on.
+ * @param[in] ctx Message context, or NULL to use the configured publish
+ * parameters.
+ * @param[out] rsp Local Location response buffer, or NULL to keep from
+ * blocking.
+ *
+ * @retval 0 Successfully sent the message and populated the @p rsp buffer.
+ * @retval -EALREADY A blocking request is already in progress.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
+ */
+int bt_mesh_loc_cli_local_get(struct bt_mesh_loc_cli *cli,
+			      struct bt_mesh_msg_ctx *ctx,
+			      struct bt_mesh_loc_local *rsp);
+
+/** @brief Set the Local Location in the server.
+ *
+ * This call is blocking if the @p rsp buffer is non-NULL. Otherwise, this
+ * function will not request a response from the server, and return
+ * immediately.
+ *
+ * @param[in] cli Client model to send on.
+ * @param[in] ctx Message context, or NULL to use the configured publish
+ * parameters.
+ * @param[in] loc New Local Location value to set.
+ * @param[out] rsp Response status buffer, or NULL to send an unacknowledged
+ * message.
+ *
+ * @retval 0 Successfully sent the message and populated the @p rsp buffer.
+ * @retval -EALREADY A blocking request is already in progress.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
+ */
+int bt_mesh_loc_cli_local_set(struct bt_mesh_loc_cli *cli,
+			      struct bt_mesh_msg_ctx *ctx,
+			      const struct bt_mesh_loc_local *loc,
+			      struct bt_mesh_loc_local *rsp);
+
+/** @cond INTERNAL_HIDDEN */
+extern const struct bt_mesh_model_op _bt_mesh_loc_cli_op[];
+extern const struct bt_mesh_model_cb _bt_mesh_loc_cli_cb;
+/** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BT_MESH_GEN_LOC_CLI_H__ */
+
+/* @} */

--- a/include/bluetooth/mesh/gen_loc_srv.h
+++ b/include/bluetooth/mesh/gen_loc_srv.h
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/**
+ * @file
+ * @defgroup bt_mesh_loc_srv Generic Location Server model
+ * @ingroup bt_mesh_loc
+ * @{
+ * @brief API for the Generic Location Server model.
+ */
+
+#ifndef BT_MESH_GEN_LOC_SRV_H__
+#define BT_MESH_GEN_LOC_SRV_H__
+
+#include <bluetooth/mesh/gen_loc.h>
+#include <sys/util.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct bt_mesh_loc_srv;
+
+/** @def BT_MESH_LOC_SRV_INIT
+ *
+ * @brief Init parameters for a @ref bt_mesh_loc_srv instance.
+ *
+ * @param[in] _handlers Handler function structure.
+ */
+#define BT_MESH_LOC_SRV_INIT(_handlers)                                        \
+	{                                                                      \
+		.handlers = _handlers,                                         \
+		.pub = {                                                       \
+			.update = _bt_mesh_loc_srv_update_handler,             \
+			.msg = NET_BUF_SIMPLE(MAX(                             \
+				BT_MESH_MODEL_BUF_LEN(                         \
+					BT_MESH_LOC_OP_LOCAL_STATUS,           \
+					BT_MESH_LOC_MSG_LEN_LOCAL_STATUS),     \
+				BT_MESH_MODEL_BUF_LEN(                         \
+					BT_MESH_LOC_OP_GLOBAL_STATUS,          \
+					BT_MESH_LOC_MSG_LEN_GLOBAL_STATUS)))   \
+		},                                                             \
+	}
+
+/** @def BT_MESH_MODEL_LOC_SRV
+ *
+ * @brief Generic Location Server model composition data entry.
+ *
+ * @param[in] _srv Pointer to a @ref bt_mesh_loc_srv instance.
+ */
+#define BT_MESH_MODEL_LOC_SRV(_srv)                                            \
+	BT_MESH_MODEL_CB(BT_MESH_MODEL_ID_GEN_LOCATION_SRV,                    \
+			 _bt_mesh_loc_srv_op, &(_srv)->pub,                    \
+			 BT_MESH_MODEL_USER_DATA(struct bt_mesh_loc_srv,       \
+						 _srv),                        \
+			 &_bt_mesh_loc_srv_cb)
+
+/** Location Server handler functions. */
+struct bt_mesh_loc_srv_handlers {
+	/** @brief Get the Global Location state.
+	 *
+	 * @note This handler is mandatory.
+	 *
+	 * @param[in] srv Server to get the Global Location state of.
+	 * @param[in] ctx Context of the get message that triggered the query,
+	 * or NULL if it was not triggered by a message.
+	 * @param[out] rsp Global Location state to fill.
+	 */
+	void (*const global_get)(struct bt_mesh_loc_srv *srv,
+				 struct bt_mesh_msg_ctx *ctx,
+				 struct bt_mesh_loc_global *rsp);
+
+	/** @brief Set the Global Location state.
+	 *
+	 * Any changes to the new @c loc parameter will be taken into account
+	 * before a response is sent to the client.
+	 *
+	 * @note This handler is mandatory.
+	 *
+	 * @param[in] srv Server to set the Global Location state of.
+	 * @param[in] ctx Context of the set message that triggered the change,
+	 * or NULL if it was not triggered by a message.
+	 * @param[in,out] loc New Global Location state.
+	 */
+	void (*const global_set)(struct bt_mesh_loc_srv *srv,
+				 struct bt_mesh_msg_ctx *ctx,
+				 struct bt_mesh_loc_global *loc);
+
+	/** @brief Get the Local Location state.
+	 *
+	 * @note This handler is mandatory.
+	 *
+	 * @param[in] srv Server to get the Local Location state of.
+	 * @param[in] ctx Context of the get message that triggered the query,
+	 * or NULL if it was not triggered by a message.
+	 * @param[out] rsp Local Location state to fill.
+	 */
+	void (*const local_get)(struct bt_mesh_loc_srv *srv,
+				struct bt_mesh_msg_ctx *ctx,
+				struct bt_mesh_loc_local *rsp);
+
+	/** @brief Set the Local Location state.
+	 *
+	 * Any changes to the new @c loc parameter will be taken into account
+	 * before a response is sent to the client.
+	 *
+	 * @note This handler is mandatory.
+	 *
+	 * @param[in] srv Server to set the Local Location state of.
+	 * @param[in] ctx Context of the set message that triggered the change,
+	 * or NULL if it was not triggered by a message.
+	 * @param[in,out] loc New Local Location state.
+	 */
+	void (*const local_set)(struct bt_mesh_loc_srv *srv,
+				struct bt_mesh_msg_ctx *ctx,
+				struct bt_mesh_loc_local *loc);
+};
+
+/**
+ * Generic Location Server instance. Should primarily be initialized with the
+ * @ref BT_MESH_LOC_SRV_INIT macro.
+ */
+struct bt_mesh_loc_srv {
+	/** Pointer to the model instance. */
+	struct bt_mesh_model *model;
+	/** Publish parameters for this model instance. */
+	struct bt_mesh_model_pub pub;
+
+	/** Current opcode being published. */
+	u16_t pub_op;
+	/** Pointer to a handler structure. */
+	const struct bt_mesh_loc_srv_handlers *const handlers;
+};
+
+/** @brief Publish the Global Location state.
+ *
+ * Asynchronously publishes a Global Location status message with the
+ * configured publish parameters.
+ *
+ * @note This API is only used publishing unprompted status messages. Response
+ * messages for get and set are handled internally.
+ *
+ * @note The server will only publish one state at the time. Calling this
+ * function will terminate any publishing of the Local Location state.
+ *
+ * @param[in] srv Server instance to publish on.
+ * @param[in] ctx Message context to send with, or NULL to send with the
+ * default publish parameters.
+ * @param[in] global Current global location.
+ *
+ * @retval 0 Successfully published a Global Location status message.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ */
+s32_t bt_mesh_loc_srv_global_pub(struct bt_mesh_loc_srv *srv,
+				 struct bt_mesh_msg_ctx *ctx,
+				 const struct bt_mesh_loc_global *global);
+
+/** @brief Publish the Local Location state.
+ *
+ * Asynchronously publishes a Local Location status message with the configured
+ * publish parameters.
+ *
+ * @note This API is only used publishing unprompted status messages. Response
+ * messages for get and set are handled internally.
+ *
+ * @note The server will only publish one state at the time. Calling this
+ * function will terminate any publishing of the Global Location state.
+ *
+ * @param[in] srv Server instance to publish on.
+ * @param[in] ctx Message context to send with, or NULL to send with the
+ * default publish parameters.
+ * @param[in] local Current local location.
+ *
+ * @retval 0 Successfully published a Local Location status message.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ */
+s32_t bt_mesh_loc_srv_local_pub(struct bt_mesh_loc_srv *srv,
+				struct bt_mesh_msg_ctx *ctx,
+				const struct bt_mesh_loc_local *local);
+
+/** @cond INTERNAL_HIDDEN */
+extern const struct bt_mesh_model_op _bt_mesh_loc_srv_op[];
+extern const struct bt_mesh_model_op _bt_mesh_loc_setup_srv_op[];
+extern const struct bt_mesh_model_cb _bt_mesh_loc_srv_cb;
+int _bt_mesh_loc_srv_update_handler(struct bt_mesh_model *model);
+/** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BT_MESH_GEN_LOC_SRV_H__ */
+
+/** @} */

--- a/include/bluetooth/mesh/gen_lvl.h
+++ b/include/bluetooth/mesh/gen_lvl.h
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/**
+ * @file
+ * @defgroup bt_mesh_lvl Bluetooth Mesh Generic Level models
+ * @{
+ * @brief Common API for the Bluetooth Mesh Generic Level models.
+ */
+#ifndef BT_MESH_GEN_LVL_H__
+#define BT_MESH_GEN_LVL_H__
+
+#include <bluetooth/mesh.h>
+#include <bluetooth/mesh/model_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @cond INTERNAL_HIDDEN */
+#define BT_MESH_LVL_OP_GET BT_MESH_MODEL_OP_2(0x82, 0x05)
+#define BT_MESH_LVL_OP_SET BT_MESH_MODEL_OP_2(0x82, 0x06)
+#define BT_MESH_LVL_OP_SET_UNACK BT_MESH_MODEL_OP_2(0x82, 0x07)
+#define BT_MESH_LVL_OP_STATUS BT_MESH_MODEL_OP_2(0x82, 0x08)
+#define BT_MESH_LVL_OP_DELTA_SET BT_MESH_MODEL_OP_2(0x82, 0x09)
+#define BT_MESH_LVL_OP_DELTA_SET_UNACK BT_MESH_MODEL_OP_2(0x82, 0x0A)
+#define BT_MESH_LVL_OP_MOVE_SET BT_MESH_MODEL_OP_2(0x82, 0x0B)
+#define BT_MESH_LVL_OP_MOVE_SET_UNACK BT_MESH_MODEL_OP_2(0x82, 0x0C)
+
+#define BT_MESH_LVL_MSG_LEN_GET 0
+#define BT_MESH_LVL_MSG_MINLEN_SET 3
+#define BT_MESH_LVL_MSG_MAXLEN_SET 5
+#define BT_MESH_LVL_MSG_MINLEN_STATUS 2
+#define BT_MESH_LVL_MSG_MAXLEN_STATUS 5
+#define BT_MESH_LVL_MSG_MINLEN_DELTA_SET 5
+#define BT_MESH_LVL_MSG_MAXLEN_DELTA_SET 7
+#define BT_MESH_LVL_MSG_MINLEN_MOVE_SET 3
+#define BT_MESH_LVL_MSG_MAXLEN_MOVE_SET 5
+/** @endcond */
+
+/** Generic Level minimum value. */
+#define BT_MESH_LVL_MIN INT16_MIN
+/** Generic Level maximum value. */
+#define BT_MESH_LVL_MAX INT16_MAX
+
+/** Generic Level set message parameters.  */
+struct bt_mesh_lvl_set {
+	/** New level. */
+	s16_t lvl;
+	/** Whether this is a new action. */
+	bool new_transaction;
+	/**
+	 * Transition time parameters for the state change. Setting the
+	 * transition to NULL makes the server use its default transition time
+	 * parameters.
+	 */
+	const struct bt_mesh_model_transition *transition;
+};
+
+/** Generic Level delta set message parameters.  */
+struct bt_mesh_lvl_delta_set {
+	/** Translation from original value. */
+	s32_t delta;
+	/**
+	 * Whether this is a new transaction. If true, the delta should be
+	 * relative to the current value. If false, the delta should be
+	 * relative to the original value in the previous delta_set command.
+	 */
+	bool new_transaction;
+	/**
+	 * Transition time parameters for the state change. Setting the
+	 * transition to NULL makes the server use its default transition time
+	 * parameters.
+	 */
+	const struct bt_mesh_model_transition *transition;
+};
+
+/** Generic Level move set message parameters. */
+struct bt_mesh_lvl_move_set {
+	/** Translation to make for every transition step. */
+	s16_t delta;
+	/** Whether this is a new action. */
+	bool new_transaction;
+	/**
+	 * Transition parameters. @c delay indicates time until the move
+	 * should start, @c transition indicates the amount of time each
+	 * @c delta step should take. Setting the transition to NULL makes the
+	 * server use its default transition time parameters.
+	 */
+	const struct bt_mesh_model_transition *transition;
+};
+
+/** Generic Level status message parameters.  */
+struct bt_mesh_lvl_status {
+	/** Current level value. */
+	s16_t current;
+	/**
+	 * Target value for the ongoing transition. If there's no ongoing
+	 * transition, @c target should match @c value.
+	 */
+	s16_t target;
+	/**
+	 * Time remaining of the ongoing transition, or @ref K_FOREVER.
+	 * If there's no ongoing transition, @c remaining_time is 0.
+	 */
+	s32_t remaining_time;
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BT_MESH_GEN_LVL_H__ */
+
+/** @} */

--- a/include/bluetooth/mesh/gen_lvl.rst
+++ b/include/bluetooth/mesh/gen_lvl.rst
@@ -1,0 +1,96 @@
+.. _bt_mesh_lvl_readme:
+
+Generic Level models
+####################
+
+The Generic Level models allows remote control of integer states on a mesh
+device.
+
+There are two Generic Level models:
+
+- :ref:`bt_mesh_lvl_srv_readme`
+- :ref:`bt_mesh_lvl_cli_readme`
+
+.. _bt_mesh_lvl_srv_readme:
+
+Generic Level Server
+====================
+
+The Generic Level Server model owns a single Generic Level state.
+
+States
+*******
+
+**Generic Level**: ``s16_t``
+
+The user is expected to hold the state memory and provide access to the state
+through the :cpp:type:`bt_mesh_lvl_srv_handlers` handler structure.
+
+Changes to the Generic Level state may include transition parameters. While
+transitioning to a new level state, any requests to read out the current level
+should report the actual current level in the transition, as well as the
+terminal level and remaining time in milliseconds, including delay.
+
+If the transition includes a delay, the state shall remain unchanged until the
+delay expires.
+
+Extended models
+****************
+
+None.
+
+Persistent storage
+*******************
+
+None.
+
+API documentation
+******************
+
+| Header file: :file:`include/bluetooth/mesh/gen_lvl_srv.h`
+| Source file: :file:`subsys/bluetooth/mesh/gen_lvl_srv.c`
+
+.. doxygengroup:: bt_mesh_lvl_srv
+   :project: nrf
+   :members:
+
+----
+
+.. _bt_mesh_lvl_cli_readme:
+
+Generic Level Client
+====================
+
+The Generic Level Client model remotely controls the state of a Generic Level
+Server model.
+
+Extended models
+****************
+
+None.
+
+Persistent storage
+*******************
+
+None.
+
+API documentation
+******************
+
+| Header file: :file:`include/bluetooth/mesh/gen_lvl_cli.h`
+| Source file: :file:`subsys/bluetooth/mesh/gen_lvl_cli.c`
+
+.. doxygengroup:: bt_mesh_lvl_cli
+   :project: nrf
+   :members:
+
+----
+
+Common types
+=============
+
+| Header file: :file:`include/bluetooth/mesh/gen_lvl.h`
+
+.. doxygengroup:: bt_mesh_lvl
+   :project: nrf
+   :members:

--- a/include/bluetooth/mesh/gen_lvl_cli.h
+++ b/include/bluetooth/mesh/gen_lvl_cli.h
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+/**
+ * @file
+ * @defgroup bt_mesh_lvl_cli Generic Level Client model
+ * @{
+ * @brief API for the Generic Level Client model.
+ */
+#ifndef BT_MESH_GEN_LVL_CLI_H__
+#define BT_MESH_GEN_LVL_CLI_H__
+
+#include <bluetooth/mesh/gen_lvl.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct bt_mesh_lvl_cli;
+
+/** @def BT_MESH_LVL_CLI_INIT
+ *
+ * @brief Initialization parameters for the @ref bt_mesh_lvl_cli.
+ *
+ * @param[in] _status_handler Optional status message handler.
+ * @sa bt_mesh_lvl_cli::status_handler
+ */
+#define BT_MESH_LVL_CLI_INIT(_status_handler)                                  \
+	{                                                                      \
+		.pub = { .msg = NET_BUF_SIMPLE(BT_MESH_MODEL_BUF_LEN(          \
+				 BT_MESH_LVL_OP_DELTA_SET,                     \
+				 BT_MESH_LVL_MSG_MAXLEN_DELTA_SET)) },         \
+		.status_handler = _status_handler,                             \
+	}
+
+/** @def BT_MESH_MODEL_LVL_CLI
+ *
+ * @brief Generic Level Client model composition data entry.
+ *
+ * @param[in] _cli Pointer to a @ref bt_mesh_lvl_cli instance.
+ */
+#define BT_MESH_MODEL_LVL_CLI(_cli)                                            \
+	BT_MESH_MODEL_CB(BT_MESH_MODEL_ID_GEN_LEVEL_CLI, _bt_mesh_lvl_cli_op,  \
+			 &(_cli)->pub,                                         \
+			 BT_MESH_MODEL_USER_DATA(struct bt_mesh_lvl_cli,       \
+						 _cli),                        \
+			 &_bt_mesh_lvl_cli_cb)
+
+/**
+ * Generic Level Client instance.
+ *
+ * Should be initialized with @ref BT_MESH_LVL_CLI_INIT.
+ */
+struct bt_mesh_lvl_cli {
+	/** Model entry. */
+	struct bt_mesh_model *model;
+	/** Publish parameters. */
+	struct bt_mesh_model_pub pub;
+	/** Acknowledged message tracking. */
+	struct bt_mesh_model_ack_ctx ack_ctx;
+	/** Current transaction ID. */
+	u8_t tid;
+
+	/** @brief Level status message handler.
+	 *
+	 * @param[in] cli Client that received the status message.
+	 * @param[in] ctx Context of the message.
+	 * @param[in] status Generic level status contained in the message.
+	 */
+	void (*const status_handler)(struct bt_mesh_lvl_cli *cli,
+				     struct bt_mesh_msg_ctx *ctx,
+				     const struct bt_mesh_lvl_status *status);
+};
+
+/** @brief Get the status of the bound server.
+ *
+ * This call is blocking if the @p rsp buffer is non-NULL. Otherwise, this
+ * function will return, and the response will be passed to the
+ * @ref bt_mesh_lvl_cli::status_handler callback.
+ *
+ * @param[in] cli Client model to send on.
+ * @param[in] ctx Message context, or NULL to use the configured publish
+ * parameters.
+ * @param[out] rsp Status response buffer, or NULL to keep from blocking.
+ *
+ * @retval 0 Successfully sent the message and populated the @p rsp buffer.
+ * @retval -EALREADY A blocking request is already in progress.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
+ */
+int bt_mesh_lvl_cli_get(struct bt_mesh_lvl_cli *cli,
+			struct bt_mesh_msg_ctx *ctx,
+			struct bt_mesh_lvl_status *rsp);
+
+/** @brief Set the level state in the server.
+ *
+ * This call is blocking if the @p rsp buffer is non-NULL. Otherwise, this
+ * function will not request a response from the server, and return
+ * immediately.
+ *
+ * @param[in] cli Client model to send on.
+ * @param[in] ctx Message context, or NULL to use the configured publish
+ * parameters.
+ * @param[in] set New level value to set. Set @p set::transition to NULL to use
+ * the server's default transition parameters.
+ * @param[out] rsp Response status buffer, or NULL to send an unacknowledged
+ * message.
+ *
+ * @retval 0 Successfully sent the message and populated the @p rsp buffer.
+ * @retval -EALREADY A blocking request is already in progress.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
+ */
+int bt_mesh_lvl_cli_set(struct bt_mesh_lvl_cli *cli,
+			struct bt_mesh_msg_ctx *ctx,
+			const struct bt_mesh_lvl_set *set,
+			struct bt_mesh_lvl_status *rsp);
+
+/** @brief Trigger a differential level state change in the server.
+ *
+ * Makes the server move its level state by some delta value. If multiple
+ * delta_set messages are sent in a row (with less than 6 seconds interval),
+ * and @p delta_set::new_transaction is set to false, the server will continue
+ * using the same base value for its delta as in the first message, unless
+ * some other client made changes to the server.
+ *
+ * This call is blocking if the @p rsp buffer is non-NULL. Otherwise, this
+ * function will not request a response from the server, and return
+ * immediately.
+ *
+ * @param[in] cli Client model to send on.
+ * @param[in] ctx Message context, or NULL to use the configured publish
+ * parameters.
+ * @param[in] delta_set State change to make. Set @p set::transition to NULL to
+ * use the server's default transition parameters.
+ * @param[out] rsp Response status buffer, or NULL to send an unacknowledged
+ * message.
+ *
+ * @retval 0 Successfully sent the message and populated the @p rsp buffer.
+ * @retval -EALREADY A blocking request is already in progress.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
+ */
+int bt_mesh_lvl_cli_delta_set(struct bt_mesh_lvl_cli *cli,
+			      struct bt_mesh_msg_ctx *ctx,
+			      const struct bt_mesh_lvl_delta_set *delta_set,
+			      struct bt_mesh_lvl_status *rsp);
+
+/** @brief Trigger a continuous level change in the server.
+ *
+ * Makes the server continuously move its level state by the set rate:
+ *
+ * @code
+ * rate_of_change = move_set->delta / move_set->transition->time
+ * @endcode
+ *
+ * The server will continue moving its level until it is told to stop, or until
+ * it reaches some application specific boundary value. The server may choose
+ * to wrap around the level value, depending on its usage. The move can be
+ * stopped by sending a new move message with a delta value of 0.
+ *
+ * This call is blocking if the @p rsp buffer is non-NULL. Otherwise, this
+ * function will not request a response from the server, and return
+ * immediately.
+ *
+ * @param[in] cli Client model to send on.
+ * @param[in] ctx Message context, or NULL to use the configured publish
+ * parameters.
+ * @param[in] move_set State change to make. Set @p set::transition to NULL to
+ * use the server's default transition parameters.
+ * @param[out] rsp Response status buffer, or NULL to send an unacknowledged
+ * message.
+ *
+ * @retval 0 Successfully sent the message and populated the @p rsp buffer.
+ * @retval -EALREADY A blocking request is already in progress.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
+ */
+int bt_mesh_lvl_cli_move_set(struct bt_mesh_lvl_cli *cli,
+			     struct bt_mesh_msg_ctx *ctx,
+			     const struct bt_mesh_lvl_move_set *move_set,
+			     struct bt_mesh_lvl_status *rsp);
+
+/** @cond INTERNAL_HIDDEN */
+extern const struct bt_mesh_model_op _bt_mesh_lvl_cli_op[];
+extern const struct bt_mesh_model_cb _bt_mesh_lvl_cli_cb;
+/** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BT_MESH_GEN_LVL_CLI_H__ */
+
+/** @} */

--- a/include/bluetooth/mesh/gen_lvl_srv.h
+++ b/include/bluetooth/mesh/gen_lvl_srv.h
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/**
+ * @file
+ * @defgroup bt_mesh_lvl_srv Bluetooth Mesh Generic Level Server model
+ * @ingroup bt_mesh_lvl
+ * @{
+ * @brief API for the Generic Level Server model.
+ */
+
+#ifndef BT_MESH_GEN_LVL_SRV_H__
+#define BT_MESH_GEN_LVL_SRV_H__
+
+#include <bluetooth/mesh/gen_lvl.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct bt_mesh_lvl_srv;
+
+/** @def BT_MESH_LVL_SRV_INIT
+ *
+ * @brief Initialization parameters for a @ref bt_mesh_lvl_srv instance.
+ *
+ * @param[in] _handlers Pointer to a handler function structure.
+ */
+#define BT_MESH_LVL_SRV_INIT(_handlers)                                        \
+	{                                                                      \
+		.handlers = _handlers,                                         \
+		.pub = {.update = _bt_mesh_lvl_srv_update_handler,             \
+			.msg = NET_BUF_SIMPLE(BT_MESH_MODEL_BUF_LEN(           \
+				BT_MESH_LVL_OP_STATUS,                         \
+				BT_MESH_LVL_MSG_MAXLEN_STATUS)),               \
+		}                                                              \
+	}
+
+/** @def BT_MESH_MODEL_LVL_SRV
+ *
+ * @brief Generic Level Server model composition data entry.
+ *
+ * @param[in] _srv Pointer to a @ref bt_mesh_lvl_srv instance.
+ */
+#define BT_MESH_MODEL_LVL_SRV(_srv)                                            \
+	BT_MESH_MODEL_CB(BT_MESH_MODEL_ID_GEN_LEVEL_SRV, _bt_mesh_lvl_srv_op,  \
+			 &(_srv)->pub,                                         \
+			 BT_MESH_MODEL_USER_DATA(struct bt_mesh_lvl_srv,       \
+						 _srv),                        \
+			 &_bt_mesh_lvl_srv_cb)
+
+/** Handler functions for the generic level server. */
+struct bt_mesh_lvl_srv_handlers {
+	/** @brief Get the current level state.
+	 *
+	 * @note This handler is mandatory.
+	 *
+	 * @param[in] srv Level server to get the state of.
+	 * @param[in] ctx Message context for the message that triggered the
+	 * request, or NULL if the request is not coming from a message.
+	 * @param[out] rsp Response structure to be filled.
+	 */
+	void (*const get)(struct bt_mesh_lvl_srv *srv,
+			  struct bt_mesh_msg_ctx *ctx,
+			  struct bt_mesh_lvl_status *rsp);
+
+	/** @brief Set the level state.
+	 *
+	 * @note This handler is mandatory.
+	 *
+	 * @param[in] srv Level server to set the state of.
+	 * @param[in] ctx Message context for the message that triggered the
+	 * change, or NULL if the change is not coming from a message.
+	 * @param[in] set Parameters of the state change. Note that the
+	 * transition will always be non-NULL.
+	 * @param[out] rsp Response structure to be filled.
+	 */
+	void (*const set)(struct bt_mesh_lvl_srv *srv,
+			  struct bt_mesh_msg_ctx *ctx,
+			  const struct bt_mesh_lvl_set *set,
+			  struct bt_mesh_lvl_status *rsp);
+
+	/**
+	 * @brief Change the level state relative to its current value.
+	 *
+	 * If @c delta_set::new_transaction is false, the state transition
+	 * should use the same start point as the previous delta_set message,
+	 * effectively overriding the previous message. If it's true, the level
+	 * transition should start from the current level, stopping any
+	 * ongoing transitions.
+	 *
+	 * @note This handler is mandatory.
+	 *
+	 * @param[in] srv Level server to change the state of.
+	 * @param[in] ctx Message context for the message that triggered the
+	 * change, or NULL if the change is not coming from a messge.
+	 * @param[in] delta_set Parameters of the state change. Note that the
+	 * transition will always be non-NULL.
+	 * @param[out] rsp Response structure to be filled.
+	 */
+	void (*const delta_set)(struct bt_mesh_lvl_srv *srv,
+				struct bt_mesh_msg_ctx *ctx,
+				const struct bt_mesh_lvl_delta_set *delta_set,
+				struct bt_mesh_lvl_status *rsp);
+
+	/** @brief Move the level state continuously at a given rate.
+	 *
+	 * The level state should move @c move_set::delta units for every
+	 * @c move_set::transition::time milliseconds. For instance, if
+	 * delta is 5 and the transition time is 100ms, the state should move
+	 * at a rate of 50 per second.
+	 *
+	 * When reaching the border values for the state, the wraparound
+	 * behavior is application specific. While the server is executing a
+	 * move command, it should report its @c target value as
+	 * @ref BT_MESH_LVL_MIN or @ref BT_MESH_LVL_MAX, depending on whether
+	 * it's moving up or down.
+	 *
+	 * @note This handler is mandatory.
+	 *
+	 * @param[in] srv Level server to change the state of.
+	 * @param[in] ctx Message context for the message that triggered the
+	 * change, or NULL if the change is not coming from a messge.
+	 * @param[in] move_set Parameters of the state change. Note that the
+	 * transition will always be non-NULL.
+	 * @param[out] rsp Response structure to be filled.
+	 */
+	void (*const move_set)(struct bt_mesh_lvl_srv *srv,
+			       struct bt_mesh_msg_ctx *ctx,
+			       const struct bt_mesh_lvl_move_set *move_set,
+			       struct bt_mesh_lvl_status *rsp);
+};
+
+/**
+ * Generic Level Server instance. Should be initialized with the
+ * @ref BT_MESH_LVL_SRV_INIT macro.
+ */
+struct bt_mesh_lvl_srv {
+	/** Application handler functions. */
+	const struct bt_mesh_lvl_srv_handlers *const handlers;
+	/** Pointer to the mesh model entry. */
+	struct bt_mesh_model *model;
+	/** Model publication parameters. */
+	struct bt_mesh_model_pub pub;
+	/** Transaction ID tracking. */
+	struct bt_mesh_tid_ctx tid;
+};
+
+/** @brief Publish the generic level state.
+ *
+ * @param[in] srv Server whose level state should be published.
+ * @param[in] ctx Message context to publish with, or NULL to publish on the
+ * configured publish parameters.
+ * @param[in] status Current status.
+ *
+ * @retval 0 Successfully published a Generic Level Status message.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ */
+int bt_mesh_lvl_srv_pub(struct bt_mesh_lvl_srv *srv,
+			struct bt_mesh_msg_ctx *ctx,
+			const struct bt_mesh_lvl_status *status);
+
+/** @cond INTERNAL_HIDDEN */
+extern const struct bt_mesh_model_op _bt_mesh_lvl_srv_op[];
+extern const struct bt_mesh_model_cb _bt_mesh_lvl_srv_cb;
+int _bt_mesh_lvl_srv_update_handler(struct bt_mesh_model *model);
+/** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BT_MESH_GEN_LVL_SRV_H__ */
+
+/** @} */

--- a/include/bluetooth/mesh/gen_onoff.h
+++ b/include/bluetooth/mesh/gen_onoff.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/**
+ * @file
+ * @defgroup bt_mesh_onoff Generic OnOff Models
+ * @{
+ * @brief Common API for the Generic OnOff models.
+ */
+
+#ifndef BT_MESH_GEN_ONOFF_H__
+#define BT_MESH_GEN_ONOFF_H__
+
+#include <bluetooth/mesh/model_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @cond INTERNAL_HIDDEN */
+#define BT_MESH_ONOFF_OP_GET BT_MESH_MODEL_OP_2(0x82, 0x01)
+#define BT_MESH_ONOFF_OP_SET BT_MESH_MODEL_OP_2(0x82, 0x02)
+#define BT_MESH_ONOFF_OP_SET_UNACK BT_MESH_MODEL_OP_2(0x82, 0x03)
+#define BT_MESH_ONOFF_OP_STATUS BT_MESH_MODEL_OP_2(0x82, 0x04)
+
+#define BT_MESH_ONOFF_MSG_LEN_GET 0
+#define BT_MESH_ONOFF_MSG_MINLEN_SET 2
+#define BT_MESH_ONOFF_MSG_MAXLEN_SET 4
+#define BT_MESH_ONOFF_MSG_MINLEN_STATUS 1
+#define BT_MESH_ONOFF_MSG_MAXLEN_STATUS 3
+/** @endcond */
+
+/** Mandatory parameters for the Generic OnOff Set message. */
+struct bt_mesh_onoff_set {
+	/** State to set. */
+	bool on_off;
+	/** Transition parameters. */
+	const struct bt_mesh_model_transition *transition;
+};
+
+/** Parameters for the Generic OnOff Status message. */
+struct bt_mesh_onoff_status {
+	/** The present value of the Generic OnOff state. */
+	bool present_on_off;
+	/** The target value of the Generic OnOff state (optional). */
+	bool target_on_off;
+	/** Remaining time value in milliseconds. */
+	s32_t remaining_time;
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BT_MESH_GEN_ONOFF_H__ */
+
+/** @} */

--- a/include/bluetooth/mesh/gen_onoff.rst
+++ b/include/bluetooth/mesh/gen_onoff.rst
@@ -1,0 +1,104 @@
+.. _bt_mesh_onoff_readme:
+
+Generic OnOff models
+####################
+
+The Generic OnOff models allows remote control of boolean states on a mesh
+device.
+
+There are two Generic OnOff models:
+
+- :ref:`bt_mesh_onoff_srv_readme`
+- :ref:`bt_mesh_onoff_cli_readme`
+
+.. _bt_mesh_onoff_srv_readme:
+
+Generic OnOff Server
+====================
+
+The Generic OnOff Server represents a single controllable On/Off value.
+
+
+States
+*******
+
+This model has the following states:
+
+**Generic OnOff:** ``boolean``
+
+Generic boolean state representing an On/Off state. The user is expected
+to hold the state memory and provide access to the state through the
+:cpp:type:`bt_mesh_onoff_srv_handlers` handler structure.
+
+Changes to the Generic OnOff state may include transition parameters. When
+transitioning to a new OnOff state, the state should be `on` during the entire
+transition, regardless of target state. This ensures that any bound non-binary
+states can have non-0 values during the transition.
+
+Any requests to read out the current OnOff state while in a transition should
+report the current OnOff value being `on`.
+
+The ``remaining_time`` parameter should be reported in milliseconds, including
+delay. If the transition parameters includes a delay, the state shall remain
+unchanged until the delay expires.
+
+Extended models
+****************
+
+None.
+
+Persistent storage
+*******************
+
+None.
+
+API documentation
+******************
+
+| Header file: :file:`include/bluetooth/mesh/gen_onoff_srv.h`
+| Source file: :file:`subsys/bluetooth/mesh/gen_onoff_srv.c`
+
+.. doxygengroup:: bt_mesh_onoff_srv
+   :project: nrf
+   :members:
+
+----
+
+.. _bt_mesh_onoff_cli_readme:
+
+Generic OnOff Client
+====================
+
+The Generic OnOff Client model remotely controls the state of a Generic OnOff
+Server model.
+
+Extended models
+****************
+
+None.
+
+Persistent storage
+*******************
+
+None.
+
+API documentation
+******************
+
+| Header file: :file:`include/bluetooth/mesh/gen_onoff_cli.h`
+| Source file: :file:`subsys/bluetooth/mesh/gen_onoff_cli.c`
+
+.. doxygengroup:: bt_mesh_onoff_cli
+   :project: nrf
+   :members:
+
+----
+
+Common types
+=============
+
+| Header file: :file:`include/bluetooth/mesh/gen_onoff.h`
+
+.. doxygengroup:: bt_mesh_onoff
+   :project: nrf
+   :members:

--- a/include/bluetooth/mesh/gen_onoff_cli.h
+++ b/include/bluetooth/mesh/gen_onoff_cli.h
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/**
+ * @file
+ * @defgroup bt_mesh_onoff_cli Generic OnOff Client model
+ * @{
+ * @brief API for the Generic OnOff Client model.
+ */
+
+#ifndef BT_MESH_GEN_ONOFF_CLI_H__
+#define BT_MESH_GEN_ONOFF_CLI_H__
+
+#include <bluetooth/mesh/gen_onoff.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct bt_mesh_onoff_cli;
+
+/** @def BT_MESH_ONOFF_CLI_INIT
+ *
+ * @brief Initialization parameters for a @ref bt_mesh_onoff_cli instance.
+ *
+ * @param[in] _status_handler Optional status message handler.
+ */
+#define BT_MESH_ONOFF_CLI_INIT(_status_handler)                                \
+	{                                                                      \
+		.status_handler = _status_handler,                             \
+		.pub = {.msg = NET_BUF_SIMPLE(BT_MESH_MODEL_BUF_LEN(           \
+				BT_MESH_ONOFF_OP_SET,                          \
+				BT_MESH_ONOFF_MSG_MAXLEN_SET)) }               \
+	}
+
+/** @def BT_MESH_MODEL_ONOFF_CLI
+ *
+ * @brief Generic OnOff Client model composition data entry.
+ *
+ * @param[in] _cli Pointer to a @ref bt_mesh_onoff_cli instance.
+ */
+#define BT_MESH_MODEL_ONOFF_CLI(_cli)                                          \
+	BT_MESH_MODEL_CB(BT_MESH_MODEL_ID_GEN_ONOFF_CLI,                       \
+			 _bt_mesh_onoff_cli_op, &(_cli)->pub,                  \
+			 BT_MESH_MODEL_USER_DATA(struct bt_mesh_onoff_cli,     \
+						 _cli),                        \
+			 &_bt_mesh_onoff_cli_cb)
+
+/**
+ * Generic OnOff Client structure.
+ *
+ * Should be initialized with the @ref BT_MESH_ONOFF_CLI_INIT macro.
+ */
+struct bt_mesh_onoff_cli {
+	/** @brief OnOff status message handler.
+	 *
+	 * @param[in] cli Client that received the status message.
+	 * @param[in] ctx Context of the incoming message.
+	 * @param[in] status OnOff Status of the Generic OnOff Server that
+	 * published the message.
+	 */
+	void (*const status_handler)(struct bt_mesh_onoff_cli *cli,
+				     struct bt_mesh_msg_ctx *ctx,
+				     const struct bt_mesh_onoff_status *status);
+	/** Current Transaction ID. */
+	u8_t tid;
+	/** Response context for tracking acknowledged messages. */
+	struct bt_mesh_model_ack_ctx ack_ctx;
+	/** Publish parameters. */
+	struct bt_mesh_model_pub pub;
+	/** Access model pointer. */
+	struct bt_mesh_model *model;
+};
+
+/** @brief Get the status of the bound srv.
+ *
+ * This call is blocking if the @p rsp buffer is non-NULL. Otherwise, this
+ * function will return, and the response will be passed to the
+ * @ref bt_mesh_onoff_cli::status_handler callback.
+ *
+ * @param[in] cli Client model to send on.
+ * @param[in] ctx Message context, or NULL to use the configured publish
+ * parameters.
+ * @param[out] rsp Status response buffer, or NULL to keep from blocking.
+ *
+ * @retval 0 Successfully sent the message and populated the @p rsp buffer.
+ * @retval -EALREADY A blocking request is already in progress.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
+ */
+int bt_mesh_onoff_cli_get(struct bt_mesh_onoff_cli *cli,
+			  struct bt_mesh_msg_ctx *ctx,
+			  struct bt_mesh_onoff_status *rsp);
+
+/** @brief Set the OnOff state in the srv.
+ *
+ * This call is blocking if the @p rsp buffer is non-NULL. Otherwise, this
+ * function will not request a response from the server, and return
+ * immediately.
+ *
+ * @param[in] cli Client model to send on.
+ * @param[in] ctx Message context, or NULL to use the configured publish
+ * parameters.
+ * @param[in] set New OnOff parameters to set. @p set::transition can either
+ * point to a transition structure, or be left to NULL to use the default
+ * transition parameters on the server.
+ * @param[out] rsp Response status buffer, or NULL to send an unacknowledged
+ * message.
+ *
+ * @retval 0 Successfully sent the message and populated the @p rsp buffer.
+ * @retval -EALREADY A blocking request is already in progress.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
+ */
+int bt_mesh_onoff_cli_set(struct bt_mesh_onoff_cli *cli,
+			  struct bt_mesh_msg_ctx *ctx,
+			  const struct bt_mesh_onoff_set *set,
+			  struct bt_mesh_onoff_status *rsp);
+
+/** @cond INTERNAL_HIDDEN */
+extern const struct bt_mesh_model_op _bt_mesh_onoff_cli_op[];
+extern const struct bt_mesh_model_cb _bt_mesh_onoff_cli_cb;
+/** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BT_MESH_GEN_ONOFF_CLI_H__ */
+
+/* @} */

--- a/include/bluetooth/mesh/gen_onoff_srv.h
+++ b/include/bluetooth/mesh/gen_onoff_srv.h
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/**
+ * @file
+ * @defgroup bt_mesh_onoff_srv Generic OnOff Server model
+ * @ingroup bt_mesh_onoff
+ * @{
+ * @brief API for the Generic OnOff Server model.
+ */
+
+#ifndef BT_MESH_GEN_ONOFF_SRV_H__
+#define BT_MESH_GEN_ONOFF_SRV_H__
+
+#include <bluetooth/mesh/gen_onoff.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct bt_mesh_onoff_srv;
+
+/** @def BT_MESH_ONOFF_SRV_INIT
+ *
+ * @brief Init parameters for a @ref bt_mesh_onoff_srv instance.
+ *
+ * @param[in] _handlers State access handlers to use in the model instance.
+ */
+#define BT_MESH_ONOFF_SRV_INIT(_handlers)                                      \
+	{                                                                      \
+		.handlers = _handlers,                                         \
+		.pub = {                                                       \
+			.update = _bt_mesh_onoff_srv_update_handler,           \
+			.msg = NET_BUF_SIMPLE(BT_MESH_MODEL_BUF_LEN(           \
+				BT_MESH_ONOFF_OP_STATUS,                       \
+				BT_MESH_ONOFF_MSG_MAXLEN_STATUS)),             \
+		},                                                             \
+	}
+
+/** @def BT_MESH_MODEL_ONOFF_SRV
+ *
+ * @brief Generic OnOff Server model composition data entry.
+ *
+ * @param[in] _srv Pointer to a @ref bt_mesh_onoff_srv instance.
+ */
+#define BT_MESH_MODEL_ONOFF_SRV(_srv)                                          \
+	BT_MESH_MODEL_CB(BT_MESH_MODEL_ID_GEN_ONOFF_SRV,                       \
+			 _bt_mesh_onoff_srv_op, &(_srv)->pub,                  \
+			 BT_MESH_MODEL_USER_DATA(struct bt_mesh_onoff_srv,     \
+						 _srv),                        \
+			 &_bt_mesh_onoff_srv_cb)
+
+/** Generic OnOff Server state access handlers. */
+struct bt_mesh_onoff_srv_handlers {
+	/** @brief Set the OnOff state.
+	 *
+	 * @note This handler is mandatory.
+	 *
+	 * @param[in] srv Server instance to set the state of.
+	 * @param[in] ctx Message context for the message that triggered the
+	 * change, or NULL if the change is not coming from a message.
+	 * @param[in] set Parameters of the state change.
+	 * @param[out] rsp Response structure to be filled, or NULL if no
+	 * response is required.
+	 */
+	void (*const set)(struct bt_mesh_onoff_srv *srv,
+			  struct bt_mesh_msg_ctx *ctx,
+			  const struct bt_mesh_onoff_set *set,
+			  struct bt_mesh_onoff_status *rsp);
+
+	/** @brief Get the OnOff state.
+	 *
+	 * @note This handler is mandatory.
+	 *
+	 * @param[in] srv Server instance to get the state of.
+	 * @param[in] ctx Message context for the message that triggered the
+	 * change, or NULL if the change is not coming from a message.
+	 * @param[out] rsp Response structure to be filled.
+	 */
+	void (*const get)(struct bt_mesh_onoff_srv *srv,
+			  struct bt_mesh_msg_ctx *ctx,
+			  struct bt_mesh_onoff_status *rsp);
+};
+
+/**
+ * Generic OnOff Server instance. Should primarily be initialized with the
+ * @ref BT_MESH_ONOFF_SRV_INIT macro.
+ */
+struct bt_mesh_onoff_srv {
+	/** Transaction ID tracker. */
+	struct bt_mesh_tid_ctx prev_transaction;
+	/** Handler function structure. */
+	const struct bt_mesh_onoff_srv_handlers *handlers;
+	/** Access model pointer. */
+	struct bt_mesh_model *model;
+	/** Publish parameters. */
+	struct bt_mesh_model_pub pub;
+};
+
+/** @brief Publish the Generic OnOff Server model status.
+ *
+ * Asynchronously publishes a Generic OnOff status message with the configured
+ * publish parameters.
+ *
+ * @note This API is only used publishing unprompted status messages. Response
+ * messages for get and set messages are handled internally.
+ *
+ * @param[in] srv Server instance to publish on.
+ * @param[in] ctx Message context to send with, or NULL to send with the
+ * default publish parameters.
+ * @param[in] status Current status.
+ *
+ * @retval 0 Successfully published a Generic OnOff Status message.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ */
+s32_t bt_mesh_onoff_srv_pub(struct bt_mesh_onoff_srv *srv,
+			    struct bt_mesh_msg_ctx *ctx,
+			    const struct bt_mesh_onoff_status *status);
+
+/** @cond INTERNAL_HIDDEN */
+extern const struct bt_mesh_model_op _bt_mesh_onoff_srv_op[];
+extern const struct bt_mesh_model_cb _bt_mesh_onoff_srv_cb;
+int _bt_mesh_onoff_srv_update_handler(struct bt_mesh_model *model);
+/** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BT_MESH_GEN_ONOFF_SRV_H__ */
+
+/** @} */

--- a/include/bluetooth/mesh/gen_plvl.h
+++ b/include/bluetooth/mesh/gen_plvl.h
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+/**
+ * @file
+ * @defgroup bt_mesh_plvl Generic Power Level Models
+ * @{
+ * @brief API for the Generic Power Level models.
+ */
+
+#ifndef BT_MESH_GEN_PLVL_H__
+#define BT_MESH_GEN_PLVL_H__
+
+#include <bluetooth/mesh.h>
+#include <bluetooth/mesh/model_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @cond INTERNAL_HIDDEN */
+#define BT_MESH_PLVL_OP_LEVEL_GET BT_MESH_MODEL_OP_2(0x82, 0x15)
+#define BT_MESH_PLVL_OP_LEVEL_SET BT_MESH_MODEL_OP_2(0x82, 0x16)
+#define BT_MESH_PLVL_OP_LEVEL_SET_UNACK BT_MESH_MODEL_OP_2(0x82, 0x17)
+#define BT_MESH_PLVL_OP_LEVEL_STATUS BT_MESH_MODEL_OP_2(0x82, 0x18)
+#define BT_MESH_PLVL_OP_LAST_GET BT_MESH_MODEL_OP_2(0x82, 0x19)
+#define BT_MESH_PLVL_OP_LAST_STATUS BT_MESH_MODEL_OP_2(0x82, 0x1A)
+#define BT_MESH_PLVL_OP_DEFAULT_GET BT_MESH_MODEL_OP_2(0x82, 0x1B)
+#define BT_MESH_PLVL_OP_DEFAULT_STATUS BT_MESH_MODEL_OP_2(0x82, 0x1C)
+#define BT_MESH_PLVL_OP_RANGE_GET BT_MESH_MODEL_OP_2(0x82, 0x1D)
+#define BT_MESH_PLVL_OP_RANGE_STATUS BT_MESH_MODEL_OP_2(0x82, 0x1E)
+#define BT_MESH_PLVL_OP_DEFAULT_SET BT_MESH_MODEL_OP_2(0x82, 0x1F)
+#define BT_MESH_PLVL_OP_DEFAULT_SET_UNACK BT_MESH_MODEL_OP_2(0x82, 0x20)
+#define BT_MESH_PLVL_OP_RANGE_SET BT_MESH_MODEL_OP_2(0x82, 0x21)
+#define BT_MESH_PLVL_OP_RANGE_SET_UNACK BT_MESH_MODEL_OP_2(0x82, 0x22)
+
+#define BT_MESH_PLVL_MSG_LEN_LEVEL_GET 0
+#define BT_MESH_PLVL_MSG_MINLEN_LEVEL_SET 3
+#define BT_MESH_PLVL_MSG_MAXLEN_LEVEL_SET 5
+#define BT_MESH_PLVL_MSG_MINLEN_LEVEL_STATUS 2
+#define BT_MESH_PLVL_MSG_MAXLEN_LEVEL_STATUS 5
+#define BT_MESH_PLVL_MSG_LEN_LAST_GET 0
+#define BT_MESH_PLVL_MSG_LEN_LAST_STATUS 2
+#define BT_MESH_PLVL_MSG_LEN_DEFAULT_GET 0
+#define BT_MESH_PLVL_MSG_LEN_DEFAULT_STATUS 2
+#define BT_MESH_PLVL_MSG_LEN_RANGE_GET 0
+#define BT_MESH_PLVL_MSG_LEN_RANGE_STATUS 4
+#define BT_MESH_PLVL_MSG_LEN_DEFAULT_SET 2
+#define BT_MESH_PLVL_MSG_LEN_RANGE_SET 4
+/** @endcond */
+
+/** Power Level set message parameters. */
+struct bt_mesh_plvl_set {
+	/** Power Level. */
+	u16_t power_lvl;
+	/**
+	 * Transition time parameters for the state change. Setting the
+	 * transition to NULL makes the server use its default transition time
+	 * parameters.
+	 */
+	const struct bt_mesh_model_transition *transition;
+};
+
+/** Power Level status message parameters. */
+struct bt_mesh_plvl_status {
+	/** Current Power Level. */
+	u16_t current;
+	/** Target Power Level. */
+	u16_t target;
+	/**
+	 * Time remaining of the ongoing transition, or @ref K_FOREVER.
+	 * If there's no ongoing transition, @c remaining_time is 0.
+	 */
+	s32_t remaining_time;
+};
+
+/** Power Level range parameters. */
+struct bt_mesh_plvl_range {
+	u16_t min; /**< Minimum allowed Power Level. */
+	u16_t max; /**< Maximum allowed Power Level. */
+};
+
+/** Power Level range message parameters. */
+struct bt_mesh_plvl_range_status {
+	/** Status of the previous operation. */
+	enum bt_mesh_model_status status;
+	/** Current Power Level range. */
+	struct bt_mesh_plvl_range range;
+};
+
+/**
+ * @brief Convert Power Level to a percent.
+ *
+ * @param[in] plvl Raw Power Level.
+ *
+ * @return The Power Level in percent.
+ */
+static inline u8_t bt_mesh_plvl_to_percent(u16_t plvl)
+{
+	return (100UL * plvl) / UINT16_MAX;
+}
+
+/**
+ * @brief Convert percent to raw Power Level.
+ *
+ * @param[in] plvl_percent Power Level in percent.
+ *
+ * @return The raw Power Level.
+ */
+static inline u16_t bt_mesh_plvl_from_percent(u8_t plvl_percent)
+{
+	return (UINT16_MAX * plvl_percent) / 100;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BT_MESH_GEN_PLVL_H__ */
+
+/** @} */

--- a/include/bluetooth/mesh/gen_plvl.rst
+++ b/include/bluetooth/mesh/gen_plvl.rst
@@ -1,0 +1,183 @@
+.. _bt_mesh_plvl_readme:
+
+Generic Power Level models
+##########################
+
+The Generic Power Level models allow remote control of power levels on a
+mesh device. Typical applications for the Generic Power Level model are
+heaters, fans and dimmer outlets.
+
+There are two Generic Power Level models:
+
+- :ref:`bt_mesh_plvl_srv_readme`
+- :ref:`bt_mesh_plvl_cli_readme`
+
+.. _bt_mesh_plvl_srv_readme:
+
+Generic Power Level Server
+==========================
+
+The Generic Power Level Server controls the output power level of a peripheral
+on the Mesh-enabled device.
+
+Generic Power Level Server adds two model instances in the composition data:
+
+- The Generic Power Level Server
+- The Generic Power Level Setup Server
+
+The two model instances share the states of the Generic Power Level Server,
+but accept different messages. This allows fine-grained control of the access
+rights for the Generic Power Level states, as the two model instances can be
+bound to different application keys.
+
+The Generic Power Level Server is the "user facing" model instance in the pair,
+and only provides access to the Generic Power Level state, and its last
+non-zero value.
+
+The Generic Power Level Setup Server provides access to the two metastates,
+Default Power and Power Range, allowing configurator devices to set up the
+range and default value for the Generic Power Level state.
+
+States
+*******
+
+**Generic Power Level**: ``u16_t``
+
+The Generic Power Level state controls the Power level of an element, and
+ranges from 0 to 65535. The Generic Power Level state is bound to the
+Generic Level State of the :ref:`bt_mesh_lvl_srv_readme`:
+
+::
+
+  Generic Power Level = Generic Level + 32768
+
+The Generic OnOff state of the :ref:`bt_mesh_onoff_srv_readme` (extended
+through the :ref:`bt_mesh_ponoff_srv_readme`) is derived from the Power state:
+
+::
+
+  Generic OnOff = (Generic Power Level > 0)
+
+Conversely, if the Generic OnOff state is changed to Off, the Generic Power
+Level is set to 0. If the Generic OnOff state is changed to On and the Default
+Level state is set, the Generic Power level is set to the value of the Default
+level state. If the Generic OnOff state is changed to On and the Default Level
+state is not set, the Generic Power Level state is set to the last known
+non-zero value.
+
+The Power state power up behavior is determined by the On Power Up state of the
+extended :ref:`bt_mesh_ponoff_srv_readme`:
+
+- :cpp:enumerator:`BT_MESH_ON_POWER_UP_OFF <bt_mesh_ponoff::BT_MESH_ON_POWER_UP_OFF>`:
+  The Power level is set to 0 on power up.
+- :cpp:enumerator:`BT_MESH_ON_POWER_UP_ON <bt_mesh_ponoff::BT_MESH_ON_POWER_UP_ON>`:
+  The Power level is set to Default Level on power up, or the last known
+  non-zero Power level if the Default level is not set.
+- :cpp:enumerator:`BT_MESH_ON_POWER_UP_RESTORE <bt_mesh_ponoff::BT_MESH_ON_POWER_UP_RESTORE>`:
+  The Power level is set to the last known Power level (zero or otherwise).
+
+The user is expected to hold the state memory and provide access to the state
+through the :cpp:type:`bt_mesh_plvl_srv_handlers` handler structure.
+
+**Default Power**: ``s16_t``
+
+The Default Power state is a metastate that controls the default non-zero
+Generic Power Level. It is used when the Generic Power Level turns on, but its
+exact level is not specified.
+
+The memory for the Default Power state is held by the model, and the
+application may receive updates on state changes through the
+:cpp:member:`bt_mesh_plvl_srv_handlers::default_update` callback.
+
+**Power Range**: :cpp:type:`bt_mesh_plvl_range`
+
+The Power Range state is a metastate that determines the accepted Generic Power
+Level range.
+
+If the Generic Power Level is set to a value outside the current Power Range,
+the actual Generic Power Level is moved to fit inside the range.
+
+If the Power Level Range changes to exclude the current Generic Power Level,
+the Generic Power Level should be changed accordingly. Note that the Generic
+Power Level may always be set to zero, even if this is outside the current
+Power Range.
+
+The memory for the Power Range state is held by the model, and the
+application may receive updates on state changes through the
+:cpp:member:`bt_mesh_plvl_srv_handlers::range_update` callback.
+
+Extended models
+****************
+
+The Generic Power Level Server extends the following models:
+
+- :ref:`bt_mesh_lvl_srv_readme`
+- :ref:`bt_mesh_ponoff_srv_readme`
+
+As the states of both extended models are bound to states in the Generic Power
+Level Server, the states of the extended models are not exposed directly to the
+application.
+
+Persistent storage
+*******************
+
+The Generic Power Level Server stores any changes to the Default Power and
+Power Range states, as well as the last known non-zero Generic Power Level and
+whether the Generic Power Level is on or off. This information is used to
+reestablish the correct Generic Power Level when the device powers up.
+
+API documentation
+******************
+
+| Header file: :file:`include/bluetooth/mesh/gen_plvl_srv.h`
+| Source file: :file:`subsys/bluetooth/mesh/gen_plvl_srv.c`
+
+.. doxygengroup:: bt_mesh_plvl_srv
+   :project: nrf
+   :members:
+
+----
+
+.. _bt_mesh_plvl_cli_readme:
+
+Generic Power Level Client
+==========================
+
+The Generic Power Level Client model remotely controls the state of a Generic
+Power Level Server model.
+
+Contrary to the Server model, the Client only creates a single model instance
+in the mesh composition data. The Generic Power Level Client may send
+messages to both the Generic Power Level Server and the Generic Power Level
+Setup Server, as long as it has the right application keys.
+
+Extended models
+****************
+
+None.
+
+Persistent storage
+*******************
+
+None.
+
+API documentation
+******************
+
+| Header file: :file:`include/bluetooth/mesh/gen_plvl_cli.h`
+| Source file: :file:`subsys/bluetooth/mesh/gen_plvl_cli.c`
+
+.. doxygengroup:: bt_mesh_plvl_cli
+   :project: nrf
+   :members:
+
+----
+
+Common types
+=============
+
+| Header file: :file:`include/bluetooth/mesh/gen_plvl.h`
+
+.. doxygengroup:: bt_mesh_plvl
+   :project: nrf
+   :members:

--- a/include/bluetooth/mesh/gen_plvl_cli.h
+++ b/include/bluetooth/mesh/gen_plvl_cli.h
@@ -1,0 +1,302 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/**
+ * @file
+ * @defgroup bt_mesh_plvl_cli Generic Power Level Client model
+ * @{
+ * @brief API for the Generic Power Level Client model.
+ */
+
+#ifndef BT_MESH_GEN_PLVL_CLI_H__
+#define BT_MESH_GEN_PLVL_CLI_H__
+
+#include <bluetooth/mesh/gen_plvl.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct bt_mesh_plvl_cli;
+
+/** @def BT_MESH_PLVL_CLI_INIT
+ *
+ * @brief Initialization parameters for the @ref bt_mesh_plvl_cli.
+ *
+ * @param[in] _handlers Optional message handler structure.
+ * @sa bt_mesh_plvl_cli_handlers.
+ */
+#define BT_MESH_PLVL_CLI_INIT(_handlers)                                       \
+	{                                                                      \
+		.pub = { .msg = NET_BUF_SIMPLE(BT_MESH_MODEL_BUF_LEN(          \
+				 BT_MESH_PLVL_OP_LEVEL_SET,                    \
+				 BT_MESH_PLVL_MSG_MAXLEN_LEVEL_SET)) },        \
+		.handlers = _handlers,                                         \
+	}
+
+/** @def BT_MESH_MODEL_PLVL_CLI
+ *
+ * @brief Generic Power Level Client model composition data entry.
+ *
+ * @param[in] _cli Pointer to a @ref bt_mesh_plvl_cli instance.
+ */
+#define BT_MESH_MODEL_PLVL_CLI(_cli)                                           \
+	BT_MESH_MODEL_CB(BT_MESH_MODEL_ID_GEN_POWER_LEVEL_CLI,                 \
+			 _bt_mesh_plvl_cli_op, &(_cli)->pub,                   \
+			 BT_MESH_MODEL_USER_DATA(struct bt_mesh_plvl_cli,      \
+						 _cli),                        \
+			 &_bt_mesh_plvl_cli_cb)
+
+/** Handler function for the Power Level Client. */
+struct bt_mesh_plvl_cli_handlers {
+	/** @brief Power Level status message handler.
+	 *
+	 * @param[in] cli Client that received the status message.
+	 * @param[in] ctx Context of the message.
+	 * @param[in] status Generic Power Level status contained in the
+	 * message.
+	 */
+	void (*const power_status)(struct bt_mesh_plvl_cli *cli,
+				   struct bt_mesh_msg_ctx *ctx,
+				   const struct bt_mesh_plvl_status *status);
+
+	/** @brief Default Power status message handler.
+	 *
+	 * @param[in] cli Client that received the status message.
+	 * @param[in] ctx Context of the message.
+	 * @param[in] default_power Default Power Level of the server.
+	 */
+	void (*const default_status)(struct bt_mesh_plvl_cli *cli,
+				     struct bt_mesh_msg_ctx *ctx,
+				     u16_t default_power);
+
+	/** @brief Power Range status message handler.
+	 *
+	 * @param[in] cli Client that received the status message.
+	 * @param[in] ctx Context of the message.
+	 * @param[in] status Power Range state of the server.
+	 */
+	void (*const range_status)(
+		struct bt_mesh_plvl_cli *cli, struct bt_mesh_msg_ctx *ctx,
+		const struct bt_mesh_plvl_range_status *status);
+
+	/** @brief Last non-zero Power Level status message handler.
+	 *
+	 * @param[in] cli Client that received the status message.
+	 * @param[in] ctx Context of the message.
+	 * @param[in] last Last non-zero Power Level of the server.
+	 */
+	void (*const last_status)(struct bt_mesh_plvl_cli *cli,
+				  struct bt_mesh_msg_ctx *ctx, u16_t last);
+};
+
+/**
+ * Generic Power Level Client instance. Should be initialized with
+ * @ref BT_MESH_PLVL_CLI_INIT.
+ */
+struct bt_mesh_plvl_cli {
+	/** Model entry. */
+	struct bt_mesh_model *model;
+	/** Publish parameters. */
+	struct bt_mesh_model_pub pub;
+	/** Acknowledged message tracking. */
+	struct bt_mesh_model_ack_ctx ack_ctx;
+	/** Current transaction ID. */
+	u8_t tid;
+	/** Collection of handler callbacks */
+	const struct bt_mesh_plvl_cli_handlers *const handlers;
+};
+
+/** @brief Get the Power Level of the bound server.
+ *
+ * This call is blocking if the @p rsp buffer is non-NULL. Otherwise, this
+ * function will return, and the response will be passed to the
+ * @ref bt_mesh_plvl_cli_handlers::power_status callback.
+ *
+ * @param[in] cli Client model to send on.
+ * @param[in] ctx Message context, or NULL to use the configured publish
+ * parameters.
+ * @param[in] rsp Status response buffer, or NULL to keep from blocking.
+ *
+ * @retval 0 Successfully sent the message and populated the @p rsp buffer.
+ * @retval -EALREADY A blocking request is already in progress.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
+ */
+int bt_mesh_plvl_cli_power_get(struct bt_mesh_plvl_cli *cli,
+			       struct bt_mesh_msg_ctx *ctx,
+			       struct bt_mesh_plvl_status *rsp);
+
+/** @brief Set the Power Level of the server.
+ *
+ * This call is blocking if the @p rsp buffer is non-NULL. Otherwise, this
+ * function will not request a response from the server, and return
+ * immediately.
+ *
+ * @param[in] cli Client model to send on.
+ * @param[in] ctx Message context, or NULL to use the configured publish
+ * parameters.
+ * @param[in] set New Power Level value to set. Set @p set::transition to NULL
+ * to use the server's default transition parameters.
+ * @param[in] rsp Response status buffer, or NULL to send an unacknowledged
+ * message.
+ *
+ * @retval 0 Successfully sent the message and populated the @p rsp buffer.
+ * @retval -EALREADY A blocking request is already in progress.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
+ */
+int bt_mesh_plvl_cli_power_set(struct bt_mesh_plvl_cli *cli,
+			       struct bt_mesh_msg_ctx *ctx,
+			       const struct bt_mesh_plvl_set *set,
+			       struct bt_mesh_plvl_status *rsp);
+
+/** @brief Get the Power Range of the bound server.
+ *
+ * This call is blocking if the @p rsp buffer is non-NULL. Otherwise, this
+ * function will return, and the response will be passed to the
+ * @ref bt_mesh_plvl_cli_handlers::range_status callback.
+ *
+ * @param[in] cli Client model to send on.
+ * @param[in] ctx Message context, or NULL to use the configured publish
+ * parameters.
+ * @param[in] rsp Status response buffer, or NULL to keep from blocking.
+ *
+ * @retval 0 Successfully sent the message and populated the @p rsp buffer.
+ * @retval -EALREADY A blocking request is already in progress.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
+ */
+int bt_mesh_plvl_cli_range_get(struct bt_mesh_plvl_cli *cli,
+			       struct bt_mesh_msg_ctx *ctx,
+			       struct bt_mesh_plvl_range_status *rsp);
+
+/** @brief Set the Power Range state in the server.
+ *
+ * This call is blocking if the @p rsp buffer is non-NULL. Otherwise, this
+ * function will not request a response from the server, and return
+ * immediately.
+ *
+ * @param[in] cli Client model to send on.
+ * @param[in] ctx Message context, or NULL to use the configured publish
+ * parameters.
+ * @param[in] range New Power Range value to set.
+ * @param[in] rsp Response status buffer, or NULL to send an unacknowledged
+ * message.
+ *
+ * @retval 0 Successfully sent the message and populated the @p rsp buffer.
+ * @retval -EALREADY A blocking request is already in progress.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
+ */
+int bt_mesh_plvl_cli_range_set(struct bt_mesh_plvl_cli *cli,
+			       struct bt_mesh_msg_ctx *ctx,
+			       const struct bt_mesh_plvl_range *range,
+			       struct bt_mesh_plvl_range_status *rsp);
+
+/** @brief Get the Default Power of the bound server.
+ *
+ * This call is blocking if the @p rsp buffer is non-NULL. Otherwise, this
+ * function will return, and the response will be passed to the
+ * @ref bt_mesh_plvl_cli_handlers::default_status callback.
+ *
+ * @param[in] cli Client model to send on.
+ * @param[in] ctx Message context, or NULL to use the configured publish
+ * parameters.
+ * @param[in] rsp Status response buffer, or NULL to keep from blocking.
+ *
+ * @retval 0 Successfully sent the message and populated the @p rsp buffer.
+ * @retval -EALREADY A blocking request is already in progress.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
+ */
+int bt_mesh_plvl_cli_default_get(struct bt_mesh_plvl_cli *cli,
+				 struct bt_mesh_msg_ctx *ctx, u16_t *rsp);
+
+/** @brief Set the Default Power state in the server.
+ *
+ * This call is blocking if the @p rsp buffer is non-NULL. Otherwise, this
+ * function will not request a response from the server, and return
+ * immediately.
+ *
+ * @param[in] cli Client model to send on.
+ * @param[in] ctx Message context, or NULL to use the configured publish
+ * parameters.
+ * @param[in] default_power New Default Power value to set.
+ * @param[in] rsp Response status buffer, or NULL to send an unacknowledged
+ * message.
+ *
+ * @retval 0 Successfully sent the message and populated the @p rsp buffer.
+ * @retval -EALREADY A blocking request is already in progress.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
+ */
+int bt_mesh_plvl_cli_default_set(struct bt_mesh_plvl_cli *cli,
+				 struct bt_mesh_msg_ctx *ctx,
+				 u16_t default_power, u16_t *rsp);
+
+/** @brief Get the last non-zero Power Level of the bound server.
+ *
+ * The last non-zero Power Level is the Power Level that will be restored if
+ * the Power Level changes from off to on and no Default Power is set.
+ *
+ * This call is blocking if the @p rsp buffer is non-NULL. Otherwise, this
+ * function will return, and the response will be passed to the
+ * @ref bt_mesh_plvl_cli_handlers::last_status callback.
+ *
+ * @param[in] cli Client model to send on.
+ * @param[in] ctx Message context, or NULL to use the configured publish
+ * parameters.
+ * @param[in] rsp Status response buffer, or NULL to keep from blocking.
+ *
+ * @retval 0 Successfully sent the message and populated the @p rsp buffer.
+ * @retval -EALREADY A blocking request is already in progress.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
+ */
+int bt_mesh_plvl_cli_last_get(struct bt_mesh_plvl_cli *cli,
+			      struct bt_mesh_msg_ctx *ctx, u16_t *rsp);
+
+/** @cond INTERNAL_HIDDEN */
+extern const struct bt_mesh_model_op _bt_mesh_plvl_cli_op[];
+extern const struct bt_mesh_model_cb _bt_mesh_plvl_cli_cb;
+/** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BT_MESH_GEN_PLVL_CLI_H__ */
+
+/** @} */

--- a/include/bluetooth/mesh/gen_plvl_srv.h
+++ b/include/bluetooth/mesh/gen_plvl_srv.h
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/**
+ * @file
+ * @defgroup bt_mesh_plvl_srv Generic Power Level Server model
+ * @{
+ * @brief API for the Generic Power Level Server.
+ */
+
+#ifndef BT_MESH_GEN_PLVL_SRV_H__
+#define BT_MESH_GEN_PLVL_SRV_H__
+
+#include <bluetooth/mesh.h>
+
+#include <bluetooth/mesh/gen_plvl.h>
+#include <bluetooth/mesh/gen_lvl_srv.h>
+#include <bluetooth/mesh/gen_ponoff_srv.h>
+#include <bluetooth/mesh/model_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct bt_mesh_plvl_srv;
+
+/** @def BT_MESH_PLVL_SRV_INIT
+ *
+ * @brief Initialization parameters for @ref bt_mesh_plvl_srv.
+ *
+ * @param[in] _handlers Handler callback structure.
+ */
+#define BT_MESH_PLVL_SRV_INIT(_handlers)                                       \
+	{                                                                      \
+		.lvl = BT_MESH_LVL_SRV_INIT(&bt_mesh_plvl_srv_lvl_handlers),   \
+		.ponoff = BT_MESH_PONOFF_SRV_INIT(                             \
+			&bt_mesh_plvl_srv_onoff_handlers, NULL, NULL),         \
+		.pub = { .update = _bt_mesh_plvl_srv_update_handler,           \
+			 .msg = NET_BUF_SIMPLE(BT_MESH_MODEL_BUF_LEN(          \
+				 BT_MESH_PLVL_OP_LEVEL_STATUS,                 \
+				 BT_MESH_PLVL_MSG_MAXLEN_LEVEL_STATUS)) },     \
+		.handlers = _handlers,                                         \
+	}
+
+/** @def BT_MESH_MODEL_PLVL_SRV
+ *
+ * @brief Generic Power Level model entry.
+ *
+ * @param[in] _srv Pointer to a @ref bt_mesh_plvl_srv instance.
+ */
+#define BT_MESH_MODEL_PLVL_SRV(_srv)                                           \
+	BT_MESH_MODEL_LVL_SRV(&(_srv)->lvl),                                   \
+		BT_MESH_MODEL_PONOFF_SRV(&(_srv)->ponoff),                     \
+		BT_MESH_MODEL_CB(BT_MESH_MODEL_ID_GEN_POWER_LEVEL_SRV,         \
+				 _bt_mesh_plvl_srv_op, &(_srv)->pub,           \
+				 BT_MESH_MODEL_USER_DATA(                      \
+					 struct bt_mesh_plvl_srv, _srv),       \
+				 &_bt_mesh_plvl_srv_cb),                       \
+		BT_MESH_MODEL_CB(BT_MESH_MODEL_ID_GEN_POWER_LEVEL_SETUP_SRV,   \
+				 _bt_mesh_plvl_setup_srv_op, NULL,             \
+				 BT_MESH_MODEL_USER_DATA(                      \
+					 struct bt_mesh_plvl_srv, _srv),       \
+				 NULL)
+
+/** Collection of handler callbacks for the Generic Power Level Server. */
+struct bt_mesh_plvl_srv_handlers {
+	/** @brief Set the Power state.
+	 *
+	 * @note This handler is mandatory.
+	 *
+	 * @param[in] srv Server to set the Power state of.
+	 * @param[in] ctx Message context, or NULL if the state change was not
+	 * a result of a message.
+	 * @param[in] set Parameters of the state change.
+	 * @param[out] rsp Response structure to be filled.
+	 */
+	void (*const power_set)(struct bt_mesh_plvl_srv *srv,
+				struct bt_mesh_msg_ctx *ctx,
+				const struct bt_mesh_plvl_set *set,
+				struct bt_mesh_plvl_status *rsp);
+
+	/** @brief Get the current Power state.
+	 *
+	 * @note This handler is mandatory.
+	 *
+	 * @param[in] srv Server to get the Power state of.
+	 * @param[in] ctx Context of the get message that triggered the query,
+	 * or NULL if it was not triggered by a message.
+	 * @param[out] rsp Response structure to be filled.
+	 */
+	void (*const power_get)(struct bt_mesh_plvl_srv *srv,
+				struct bt_mesh_msg_ctx *ctx,
+				struct bt_mesh_plvl_status *rsp);
+
+	/** @brief The Default Power state has changed.
+	 *
+	 * The user may implement this handler to subscribe to changes to the
+	 * Default Power state.
+	 *
+	 * @param[in] srv Server the Default Power state was changed on.
+	 * @param[in] ctx Context of the set message that triggered the update,
+	 * or NULL if it was not triggered by a message.
+	 * @param[in] old_default The Default Power before the change.
+	 * @param[in] new_default The Default Power after the change.
+	 */
+	void (*const default_update)(struct bt_mesh_plvl_srv *srv,
+				     struct bt_mesh_msg_ctx *ctx,
+				     u16_t old_default, u16_t new_default);
+
+	/** @brief The Power Range state has changed.
+	 *
+	 * The user may implement this handler to subscribe to change to the
+	 * Power Range state. If the change in range causes the current Power
+	 * state to be out of range, the Power state should be changed to the
+	 * nearest value inside the range. It's recommended to call
+	 * @ref bt_mesh_plvl_srv_pub to notify the mesh if the Power state
+	 * changes.
+	 *
+	 * @param[in] srv Server the Power Range state was changed on.
+	 * @param[in] ctx Context of the set message that triggered the update,
+	 * or NULL if it was not triggered by a message.
+	 * @param[in] old_range The Power Range before the change.
+	 * @param[in] new_range The Power Range after the change.
+	 */
+	void (*const range_update)(struct bt_mesh_plvl_srv *srv,
+				   struct bt_mesh_msg_ctx *ctx,
+				   const struct bt_mesh_plvl_range *old_range,
+				   const struct bt_mesh_plvl_range *new_range);
+};
+
+/**
+ * Generic Power Level Server instance.
+ *
+ * Should be initialized with @ref BT_MESH_PLVL_SRV_INIT.
+ */
+struct bt_mesh_plvl_srv {
+	/** Generic Level Server instance. */
+	struct bt_mesh_lvl_srv lvl;
+	/** Generic Power OnOff server instance. */
+	struct bt_mesh_ponoff_srv ponoff;
+	/** Pointer to the model entry in the composition data. */
+	struct bt_mesh_model *plvl_model;
+	/** Model publication parameters. */
+	struct bt_mesh_model_pub pub;
+	/** Transaction ID tracker for the set messages. */
+	struct bt_mesh_tid_ctx tid;
+	/** User handler functions. */
+	const struct bt_mesh_plvl_srv_handlers *const handlers;
+
+	/** Current Power Range. */
+	struct bt_mesh_plvl_range range;
+	/** Current Default Power. */
+	u16_t default_power;
+	/** The last known Power Level. */
+	u16_t last;
+	/** Whether the Power is on. */
+	bool is_on;
+};
+
+/** @brief Publish the current Power state.
+ *
+ * Publishes a Generic Power Level status message with the configured publish
+ * parameters, or using the given message context.
+ *
+ * @note This API is only used publishing unprompted status messages. Response
+ * messages for get and set messages are handled internally.
+ *
+ * @param[in] srv Server instance to publish with.
+ * @param[in] ctx Message context, or NULL to publish with the configured
+ * parameters.
+ * @param[in] status Status to publish.
+ *
+ * @return 0 Successfully published the current Power state.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ */
+int bt_mesh_plvl_srv_pub(struct bt_mesh_plvl_srv *srv,
+			 struct bt_mesh_msg_ctx *ctx,
+			 const struct bt_mesh_plvl_status *status);
+
+/** @cond INTERNAL_HIDDEN */
+extern const struct bt_mesh_model_cb _bt_mesh_plvl_srv_cb;
+extern const struct bt_mesh_model_op _bt_mesh_plvl_srv_op[];
+extern const struct bt_mesh_model_op _bt_mesh_plvl_setup_srv_op[];
+extern const struct bt_mesh_lvl_srv_handlers bt_mesh_plvl_srv_lvl_handlers;
+extern const struct bt_mesh_onoff_srv_handlers bt_mesh_plvl_srv_onoff_handlers;
+int _bt_mesh_plvl_srv_update_handler(struct bt_mesh_model *model);
+/** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BT_MESH_GEN_PLVL_SRV_H__ */
+
+/** @} */

--- a/include/bluetooth/mesh/gen_ponoff.h
+++ b/include/bluetooth/mesh/gen_ponoff.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+/**
+ * @file
+ * @defgroup bt_mesh_ponoff Generic Power OnOff Models
+ * @{
+ * @brief API for the Generic Power OnOff models.
+ */
+
+#ifndef BT_MESH_GEN_PONOFF_H__
+#define BT_MESH_GEN_PONOFF_H__
+
+#include <bluetooth/mesh.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @cond INTERNAL_HIDDEN */
+#define BT_MESH_PONOFF_OP_GET BT_MESH_MODEL_OP_2(0x82, 0x11)
+#define BT_MESH_PONOFF_OP_STATUS BT_MESH_MODEL_OP_2(0x82, 0x12)
+#define BT_MESH_PONOFF_OP_SET BT_MESH_MODEL_OP_2(0x82, 0x13)
+#define BT_MESH_PONOFF_OP_SET_UNACK BT_MESH_MODEL_OP_2(0x82, 0x14)
+
+#define BT_MESH_PONOFF_MSG_LEN_GET 0
+#define BT_MESH_PONOFF_MSG_LEN_STATUS 1
+#define BT_MESH_PONOFF_MSG_LEN_SET 1
+/** @endcond */
+
+/** Generic Power OnOff On Power Up state values. */
+enum bt_mesh_on_power_up {
+	/** On power up, set state to off. */
+	BT_MESH_ON_POWER_UP_OFF,
+	/** On power up, set state to on. */
+	BT_MESH_ON_POWER_UP_ON,
+	/** On power up, Restore the previous state value. */
+	BT_MESH_ON_POWER_UP_RESTORE,
+	/** Invalid power up state. */
+	BT_MESH_ON_POWER_UP_INVALID,
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BT_MESH_GEN_PONOFF_H__ */
+
+/** @} */

--- a/include/bluetooth/mesh/gen_ponoff.rst
+++ b/include/bluetooth/mesh/gen_ponoff.rst
@@ -1,0 +1,140 @@
+.. _bt_mesh_ponoff_readme:
+
+Generic Power OnOff models
+##########################
+
+The Generic Power OnOff models allow remote control of the power up behavior
+on a mesh device.
+
+There are two Generic Power OnOff models:
+
+- :ref:`bt_mesh_ponoff_srv_readme`
+- :ref:`bt_mesh_ponoff_cli_readme`
+
+.. _bt_mesh_ponoff_srv_readme:
+
+Generic Power OnOff Server
+==========================
+
+The Generic Power OnOff server controls the power up behavior of other models
+on its element. The Generic Power OnOff server depends on the
+:option:`CONFIG_BT_SETTINGS` to be enabled to work properly. Unless
+:option:`CONFIG_BT_SETTINGS` is explicitly disabled, including the Generic
+Power OnOff Server will enable :option:`CONFIG_BT_SETTINGS`.
+
+Generic Power OnOff Server adds two model instances in the composition data:
+
+- The Generic Power OnOff Server
+- The Generic Power OnOff Setup Server
+
+The two model instances share the states of the Generic Power OnOff Server,
+but accept different messages. This allows fine-grained control of the access
+rights for the Generic Power OnOff state, as the two model instances can be
+bound to different application keys.
+
+The Generic Power OnOff Server only provides read access to the Generic
+On Power Up state.
+
+The Generic Power OnOff Setup Server provides write access to the Generic
+On Power Up state, allowing configurator devices to change the power up
+behavior of the element.
+
+States
+*******
+
+**Generic On Power Up**: :cpp:type:`bt_mesh_on_power_up`.
+
+The Generic On Power Up state controls the initial value of the extended
+Generic OnOff state when the device powers up:
+
+- On Power Up is
+  :cpp:enumerator:`BT_MESH_ON_POWER_UP_OFF <bt_mesh_ponoff::BT_MESH_ON_POWER_UP_OFF>`:
+  The OnOff state is initialized to Off.
+- On Power Up is
+  :cpp:enumerator:`BT_MESH_ON_POWER_UP_ON <bt_mesh_ponoff::BT_MESH_ON_POWER_UP_ON>`:
+  The OnOff state is initialized to On. If any other states are bound to the On
+  Power Up state, they are initialized to their default values.
+- On Power Up is
+  :cpp:enumerator:`BT_MESH_ON_POWER_UP_RESTORE <bt_mesh_ponoff::BT_MESH_ON_POWER_UP_RESTORE>`:
+  The OnOff state is initialized to its last known value. If any other states
+  are bound to the On Power Up state, they are initialized to their default
+  values.
+
+The memory for the Generic On Power Up state is contained in the model
+structure, and state changes can be observed with the
+:cpp:member:`bt_mesh_ponoff_srv::update` callback.
+
+Extended models
+****************
+
+The Generic Power OnOff Server extends the following models:
+
+- :ref:`bt_mesh_onoff_srv_readme`
+- :ref:`bt_mesh_dtt_srv_readme`
+
+The On Power Up state is bound to the Generic OnOff state of the extended
+Generic OnOff model through its power up behavior. No other state bindings
+are present, and the callbacks for both the Generic OnOff server and the
+Generic DTT server are forwarded to the application as they are.
+
+Persistent storage
+*******************
+
+The Generic On Power Up state is stored persistently, along with the current
+Generic OnOff state of the extended :ref:`bt_mesh_onoff_srv_readme`.
+
+API documentation
+******************
+
+| Header file: :file:`include/bluetooth/mesh/gen_ponoff_srv.h`
+| Source file: :file:`subsys/bluetooth/mesh/gen_ponoff_srv.c`
+
+.. doxygengroup:: bt_mesh_ponoff_srv
+   :project: nrf
+   :members:
+
+----
+
+.. _bt_mesh_ponoff_cli_readme:
+
+Generic Power OnOff Client
+==========================
+
+The Generic Power OnOff Client model remotely controls the state of a Generic
+Power OnOff Server model.
+
+Contrary to the Generic Power OnOff Server, the Generic Power OnOff Client only
+adds one model instance to the composition data. The Generic Power OnOff Client
+may send messages to both the Generic Power OnOff Server and the Generic Power
+OnOff Setup server, as long as it has the right application keys.
+
+Extended models
+****************
+
+None.
+
+Persistent storage
+*******************
+
+None.
+
+API documentation
+******************
+
+| Header file: :file:`include/bluetooth/mesh/gen_ponoff_cli.h`
+| Source file: :file:`subsys/bluetooth/mesh/gen_ponoff_cli.c`
+
+.. doxygengroup:: bt_mesh_ponoff_cli
+   :project: nrf
+   :members:
+
+----
+
+Common types
+=============
+
+| Header file: :file:`include/bluetooth/mesh/gen_ponoff.h`
+
+.. doxygengroup:: bt_mesh_ponoff
+   :project: nrf
+   :members:

--- a/include/bluetooth/mesh/gen_ponoff_cli.h
+++ b/include/bluetooth/mesh/gen_ponoff_cli.h
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/**
+ * @file
+ * @defgroup bt_mesh_ponoff_cli Generic Power OnOff Client
+ * @{
+ * @brief API for the Generic Power OnOff Client.
+ */
+#ifndef BT_MESH_GEN_PONOFF_CLI_H__
+#define BT_MESH_GEN_PONOFF_CLI_H__
+
+#include <bluetooth/mesh/gen_ponoff.h>
+#include <bluetooth/mesh/model_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct bt_mesh_ponoff_cli;
+
+/** @def BT_MESH_PONOFF_CLI_INIT
+ *
+ * @brief Initialization parameters for @ref bt_mesh_ponoff_cli.
+ *
+ * @param[in] _power_onoff_status_handler OnPowerUp status handler.
+ */
+#define BT_MESH_PONOFF_CLI_INIT(_power_onoff_status_handler)                   \
+	{                                                                      \
+		.status_handler = _power_onoff_status_handler,                 \
+		.pub = { .msg = NET_BUF_SIMPLE(BT_MESH_MODEL_BUF_LEN(          \
+				 BT_MESH_PONOFF_OP_SET,                        \
+				 BT_MESH_PONOFF_MSG_LEN_SET)) },               \
+	}
+
+/** @def BT_MESH_MODEL_PONOFF_CLI
+ *
+ * @brief Generic Power OnOff Client model composition data entry.
+ *
+ * @param[in] _cli Pointer to a @ref bt_mesh_ponoff_cli instance.
+ */
+#define BT_MESH_MODEL_PONOFF_CLI(_cli)                                         \
+		BT_MESH_MODEL_CB(BT_MESH_MODEL_ID_GEN_POWER_ONOFF_CLI,         \
+				 _bt_mesh_ponoff_cli_op, &(_cli)->pub,         \
+				 BT_MESH_MODEL_USER_DATA(                      \
+					 struct bt_mesh_ponoff_cli, _cli),     \
+				 &_bt_mesh_ponoff_cli_cb)
+
+/**
+ * Generic Power OnOff client instance.
+ *
+ * Should be initialized with @ref BT_MESH_PONOFF_CLI_INIT.
+ */
+struct bt_mesh_ponoff_cli {
+	/** Model entry pointer. */
+	struct bt_mesh_model *model;
+	/** Publish parameters. */
+	struct bt_mesh_model_pub pub;
+	/** Response context for tracking acknowledged messages. */
+	struct bt_mesh_model_ack_ctx ack_ctx;
+
+	/** @brief OnPowerUp status message handler.
+	 *
+	 * @param[in] cli Client that received the status message.
+	 * @param[in] ctx Message context the message was received with.
+	 * @param[in] on_power_up The OnPowerUp state presented in the message.
+	 */
+	void (*const status_handler)(struct bt_mesh_ponoff_cli *cli,
+				     struct bt_mesh_msg_ctx *ctx,
+				     enum bt_mesh_on_power_up on_power_up);
+};
+
+/** @brief Get the OnPowerUp state of a server.
+ *
+ * This call is blocking if the @p rsp buffer is non-NULL. Otherwise, this
+ * function will return, and the response will be passed to the
+ * @ref bt_mesh_ponoff_cli::status_handler callback.
+ *
+ * @param[in] cli Power OnOff client to send the message on.
+ * @param[in] ctx Context of the message, or NULL to send on the configured
+ * publish parameters.
+ * @param[out] rsp Response buffer to put the received response in, or NULL to
+ * process the response in the status handler callback.
+ *
+ * @retval 0 Successfully sent a get message. If a response buffer is
+ * provided, it has been populated.
+ * @retval -EALREADY A blocking request is already in progress.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
+ */
+int bt_mesh_ponoff_cli_on_power_up_get(struct bt_mesh_ponoff_cli *cli,
+				       struct bt_mesh_msg_ctx *ctx,
+				       enum bt_mesh_on_power_up *rsp);
+
+/** @brief Set the OnPowerUp state of a server.
+ *
+ * @param[in] cli Power OnOff client to send the message on.
+ * @param[in] ctx Context of the message, or NULL to send with the configured
+ * publish parameters.
+ * @param[in] on_power_up New OnPowerUp state of the server.
+ * @param[out] rsp Response buffer to put the received response in, or NULL to
+ * send an unacknowledged message.
+ *
+ * @retval 0 Successfully sent a set message. If a response buffer is
+ * provided, it has been populated.
+ * @retval -EALREADY A blocking request is already in progress.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
+ */
+int bt_mesh_ponoff_cli_on_power_up_set(struct bt_mesh_ponoff_cli *cli,
+				       struct bt_mesh_msg_ctx *ctx,
+				       enum bt_mesh_on_power_up on_power_up,
+				       enum bt_mesh_on_power_up *rsp);
+
+/** @cond INTERNAL_HIDDEN */
+extern const struct bt_mesh_model_op _bt_mesh_ponoff_cli_op[];
+extern const struct bt_mesh_model_cb _bt_mesh_ponoff_cli_cb;
+/** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BT_MESH_GEN_PONOFF_CLI_H__ */
+
+/** @} */

--- a/include/bluetooth/mesh/gen_ponoff_srv.h
+++ b/include/bluetooth/mesh/gen_ponoff_srv.h
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+/**
+ * @file
+ * @defgroup bt_mesh_ponoff_srv Generic Power OnOff Server model
+ * @{
+ * @brief API for the Generic Power OnOff Server.
+ */
+
+#ifndef BT_MESH_GEN_PONOFF_SRV_H__
+#define BT_MESH_GEN_PONOFF_SRV_H__
+
+#include <bluetooth/mesh.h>
+
+#include <bluetooth/mesh/gen_ponoff.h>
+#include <bluetooth/mesh/gen_onoff_srv.h>
+#include <bluetooth/mesh/gen_dtt_srv.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct bt_mesh_ponoff_srv;
+
+/** @def BT_MESH_PONOFF_SRV_INIT
+ *
+ * @brief Initialization parameters for @ref bt_mesh_ponoff_srv.
+ *
+ * @param[in] _onoff_handlers Handlers for the underlying Generic OnOff Server.
+ * @param[in] _dtt_change_handler Handler function for changes to the Default
+ * Transition Time Server state.
+ * @param[in] _on_power_up_change_handler Handler function for changes to the
+ * OnPowerUp state.
+ */
+#define BT_MESH_PONOFF_SRV_INIT(_onoff_handlers, _dtt_change_handler,          \
+				_on_power_up_change_handler)                   \
+	{                                                                      \
+		.onoff = BT_MESH_ONOFF_SRV_INIT(                               \
+			&_bt_mesh_ponoff_onoff_intercept),                     \
+		.dtt = BT_MESH_DTT_SRV_INIT(_dtt_change_handler),              \
+		.onoff_handlers = _onoff_handlers,                             \
+		.pub = { .update = _bt_mesh_ponoff_srv_update_handler,         \
+			 .msg = NET_BUF_SIMPLE(BT_MESH_MODEL_BUF_LEN(          \
+				 BT_MESH_PONOFF_OP_STATUS,                     \
+				 BT_MESH_PONOFF_MSG_LEN_STATUS)) },            \
+		.update = _on_power_up_change_handler,                         \
+	}
+
+/** @def BT_MESH_MODEL_PONOFF_SRV
+ *
+ * @brief Generic Power OnOff model entry.
+ *
+ * @param[in] _srv Pointer to a @ref bt_mesh_ponoff_srv instance.
+ */
+#define BT_MESH_MODEL_PONOFF_SRV(_srv)                                         \
+	BT_MESH_MODEL_ONOFF_SRV(&(_srv)->onoff),                               \
+		BT_MESH_MODEL_DTT_SRV(&(_srv)->dtt),                           \
+		BT_MESH_MODEL_CB(BT_MESH_MODEL_ID_GEN_POWER_ONOFF_SRV,         \
+				 _bt_mesh_ponoff_srv_op, &(_srv)->pub,         \
+				 BT_MESH_MODEL_USER_DATA(                      \
+					 struct bt_mesh_ponoff_srv, _srv),     \
+				 &_bt_mesh_ponoff_srv_cb),                     \
+		BT_MESH_MODEL_CB(BT_MESH_MODEL_ID_GEN_POWER_ONOFF_SETUP_SRV,   \
+				 _bt_mesh_ponoff_setup_srv_op, NULL,           \
+				 BT_MESH_MODEL_USER_DATA(                      \
+					 struct bt_mesh_ponoff_srv, _srv),     \
+				 NULL)
+
+/**
+ * Generic Power OnOff Server instance.
+ *
+ * Should be initialized with @ref BT_MESH_PONOFF_SRV_INIT.
+ */
+struct bt_mesh_ponoff_srv {
+	/** Generic OnOff Server instance. */
+	struct bt_mesh_onoff_srv onoff;
+	/** Generic Default Transition Time server instance. */
+	struct bt_mesh_dtt_srv dtt;
+	/** Pointer to the model entry in the composition data. */
+	struct bt_mesh_model *ponoff_model;
+	/** Model publication parameters. */
+	struct bt_mesh_model_pub pub;
+	/** Handlers for the Generic OnOff Server. */
+	const struct bt_mesh_onoff_srv_handlers *const onoff_handlers;
+
+	/** @brief Update handler.
+	 *
+	 * Called every time there's a change to the OnPowerUp state.
+	 *
+	 * @param[in] srv Server instance that was updated
+	 * @param[in] ctx Context of the set message that triggered the update,
+	 * or NULL if it was not triggered by a message.
+	 * @param[in] old_on_power_up The previous OnPowerUp value.
+	 * @param[in] new_on_power_up The new OnPowerUp value.
+	 */
+	void (*const update)(struct bt_mesh_ponoff_srv *srv,
+			     struct bt_mesh_msg_ctx *ctx,
+			     enum bt_mesh_on_power_up old_on_power_up,
+			     enum bt_mesh_on_power_up new_on_power_up);
+
+	/** Current OnPowerUp state. */
+	enum bt_mesh_on_power_up on_power_up;
+};
+
+/** @brief Set the OnPowerUp state of a Power OnOff server.
+ *
+ * If an update handler is set, it'll be called with the updated OnPowerUp
+ * value. If publication is configured, the change will cause the server to
+ * publish.
+ *
+ * @param[in] srv Server to set the OnPowerUp state of.
+ * @param[in] on_power_up New OnPowerUp value.
+ */
+void bt_mesh_ponoff_srv_set(struct bt_mesh_ponoff_srv *srv,
+			    enum bt_mesh_on_power_up on_power_up);
+
+/** @brief Publish the current OnPowerUp state.
+ *
+ * Publishes a Generic Power OnOff status message with the configured publish
+ * parameters, or using the given message context.
+ *
+ * @note This API is only used publishing unprompted status messages. Response
+ * messages for get and set messages are handled internally.
+ *
+ * @param[in] srv Server instance to publish with.
+ * @param[in] ctx Message context, or NULL to publish with the configured
+ * parameters.
+ *
+ * @return 0 Successfully published the current OnPowerUp state.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ */
+int bt_mesh_ponoff_srv_pub(struct bt_mesh_ponoff_srv *srv,
+			   struct bt_mesh_msg_ctx *ctx);
+
+/** @cond INTERNAL_HIDDEN */
+extern const struct bt_mesh_model_cb _bt_mesh_ponoff_srv_cb;
+extern const struct bt_mesh_model_op _bt_mesh_ponoff_srv_op[];
+extern const struct bt_mesh_model_op _bt_mesh_ponoff_setup_srv_op[];
+extern const struct bt_mesh_onoff_srv_handlers _bt_mesh_ponoff_onoff_intercept;
+int _bt_mesh_ponoff_srv_update_handler(struct bt_mesh_model *model);
+/** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BT_MESH_GEN_PONOFF_SRV_H__ */
+
+/** @} */

--- a/include/bluetooth/mesh/gen_prop.h
+++ b/include/bluetooth/mesh/gen_prop.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/**
+ * @file
+ * @defgroup bt_mesh_prop Generic Property models
+ * @{
+ * @brief API for the Generic Property models.
+ */
+
+#ifndef BT_MESH_GEN_PROP_H__
+#define BT_MESH_GEN_PROP_H__
+
+#include <bluetooth/mesh.h>
+#include <bluetooth/mesh/properties.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @cond INTERNAL_HIDDEN */
+#define BT_MESH_PROP_OP_MFR_PROPS_GET BT_MESH_MODEL_OP_2(0x82, 0x2A)
+#define BT_MESH_PROP_OP_MFR_PROPS_STATUS BT_MESH_MODEL_OP_1(0x43)
+#define BT_MESH_PROP_OP_MFR_PROP_GET BT_MESH_MODEL_OP_2(0x82, 0x2B)
+#define BT_MESH_PROP_OP_MFR_PROP_SET BT_MESH_MODEL_OP_1(0x44)
+#define BT_MESH_PROP_OP_MFR_PROP_SET_UNACK BT_MESH_MODEL_OP_1(0x45)
+#define BT_MESH_PROP_OP_MFR_PROP_STATUS BT_MESH_MODEL_OP_1(0x46)
+#define BT_MESH_PROP_OP_ADMIN_PROPS_GET BT_MESH_MODEL_OP_2(0x82, 0x2C)
+#define BT_MESH_PROP_OP_ADMIN_PROPS_STATUS BT_MESH_MODEL_OP_1(0x47)
+#define BT_MESH_PROP_OP_ADMIN_PROP_GET BT_MESH_MODEL_OP_2(0x82, 0x2D)
+#define BT_MESH_PROP_OP_ADMIN_PROP_SET BT_MESH_MODEL_OP_1(0x48)
+#define BT_MESH_PROP_OP_ADMIN_PROP_SET_UNACK BT_MESH_MODEL_OP_1(0x49)
+#define BT_MESH_PROP_OP_ADMIN_PROP_STATUS BT_MESH_MODEL_OP_1(0x4A)
+#define BT_MESH_PROP_OP_USER_PROPS_GET BT_MESH_MODEL_OP_2(0x82, 0x2E)
+#define BT_MESH_PROP_OP_USER_PROPS_STATUS BT_MESH_MODEL_OP_1(0x4B)
+#define BT_MESH_PROP_OP_USER_PROP_GET BT_MESH_MODEL_OP_2(0x82, 0x2F)
+#define BT_MESH_PROP_OP_USER_PROP_SET BT_MESH_MODEL_OP_1(0x4C)
+#define BT_MESH_PROP_OP_USER_PROP_SET_UNACK BT_MESH_MODEL_OP_1(0x4D)
+#define BT_MESH_PROP_OP_USER_PROP_STATUS BT_MESH_MODEL_OP_1(0x4E)
+#define BT_MESH_PROP_OP_CLIENT_PROPS_GET BT_MESH_MODEL_OP_1(0x4F)
+#define BT_MESH_PROP_OP_CLIENT_PROPS_STATUS BT_MESH_MODEL_OP_1(0x50)
+
+#define BT_MESH_PROP_MSG_LEN_PROPS_GET 0
+#define BT_MESH_PROP_MSG_MINLEN_PROPS_STATUS 0
+#define BT_MESH_PROP_MSG_MAXLEN_PROPS_STATUS (2 * CONFIG_BT_MESH_PROP_MAXCOUNT)
+#define BT_MESH_PROP_MSG_LEN_PROP_GET 2
+#define BT_MESH_PROP_MSG_MINLEN_PROP_STATUS 3
+#define BT_MESH_PROP_MSG_MAXLEN_PROP_STATUS (3 + CONFIG_BT_MESH_PROP_MAXSIZE)
+#define BT_MESH_PROP_MSG_LEN_MFR_PROP_SET 3
+#define BT_MESH_PROP_MSG_MINLEN_ADMIN_PROP_SET 3
+#define BT_MESH_PROP_MSG_MAXLEN_ADMIN_PROP_SET (3 + CONFIG_BT_MESH_PROP_MAXSIZE)
+#define BT_MESH_PROP_MSG_MINLEN_USER_PROP_SET 2
+#define BT_MESH_PROP_MSG_MAXLEN_USER_PROP_SET (2 + CONFIG_BT_MESH_PROP_MAXSIZE)
+/** @endcond */
+
+/** Access flags for properties */
+enum bt_mesh_prop_access {
+	/** Access to the property is prohibited. */
+	BT_MESH_PROP_ACCESS_PROHIBITED = 0,
+	/** Property may be read. */
+	BT_MESH_PROP_ACCESS_READ = BIT(0),
+	/** Property may be written. */
+	BT_MESH_PROP_ACCESS_WRITE = BIT(1),
+	/** Property may be read or written. */
+	BT_MESH_PROP_ACCESS_READ_WRITE =
+		(BT_MESH_PROP_ACCESS_READ | BT_MESH_PROP_ACCESS_WRITE),
+};
+
+/** Property Server kinds. */
+enum bt_mesh_prop_srv_kind {
+	/** Manufacturer property server. */
+	BT_MESH_PROP_SRV_KIND_MFR,
+	/** Admin property server. */
+	BT_MESH_PROP_SRV_KIND_ADMIN,
+	/** User property server. */
+	BT_MESH_PROP_SRV_KIND_USER,
+	/** Client property server. */
+	BT_MESH_PROP_SRV_KIND_CLIENT,
+};
+
+/** Property representation. */
+struct bt_mesh_prop {
+	/** Property ID. @sa bt_mesh_property_ids. */
+	u16_t id;
+	/** User access flags for the property. */
+	enum bt_mesh_prop_access user_access;
+};
+
+/** Property value representation. */
+struct bt_mesh_prop_val {
+	struct bt_mesh_prop meta; /**< Metadata for this property. */
+	size_t size; /**< Size of the property value. */
+	u8_t *value; /**< Property value. */
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BT_MESH_GEN_PROP_H__ */
+
+/** @} */

--- a/include/bluetooth/mesh/gen_prop.rst
+++ b/include/bluetooth/mesh/gen_prop.rst
@@ -1,0 +1,150 @@
+.. _bt_mesh_prop_readme:
+
+Generic Property models
+#######################
+
+The Generic Property models allow remote access to the Device Properties of a
+mesh node. Read more about device properties in
+:ref:`bt_mesh_properties_readme`.
+
+There Generic Property models fall into two categories:
+
+- :ref:`bt_mesh_prop_srv_readme`
+- :ref:`bt_mesh_prop_cli_readme`
+
+Configuration
+==============
+
+There are two configuration parameters associated with the Generic Property
+models:
+
+- :option:`CONFIG_BT_MESH_PROP_MAXSIZE`: The largest available property value.
+- :option:`CONFIG_BT_MESH_PROP_MAXCOUNT`: The largest number of properties
+  available on a single Generic Property Server.
+
+.. _bt_mesh_prop_srv_readme:
+
+Generic Property Servers
+========================
+
+A Generic Property Server holds a list of Device Properties.
+There are four different property servers:
+
+- **Generic Manufacturer Property Server**: Provides access to Manufacturer
+  properties, which are read-only properties set by the device manufacturer.
+- **Generic Admin Property Server**: Provides access to Admin properties, which
+  can be read and written to.
+- **Generic User Property Server**: Provides access to both Admin and
+  Manufacturer properties on its element, but only if the Property owner allows
+  it.
+- **Generic Client Property Server**: Provides a list of all properties
+  supported by the Generic Property Client on the same element. The Client
+  Property Server does not actually own any properties, and does not need the
+  user to provide access to any property values.
+
+Typically, only the administrator of the mesh network should have access to the
+Admin or Manufacturer servers, all other mesh nodes should operate on the User
+server. The Manufacturer and Admin servers may change the User property access
+rights for each individual Property it owns at runtime.
+
+The Manufacturer and Admin Servers must provide a list of all Properties they
+own in the initialization of the model. Access to the property values should be
+provided through the server getter (:cpp:member:`bt_mesh_prop_srv::get`) and
+setter (:cpp:member:`bt_mesh_prop_srv::set`) callbacks.
+
+The User Property server does not own any properties, but relies on Admin and
+Manufacturer servers on the same element to provide access to theirs. An
+element with a User Property Server and no Admin or Manufacturer Servers is
+useless.
+
+The model keeps the user access field of each Admin and Manufacturer property
+in persistent storage. The property values themselves have to be stored by the
+application.
+
+The set of Property IDs and their order cannot be changed.
+
+States
+*******
+
+**Device Properties**: :cpp:type:`bt_mesh_prop`
+
+A single server may own several Device Properties, which are accessed by their
+Property ID. Each Property holds a value and a user access parameter, which
+controls the Property's availability to a Generic User Property Server on the
+same element.
+
+The Device properties have slightly different access restrictions depending on
+the type of server that owns them:
+
+- **Manufacturer Property**: The value can only be read.
+- **Admin Property**: The value can be read and written.
+- **Client Property**: Has no associated value, and is only a listing of the
+  property IDs supported by the accompanying Generic Property Client.
+
+Extended models
+****************
+
+The Generic Admin Property Server and Generic Manufacturer Property Server both
+extend the Generic User Property Server. As a consequence, a single element can
+only hold one Generic Manufacturer or Generic Admin Property Server.
+
+Persistent storage
+*******************
+
+The Generic Manufacturer Property Server and Generic Admin Property Server
+models will store changes to the user access rights of their properties.
+Any permanent changes to the property values themselves should be stored
+manually by the application.
+
+API documentation
+******************
+
+| Header file: :file:`include/bluetooth/mesh/gen_prop_srv.h`
+| Source file: :file:`subsys/bluetooth/mesh/gen_prop_srv.c`
+
+.. doxygengroup:: bt_mesh_prop_srv
+   :project: nrf
+   :members:
+
+----
+
+.. _bt_mesh_prop_cli_readme:
+
+Generic Property Client
+=======================
+
+The Generic Property Client model can access properties from a Property Server
+remotely. The Property Client can talk directly to all types of Property
+Servers, but only if it shares an application key with the target server.
+
+Generally, the Property Client should only target User Property Servers, unless
+it is part of some network administrator node that is responsible for
+configuring the other mesh nodes.
+
+To ease configuration, the Property Client can be paired with a Client Property
+Server that lists which properties this Client will request.
+
+Extended models
+****************
+
+None.
+
+API documentation
+******************
+
+| Header file: :file:`include/bluetooth/mesh/gen_prop_cli.h`
+| Source file: :file:`subsys/bluetooth/mesh/gen_prop_cli.c`
+
+.. doxygengroup:: bt_mesh_prop_cli
+   :project: nrf
+   :members:
+
+----
+
+Common types
+=============
+
+| Header file: :file:`include/bluetooth/mesh/gen_prop.h`
+
+.. doxygenfile:: gen_prop.h
+   :project: nrf

--- a/include/bluetooth/mesh/gen_prop_cli.h
+++ b/include/bluetooth/mesh/gen_prop_cli.h
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+/**
+ * @file
+ * @defgroup bt_mesh_prop_cli Generic Property Client model
+ * @{
+ * @brief API for the Generic Property Client model.
+ */
+#ifndef BT_MESH_GEN_PROP_CLI_H__
+#define BT_MESH_GEN_PROP_CLI_H__
+
+#include <bluetooth/mesh/gen_prop.h>
+#include <bluetooth/mesh/model_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct bt_mesh_prop_cli;
+
+/** @def BT_MESH_PROP_CLI_INIT
+ *
+ * @brief Initialization parameters for the @ref bt_mesh_prop_cli.
+ *
+ * @param[in] _prop_list_handler Optional status message handler.
+ * @sa bt_mesh_prop_cli::prop_list
+ * @param[in] _prop_status_handler Optional status message handler.
+ * @sa bt_mesh_prop_cli::prop_status
+ */
+#define BT_MESH_PROP_CLI_INIT(_prop_list_handler, _prop_status_handler)        \
+	{                                                                      \
+		.pub = { .msg = NET_BUF_SIMPLE(BT_MESH_MODEL_BUF_LEN(          \
+				 BT_MESH_PROP_OP_ADMIN_PROP_SET,               \
+				 BT_MESH_PROP_MSG_MAXLEN_ADMIN_PROP_SET)) },   \
+		.prop_list = _prop_list_handler,                               \
+		.prop_status = _prop_status_handler,                           \
+	}
+
+/** @def BT_MESH_MODEL_PROP_CLI
+ *
+ * @brief Generic Property Client model composition data entry.
+ *
+ * @param[in] _cli Pointer to a @ref bt_mesh_prop_cli instance.
+ */
+#define BT_MESH_MODEL_PROP_CLI(_cli)                                           \
+	BT_MESH_MODEL_CB(BT_MESH_MODEL_ID_GEN_PROP_CLI, _bt_mesh_prop_cli_op,  \
+			 &(_cli)->pub,                                         \
+			 BT_MESH_MODEL_USER_DATA(struct bt_mesh_prop_cli,      \
+						 _cli),                        \
+			 &_bt_mesh_prop_cli_cb)
+
+/** List of property IDs. */
+struct bt_mesh_prop_list {
+	u8_t count; /**< Number of IDs in the list. */
+	u16_t *ids; /**< Available Property IDs. */
+};
+
+/**
+ * Generic Property Client instance.
+ * Should be initialized with @ref BT_MESH_PROP_CLI_INIT.
+ */
+struct bt_mesh_prop_cli {
+	/** Model entry. */
+	struct bt_mesh_model *model;
+	/** Publish parameters. */
+	struct bt_mesh_model_pub pub;
+	/** Acknowledged message tracking. */
+	struct bt_mesh_model_ack_ctx ack_ctx;
+
+	/** @brief Property list message handler.
+	 *
+	 * @param[in] cli Client that received the message.
+	 * @param[in] ctx Context of the message.
+	 * @param[in] kind Kind of Property Server that sent the message.
+	 * @param[in] list List of properties supported by the server.
+	 */
+	void (*const prop_list)(struct bt_mesh_prop_cli *cli,
+				struct bt_mesh_msg_ctx *ctx,
+				enum bt_mesh_prop_srv_kind kind,
+				const struct bt_mesh_prop_list *list);
+
+	/** @brief Property status message handler.
+	 *
+	 * @param[in] cli Client that received the message.
+	 * @param[in] ctx Context of the message.
+	 * @param[in] kind Kind of Property Server that sent the message.
+	 * @param[in] prop Property value.
+	 */
+	void (*const prop_status)(struct bt_mesh_prop_cli *cli,
+				  struct bt_mesh_msg_ctx *ctx,
+				  enum bt_mesh_prop_srv_kind kind,
+				  const struct bt_mesh_prop_val *prop);
+};
+
+/** @brief Get the list of properties of the bound server.
+ *
+ * This call is blocking if the @p rsp buffer is non-NULL. Otherwise, this
+ * function will return, and the response will be passed to the
+ * @ref bt_mesh_prop_cli::prop_list callback.
+ *
+ * @param[in] cli Client model to send on.
+ * @param[in] ctx Message context, or NULL to use the configured publish
+ * parameters.
+ * @param[in] kind Kind of Property Server to query.
+ * @param[out] rsp Response buffer, or NULL to keep from blocking.
+ *
+ * @retval 0 Successfully sent the message and populated the @p rsp buffer.
+ * @retval -EINVAL The @p rsp::ids list was NULL.
+ * @retval -ENOBUFS The client received a response, but the supplied response
+ * buffer was too small to hold all the properties. All property IDs that could
+ * fit in the response buffers were copied into it, and the @p rsp::count
+ * field was left unchanged.
+ * @retval -EALREADY A blocking request is already in progress.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
+ */
+int bt_mesh_prop_cli_props_get(struct bt_mesh_prop_cli *cli,
+			       struct bt_mesh_msg_ctx *ctx,
+			       enum bt_mesh_prop_srv_kind kind,
+			       struct bt_mesh_prop_list *rsp);
+
+/** @brief Get the value of a property in a server.
+ *
+ * This call is blocking if the @p rsp buffer is non-NULL. Otherwise, this
+ * function will return, and the response will be passed to the
+ * @ref bt_mesh_prop_cli::prop_status callback.
+ *
+ * @param[in] cli Client model to send on.
+ * @param[in] ctx Message context, or NULL to use the configured publish
+ * parameters.
+ * @param[in] kind Kind of Property Server to query.
+ * @param[in] id ID of the property to get.
+ * @param[out] rsp Response buffer, or NULL to keep from blocking.
+ *
+ * @retval 0 Successfully sent the message and populated the @p rsp buffer.
+ * @retval -EINVAL The @p rsp::ids list was NULL.
+ * @retval -ENOBUFS The client received a response, but the supplied response
+ * buffer was too small to hold all the properties. All property IDs that could
+ * fit in the response buffers were copied into it, and the @p rsp::count
+ * field was left unchanged.
+ * @retval -EALREADY A blocking request is already in progress.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
+ */
+int bt_mesh_prop_cli_prop_get(struct bt_mesh_prop_cli *cli,
+			      struct bt_mesh_msg_ctx *ctx,
+			      enum bt_mesh_prop_srv_kind kind, u16_t id,
+			      struct bt_mesh_prop_val *rsp);
+
+/** @brief Set a property value in a User Property Server.
+ *
+ * The User Property may only be set if the server enabled user write access to
+ * it. If this is not the case, the server will only respond with the set user
+ * access mode for the given property.
+ *
+ * This call is blocking if the @p rsp buffer is non-NULL. Otherwise, this
+ * function will not request a response from the server, and return
+ * immediately.
+ *
+ * @note The @p val::meta::user_access level will be ignored.
+ *
+ * @param[in] cli Client model to send on.
+ * @param[in] ctx Message context, or NULL to use the configured publish
+ * parameters.
+ * @param[in] val New property value to set. Note that the user_access mode
+ * will be ignored.
+ * @param[out] rsp Response status buffer, or NULL to send an unacknowledged
+ * message.
+ *
+ * @retval 0 Successfully sent the message and populated the @p rsp buffer.
+ * @retval -EALREADY A blocking request is already in progress.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
+ */
+int bt_mesh_prop_cli_user_prop_set(struct bt_mesh_prop_cli *cli,
+				   struct bt_mesh_msg_ctx *ctx,
+				   const struct bt_mesh_prop_val *val,
+				   struct bt_mesh_prop_val *rsp);
+
+/** @brief Set a property value in an Admin Property server.
+ *
+ * This call is blocking if the @p rsp buffer is non-NULL. Otherwise, this
+ * function will not request a response from the server, and return
+ * immediately.
+ *
+ * @param[in] cli Client model to send on.
+ * @param[in] ctx Message context, or NULL to use the configured publish
+ * parameters.
+ * @param[in] val New property value to set.
+ * @param[out] rsp Response status buffer, or NULL to send an unacknowledged
+ * message.
+ *
+ * @retval 0 Successfully sent the message and populated the @p rsp buffer.
+ * @retval -EALREADY A blocking request is already in progress.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
+ */
+int bt_mesh_prop_cli_admin_prop_set(struct bt_mesh_prop_cli *cli,
+				    struct bt_mesh_msg_ctx *ctx,
+				    const struct bt_mesh_prop_val *val,
+				    struct bt_mesh_prop_val *rsp);
+
+/** @brief Set the user access of a property in a Manufacturer Property server.
+ *
+ * This call is blocking if the @p rsp buffer is non-NULL. Otherwise, this
+ * function will not request a response from the server, and return
+ * immediately.
+ *
+ * @param[in] cli Client model to send on.
+ * @param[in] ctx Message context, or NULL to use the configured publish
+ * parameters.
+ * @param[in] val New property value to set.
+ * @param[out] rsp Response status buffer, or NULL to send an unacknowledged
+ * message.
+ *
+ * @retval 0 Successfully sent the message and populated the @p rsp buffer.
+ * @retval -EALREADY A blocking request is already in progress.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
+ */
+int bt_mesh_prop_cli_mfr_prop_set(struct bt_mesh_prop_cli *cli,
+				  struct bt_mesh_msg_ctx *ctx,
+				  const struct bt_mesh_prop *prop,
+				  struct bt_mesh_prop_val *rsp);
+
+/** @cond INTERNAL_HIDDEN */
+extern const struct bt_mesh_model_op _bt_mesh_prop_cli_op[];
+extern const struct bt_mesh_model_cb _bt_mesh_prop_cli_cb;
+/** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BT_MESH_GEN_PROP_CLI_H__ */
+
+/** @} */

--- a/include/bluetooth/mesh/gen_prop_srv.h
+++ b/include/bluetooth/mesh/gen_prop_srv.h
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/**
+ * @file
+ * @defgroup bt_mesh_prop_srv Generic Property server models
+ * @{
+ * @brief API for the Generic Property server models.
+ */
+#ifndef BT_MESH_GEN_PROP_SRV_H__
+#define BT_MESH_GEN_PROP_SRV_H__
+
+#include <bluetooth/mesh/gen_prop.h>
+#include <bluetooth/mesh/model_types.h>
+#include <sys/util.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct bt_mesh_prop_srv;
+
+/** @def BT_MESH_PROP_SRV_INIT
+ *
+ * @brief Initialization parameters for a @ref bt_mesh_prop_srv instance.
+ *
+ * @param[in] _properties Array of properties supported by the server.
+ * @param[in] _property_count Number of properties supported by the server.
+ * @param[in] _get Getter handler for property values. @sa
+ * bt_mesh_prop_srv::get.
+ * @param[in] _set Setter handler for property values. @sa
+ * bt_mesh_prop_srv::set.
+ */
+#define BT_MESH_PROP_SRV_INIT(_properties, _property_count, _get, _set)        \
+	{                                                                      \
+		.get = _get, .set = _set, .properties = _properties,           \
+		.property_count = _property_count,                             \
+		.pub = {                                                       \
+			.update = _bt_mesh_prop_srv_update_handler,            \
+			.msg = NET_BUF_SIMPLE(MAX(                             \
+				BT_MESH_MODEL_BUF_LEN(                         \
+					BT_MESH_PROP_OP_MFR_PROP_STATUS,       \
+					BT_MESH_PROP_MSG_MAXLEN_PROP_STATUS),  \
+				BT_MESH_MODEL_BUF_LEN(                         \
+					BT_MESH_PROP_OP_MFR_PROPS_STATUS,      \
+					2 * _property_count))),                \
+		},                                                             \
+	}
+
+/** @def BT_MESH_PROP_SRV_ADMIN_INIT
+ *
+ * @brief Initialization parameters for a @ref bt_mesh_prop_srv acting as a
+ * Generic Admin Property Server.
+ *
+ * @param[in] _properties Array of properties exposed by the server.
+ * @param[in] _get Getter function for property values.
+ * @param[in] _set Setter function for property values.
+ */
+#define BT_MESH_PROP_SRV_ADMIN_INIT(_properties, _get, _set)                   \
+	BT_MESH_PROP_SRV_INIT(_properties, ARRAY_SIZE(_properties), _get, _set)
+
+/** @def BT_MESH_PROP_SRV_MFR_INIT
+ *
+ * @brief Initialization parameters for a @ref bt_mesh_prop_srv acting as a
+ * Generic Manufacturer Property Server.
+ *
+ * @param[in] _properties Array of properties exposed by the server.
+ * @param[in] _get Getter function for property values.
+ */
+#define BT_MESH_PROP_SRV_MFR_INIT(_properties, _get)                           \
+	BT_MESH_PROP_SRV_INIT(_properties, ARRAY_SIZE(_properties), _get, NULL)
+
+/** @def BT_MESH_PROP_SRV_CLIENT_INIT
+ *
+ * @brief Initialization parameters for a @ref bt_mesh_prop_srv acting as a
+ * Generic Client Property Server.
+ *
+ * @param[in] _properties Array of properties exposed by the server. May be
+ * constant.
+ */
+#define BT_MESH_PROP_SRV_CLIENT_INIT(_properties)                              \
+	BT_MESH_PROP_SRV_INIT((struct bt_mesh_prop *)_properties,              \
+			      ARRAY_SIZE(_properties), NULL, NULL)
+
+/** @def BT_MESH_MODEL_PROP_SRV_USER
+ *
+ * @brief Generic User Property Server model composition data entry.
+ */
+#define BT_MESH_MODEL_PROP_SRV_USER                                            \
+	BT_MESH_MODEL(BT_MESH_MODEL_ID_GEN_USER_PROP_SRV,                      \
+		      _bt_mesh_prop_user_srv_op, NULL, NULL)
+
+/** @def BT_MESH_MODEL_PROP_SRV_ADMIN
+ *
+ * @brief Generic Admin Property Server model composition data entry.
+ *
+ * @param[in] _srv Pointer to a @ref bt_mesh_prop_srv instance acting as an
+ * Admin Property Server.
+ */
+#define BT_MESH_MODEL_PROP_SRV_ADMIN(_srv)                                     \
+	BT_MESH_MODEL_PROP_SRV_USER,                                           \
+		BT_MESH_MODEL_CB(BT_MESH_MODEL_ID_GEN_ADMIN_PROP_SRV,          \
+				 _bt_mesh_prop_admin_srv_op, &(_srv)->pub,     \
+				 BT_MESH_MODEL_USER_DATA(                      \
+					 struct bt_mesh_prop_srv, _srv),       \
+				 &_bt_mesh_prop_srv_cb)
+
+/** @def BT_MESH_MODEL_PROP_SRV_MFR
+ *
+ * @brief Generic Manufacturer Property Server model data entry.
+ *
+ * @param[in] _srv Pointer to a @ref bt_mesh_prop_srv instance acting as a
+ * Manufacturer Property Server.
+ */
+#define BT_MESH_MODEL_PROP_SRV_MFR(_srv)                                       \
+	BT_MESH_MODEL_PROP_SRV_USER,                                           \
+		BT_MESH_MODEL_CB(BT_MESH_MODEL_ID_GEN_MANUFACTURER_PROP_SRV,   \
+				 _bt_mesh_prop_mfr_srv_op, &(_srv)->pub,       \
+				 BT_MESH_MODEL_USER_DATA(                      \
+					 struct bt_mesh_prop_srv, _srv),       \
+				 &_bt_mesh_prop_srv_cb)
+
+/** @def BT_MESH_MODEL_PROP_SRV_CLIENT
+ *
+ * @brief Generic Client Property Server model data entry.
+ *
+ * @param[in] _srv Pointer to a @ref bt_mesh_prop_srv instance acting as a
+ * Client Property Server.
+ */
+#define BT_MESH_MODEL_PROP_SRV_CLIENT(_srv)                                    \
+	BT_MESH_MODEL_CB(BT_MESH_MODEL_ID_GEN_CLIENT_PROP_SRV,                 \
+			 _bt_mesh_prop_client_srv_op, &(_srv)->pub,            \
+			 BT_MESH_MODEL_USER_DATA(struct bt_mesh_prop_srv,      \
+						 _srv),                        \
+			 &_bt_mesh_prop_srv_cb)
+
+/** Enumeration of all property server states. */
+enum bt_mesh_prop_srv_state {
+	BT_MESH_PROP_SRV_STATE_NONE, /**< No state. */
+	BT_MESH_PROP_SRV_STATE_LIST, /**< Property List. */
+	BT_MESH_PROP_SRV_STATE_PROP, /**< Property value. */
+};
+
+/**
+ * Generic Property Server instance. Should be initialized with the
+ * @ref BT_MESH_PROP_SRV_INIT, @ref BT_MESH_PROP_SRV_ADMIN_INIT,
+ * @ref BT_MESH_PROP_SRV_MFR_INIT or @ref BT_MESH_PROP_SRV_CLIENT_INIT macro.
+ */
+struct bt_mesh_prop_srv {
+	/** Pointer to the mesh model entry. */
+	struct bt_mesh_model *mod;
+	/** Model publication parameters. */
+	struct bt_mesh_model_pub pub;
+	/** Property ID currently being published. */
+	u16_t pub_id;
+	/** Which state is currently being published. */
+	enum bt_mesh_prop_srv_state pub_state;
+
+	/** List of properties supported by the server. */
+	struct bt_mesh_prop *const properties;
+	/** Number of properties supported by the server. */
+	const u32_t property_count;
+
+	/** @brief Set a property value.
+	 *
+	 * The handler may reject the value change by replacing the contents of
+	 * @p buf and @p size with the current property value and size. Note
+	 * that @p buf can only fit a value of size @c CONFIG_GEN_PROP_MAXSIZE.
+	 *
+	 * @note This handler is mandatory if the server is acting as an Admin
+	 * Property Server, and ignored if the server is acting as a
+	 * Manufacturer Property Server.
+	 *
+	 * @param[in] srv Property Server instance whose property to set.
+	 * @param[in] ctx Message context for the message that triggered the
+	 * change, or NULL if the change is not coming from a messge.
+	 * @param[in,out] val Property value to set. Any changes to the value
+	 * will be reflected in the response message.
+	 */
+	void (*const set)(struct bt_mesh_prop_srv *srv,
+			  struct bt_mesh_msg_ctx *ctx,
+			  struct bt_mesh_prop_val *val);
+
+	/** @brief Get a property value.
+	 *
+	 * Note that @p buf can only fit a value of size
+	 * @c CONFIG_GEN_PROP_MAXSIZE.
+	 *
+	 * @note This handler is mandatory.
+	 *
+	 * @param[in] srv Property Server instance whose property to set.
+	 * @param[in] ctx Message context for the message that triggered the
+	 * change, or NULL if the change is not coming from a messge.
+	 * @param[in,out] val Property value to get. Any changes to the value
+	 * will be reflected in the response message.
+	 */
+	void (*const get)(struct bt_mesh_prop_srv *srv,
+			  struct bt_mesh_msg_ctx *ctx,
+			  struct bt_mesh_prop_val *val);
+};
+
+/** @brief Publish a list of all properties on the server.
+ *
+ * @param[in] srv Server that owns the property.
+ * @param[in] ctx Message context to publish with, or NULL to publish on the
+ * configured publish parameters.
+ *
+ * @retval 0 Successfully publish a Generic Level Status message.
+ * @retval -EMSGSIZE The given property size is not supported.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ */
+int bt_mesh_prop_srv_pub_list(struct bt_mesh_prop_srv *srv,
+			      struct bt_mesh_msg_ctx *ctx);
+
+/** @brief Publish a property value.
+ *
+ * @param[in] srv Server that owns the property.
+ * @param[in] ctx Message context to publish with, or NULL to publish on the
+ * configured publish parameters.
+ * @param[in] prop Property to publish.
+ * @param[in] value Value of the property.
+ *
+ * @retval 0 Successfully publish a Generic Level Status message.
+ * @retval -EINVAL The server is a Client Property server, which does not
+ * support publishing of property values.
+ * @retval -EMSGSIZE The given property size is not supported.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ */
+int bt_mesh_prop_srv_pub(struct bt_mesh_prop_srv *srv,
+			 struct bt_mesh_msg_ctx *ctx,
+			 const struct bt_mesh_prop_val *val);
+
+/** @cond INTERNAL_HIDDEN */
+extern const struct bt_mesh_model_cb _bt_mesh_prop_srv_cb;
+extern const struct bt_mesh_model_op _bt_mesh_prop_user_srv_op[];
+extern const struct bt_mesh_model_op _bt_mesh_prop_admin_srv_op[];
+extern const struct bt_mesh_model_op _bt_mesh_prop_mfr_srv_op[];
+extern const struct bt_mesh_model_op _bt_mesh_prop_client_srv_op[];
+int _bt_mesh_prop_srv_update_handler(struct bt_mesh_model *mod);
+/** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BT_MESH_GEN_PROP_SRV_H__ */
+
+/** @} */

--- a/include/bluetooth/mesh/model_types.h
+++ b/include/bluetooth/mesh/model_types.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+/**
+ * @file
+ * @defgroup bt_mesh_model_types Common model types
+ * @{
+ * @brief Collection of types exposed in the model definitions.
+ */
+
+#ifndef BT_MESH_MODEL_TYPES_H__
+#define BT_MESH_MODEL_TYPES_H__
+
+#include <bluetooth/mesh.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Maximum permissible transition time in milliseconds */
+#define BT_MESH_MODEL_TRANSITION_TIME_MAX_MS (K_MINUTES(10) * (0x3e))
+
+/** Generic Transition parameters for the model messages. */
+struct bt_mesh_model_transition {
+	u32_t time; /**< Transition time value in milliseconds */
+	u32_t delay; /**< Message execution delay in milliseconds */
+};
+
+/**
+ * Transaction ID context, storing information about the previous
+ * transaction in model spec messages.
+ */
+struct bt_mesh_tid_ctx {
+	u16_t src; /**< Source address. */
+	u16_t dst; /**< Destination address. */
+	u64_t timestamp; /**< System uptime of the transaction. */
+	u8_t tid; /**< Transaction ID. */
+};
+
+/**
+ * Acknowledged message context for tracking the status of model messages
+ * pending a response.
+ */
+struct bt_mesh_model_ack_ctx {
+	struct k_sem sem; /**< Sync semaphore. */
+	u32_t op; /**< Opcode we're waiting for. */
+	u16_t dst; /**< Address of the node that should respond. */
+	void *user_data; /**< User specific parameter. */
+};
+
+/** Model status values. */
+enum bt_mesh_model_status {
+	/** Command successfully processed. */
+	BT_MESH_MODEL_SUCCESS,
+	/** The provided value for range min cannot be set. */
+	BT_MESH_MODEL_ERROR_INVALID_RANGE_MIN,
+	/** The provided value for range max cannot be set. */
+	BT_MESH_MODEL_ERROR_INVALID_RANGE_MAX,
+	/** Invalid status code. */
+	BT_MESH_MODEL_STATUS_INVALID,
+};
+
+/** @cond INTERNAL_HIDDEN
+ * @def BT_MESH_MODEL_USER_DATA
+ *
+ * @brief Internal utility macro for type checking model user data.
+ *
+ * Produces a "Comparison of distinct pointer types" warning if @p _user_data
+ * is of the wrong type.
+ *
+ * This macro abuses the C language a bit, but when used in the
+ * @c BT_MESH_MODEL_ macros, it generates a compiler warning for a bug that is
+ * otherwise very hard to detect, and relatively easy to make:
+ *
+ * As the @ref bt_mesh_model::user_data is a void pointer, it does not have
+ * any type checking. The Mesh model implementations wrap this macro, often
+ * taking a pointer parameter to a context structure, passing it to the model
+ * user data. As the @c BT_MESH_MODEL_ macros are used in listing of models,
+ * users are likely to copy and paste them, but only change the suffix.
+ * If they do this, but fail to change the context pointer, the resulting
+ * misbehavior will be confusing, dangerous and potentially hard to detect.
+ *
+ * @param[in] _type Expected type of the user data.
+ * @param[in] _user_data User data pointer.
+ */
+#define BT_MESH_MODEL_USER_DATA(_type, _user_data)                             \
+	(((_user_data) == (_type *)0) ? NULL : (_user_data))
+/** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BT_MESH_MODEL_TYPES_H__ */
+
+/** @} */

--- a/include/bluetooth/mesh/models.h
+++ b/include/bluetooth/mesh/models.h
@@ -30,5 +30,7 @@
 #include <bluetooth/mesh/gen_plvl_cli.h>
 #include <bluetooth/mesh/gen_battery_srv.h>
 #include <bluetooth/mesh/gen_battery_cli.h>
+#include <bluetooth/mesh/gen_loc_srv.h>
+#include <bluetooth/mesh/gen_loc_cli.h>
 
 #endif /* BT_MESH_MODELS_H__ */

--- a/include/bluetooth/mesh/models.h
+++ b/include/bluetooth/mesh/models.h
@@ -24,5 +24,7 @@
 #include <bluetooth/mesh/gen_lvl_cli.h>
 #include <bluetooth/mesh/gen_dtt_srv.h>
 #include <bluetooth/mesh/gen_dtt_cli.h>
+#include <bluetooth/mesh/gen_ponoff_srv.h>
+#include <bluetooth/mesh/gen_ponoff_cli.h>
 
 #endif /* BT_MESH_MODELS_H__ */

--- a/include/bluetooth/mesh/models.h
+++ b/include/bluetooth/mesh/models.h
@@ -32,5 +32,7 @@
 #include <bluetooth/mesh/gen_battery_cli.h>
 #include <bluetooth/mesh/gen_loc_srv.h>
 #include <bluetooth/mesh/gen_loc_cli.h>
+#include <bluetooth/mesh/gen_prop_srv.h>
+#include <bluetooth/mesh/gen_prop_cli.h>
 
 #endif /* BT_MESH_MODELS_H__ */

--- a/include/bluetooth/mesh/models.h
+++ b/include/bluetooth/mesh/models.h
@@ -22,5 +22,7 @@
 #include <bluetooth/mesh/gen_onoff_cli.h>
 #include <bluetooth/mesh/gen_lvl_srv.h>
 #include <bluetooth/mesh/gen_lvl_cli.h>
+#include <bluetooth/mesh/gen_dtt_srv.h>
+#include <bluetooth/mesh/gen_dtt_cli.h>
 
 #endif /* BT_MESH_MODELS_H__ */

--- a/include/bluetooth/mesh/models.h
+++ b/include/bluetooth/mesh/models.h
@@ -20,5 +20,7 @@
 /* Generic models */
 #include <bluetooth/mesh/gen_onoff_srv.h>
 #include <bluetooth/mesh/gen_onoff_cli.h>
+#include <bluetooth/mesh/gen_lvl_srv.h>
+#include <bluetooth/mesh/gen_lvl_cli.h>
 
 #endif /* BT_MESH_MODELS_H__ */

--- a/include/bluetooth/mesh/models.h
+++ b/include/bluetooth/mesh/models.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#ifndef BT_MESH_MODELS_H__
+#define BT_MESH_MODELS_H__
+
+#include <bluetooth/mesh.h>
+
+#include <bluetooth/mesh/model_types.h>
+
+/* Foundation models */
+#include <bluetooth/mesh/cfg_cli.h>
+#include <bluetooth/mesh/cfg_srv.h>
+#include <bluetooth/mesh/health_cli.h>
+#include <bluetooth/mesh/health_srv.h>
+
+#endif /* BT_MESH_MODELS_H__ */

--- a/include/bluetooth/mesh/models.h
+++ b/include/bluetooth/mesh/models.h
@@ -26,5 +26,7 @@
 #include <bluetooth/mesh/gen_dtt_cli.h>
 #include <bluetooth/mesh/gen_ponoff_srv.h>
 #include <bluetooth/mesh/gen_ponoff_cli.h>
+#include <bluetooth/mesh/gen_plvl_srv.h>
+#include <bluetooth/mesh/gen_plvl_cli.h>
 
 #endif /* BT_MESH_MODELS_H__ */

--- a/include/bluetooth/mesh/models.h
+++ b/include/bluetooth/mesh/models.h
@@ -17,4 +17,8 @@
 #include <bluetooth/mesh/health_cli.h>
 #include <bluetooth/mesh/health_srv.h>
 
+/* Generic models */
+#include <bluetooth/mesh/gen_onoff_srv.h>
+#include <bluetooth/mesh/gen_onoff_cli.h>
+
 #endif /* BT_MESH_MODELS_H__ */

--- a/include/bluetooth/mesh/models.h
+++ b/include/bluetooth/mesh/models.h
@@ -28,5 +28,7 @@
 #include <bluetooth/mesh/gen_ponoff_cli.h>
 #include <bluetooth/mesh/gen_plvl_srv.h>
 #include <bluetooth/mesh/gen_plvl_cli.h>
+#include <bluetooth/mesh/gen_battery_srv.h>
+#include <bluetooth/mesh/gen_battery_cli.h>
 
 #endif /* BT_MESH_MODELS_H__ */

--- a/include/bluetooth/mesh/models.rst
+++ b/include/bluetooth/mesh/models.rst
@@ -1,0 +1,32 @@
+.. _bt_mesh_models:
+
+Bluetooth Mesh Models
+######################
+
+Nordic Semiconductor provides a variety of model implementations from the Mesh
+Model Specification.
+
+Here you can find documentation for these model implementations, including API
+documentation.
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Model implementations:
+   :glob:
+
+   ../../../include/bluetooth/mesh/gen_*
+
+Common model types
+===================
+
+Models in the Bluetooth Mesh Model Specification share some common types, that
+are collected in a single header file.
+
+API documentation
+******************
+
+| Header file: :file:`include/bluetooth/mesh/model_types.h`
+
+.. doxygengroup:: bt_mesh_model_types
+   :project: nrf
+   :members:

--- a/include/bluetooth/mesh/properties.h
+++ b/include/bluetooth/mesh/properties.h
@@ -1,0 +1,255 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+/**
+ * @file
+ * @defgroup bt_mesh_properties Bluetooth Mesh Properties
+ * @{
+ * @brief Device properties definitions.
+ */
+#ifndef BT_MESH_PROPERTIES_H__
+#define BT_MESH_PROPERTIES_H__
+
+#include <bluetooth/mesh.h>
+
+/**
+ * @defgroup bt_mesh_property_ids Property IDs
+ * All available Mesh Property IDs. See the Bluetooth Mesh Device Properties
+ * Specification for details.
+ * @{
+ */
+/** Prohibited. */
+#define BT_MESH_PROP_ID_PROHIBITED 0x0000
+/** Average ambient temperature in a period of day. */
+#define BT_MESH_PROP_ID_AVG_AMB_TEMP_IN_A_PERIOD_OF_DAY 0x0001
+/** Average input current. */
+#define BT_MESH_PROP_ID_AVG_INPUT_CURRENT 0x0002
+/** Average input voltage. */
+#define BT_MESH_PROP_ID_AVG_INPUT_VOLTAGE 0x0003
+/** Average output current. */
+#define BT_MESH_PROP_ID_AVG_OUTPUT_CURRENT 0x0004
+/** Average output voltage. */
+#define BT_MESH_PROP_ID_AVG_OUTPUT_VOLTAGE 0x0005
+/** Center beam intensity at full power. */
+#define BT_MESH_PROP_ID_CENTER_BEAM_INTENSITY_AT_FULL_POWER 0x0006
+/** Chromaticity tolerance. */
+#define BT_MESH_PROP_ID_CHROMATICITY_TOLERANCE 0x0007
+/** Color rendering index R9. */
+#define BT_MESH_PROP_ID_COL_RENDERING_INDEX_R9 0x0008
+/** Color rendering index RA. */
+#define BT_MESH_PROP_ID_COL_RENDERING_INDEX_RA 0x0009
+/** Device appearance. */
+#define BT_MESH_PROP_ID_DEV_APPEARANCE 0x000A
+/** Device country of origin. */
+#define BT_MESH_PROP_ID_DEV_COUNTRY_OF_ORIGIN 0x000B
+/** Device date of manufacture. */
+#define BT_MESH_PROP_ID_DEV_DATE_OF_MANUFACTURE 0x000C
+/** Device energy use since turn on. */
+#define BT_MESH_PROP_ID_DEV_ENERGY_USE_SINCE_TURN_ON 0x000D
+/** Device firmware revision. */
+#define BT_MESH_PROP_ID_DEV_FW_REVISION 0x000E
+/** Device global trade item number. */
+#define BT_MESH_PROP_ID_DEV_GLOBAL_TRADE_ITEM_NUM 0x000F
+/** Device hardware revision. */
+#define BT_MESH_PROP_ID_DEV_HW_REVISION 0x0010
+/** Device manufacturer name. */
+#define BT_MESH_PROP_ID_DEV_MFR_NAME 0x0011
+/** Device model number. */
+#define BT_MESH_PROP_ID_DEV_MODEL_NUM 0x0012
+/** Device operating temperature range specification. */
+#define BT_MESH_PROP_ID_DEV_OP_TEMP_RANGE_SPEC 0x0013
+/** Device operating temperature statistical values. */
+#define BT_MESH_PROP_ID_DEV_OP_TEMP_STAT_VALUES 0x0014
+/** Device over temperature event statistics. */
+#define BT_MESH_PROP_ID_DEV_OVER_TEMP_EVT_STAT 0x0015
+/** Device power range specification. */
+#define BT_MESH_PROP_ID_DEV_POWER_RANGE_SPEC 0x0016
+/** Device runtime since turn on. */
+#define BT_MESH_PROP_ID_DEV_RUNTIME_SINCE_TURN_ON 0x0017
+/** Device runtime warranty. */
+#define BT_MESH_PROP_ID_DEV_RUNTIME_WARRANTY 0x0018
+/** Device serial number. */
+#define BT_MESH_PROP_ID_DEV_SERIAL_NUM 0x0019
+/** Device software revision. */
+#define BT_MESH_PROP_ID_DEV_SW_REVISION 0x001A
+/** Device under temperature event statistics. */
+#define BT_MESH_PROP_ID_DEV_UNDER_TEMP_EVT_STAT 0x001B
+/** Indoor ambient temperature statistical values. */
+#define BT_MESH_PROP_ID_INDOOR_AMB_TEMP_STAT_VALUES 0x001C
+/** Initial CIE-1931 chromaticity coordinates. */
+#define BT_MESH_PROP_ID_INITIAL_CIE_1931_CHROMATICITY_COORDS 0x001D
+/** Initial correlated color temperature. */
+#define BT_MESH_PROP_ID_INITIAL_CORRELATED_COL_TEMP 0x001E
+/** Initial luminous flux. */
+#define BT_MESH_PROP_ID_INITIAL_LUMINOUS_FLUX 0x001F
+/** Initial planckian distance. */
+#define BT_MESH_PROP_ID_INITIAL_PLANCKIAN_DISTANCE 0x0020
+/** Input current range specification. */
+#define BT_MESH_PROP_ID_INPUT_CURRENT_RANGE_SPEC 0x0021
+/** Input current statistics. */
+#define BT_MESH_PROP_ID_INPUT_CURRENT_STAT 0x0022
+/** Input over current event statistics. */
+#define BT_MESH_PROP_ID_INPUT_OVER_CURRENT_EVT_STAT 0x0023
+/** Input over ripple voltage event statistics. */
+#define BT_MESH_PROP_ID_INPUT_OVER_RIPPLE_VOLTAGE_EVT_STAT 0x0024
+/** Input over voltage event statistics. */
+#define BT_MESH_PROP_ID_INPUT_OVER_VOLTAGE_EVT_STAT 0x0025
+/** Input under current event statistics. */
+#define BT_MESH_PROP_ID_INPUT_UNDER_CURRENT_EVT_STAT 0x0026
+/** Input under voltage event statistics. */
+#define BT_MESH_PROP_ID_INPUT_UNDER_VOLTAGE_EVT_STAT 0x0027
+/** Input voltage range specification. */
+#define BT_MESH_PROP_ID_INPUT_VOLTAGE_RANGE_SPEC 0x0028
+/** Input voltage ripple specification. */
+#define BT_MESH_PROP_ID_INPUT_VOLTAGE_RIPPLE_SPEC 0x0029
+/** Input voltage statistics. */
+#define BT_MESH_PROP_ID_INPUT_VOLTAGE_STAT 0x002A
+/** Light control ambient luxlevel on. */
+#define BT_MESH_PROP_ID_LIGHT_CTRL_AMB_LUXLEVEL_ON 0x002B
+/** Light control ambient luxlevel prolong. */
+#define BT_MESH_PROP_ID_LIGHT_CTRL_AMB_LUXLEVEL_PROLONG 0x002C
+/** Light control ambient luxlevel standby. */
+#define BT_MESH_PROP_ID_LIGHT_CTRL_AMB_LUXLEVEL_STANDBY 0x002D
+/** Light control lightness on. */
+#define BT_MESH_PROP_ID_LIGHT_CTRL_LIGHTNESS_ON 0x002E
+/** Light control lightness prolong. */
+#define BT_MESH_PROP_ID_LIGHT_CTRL_LIGHTNESS_PROLONG 0x002F
+/** Light control lightness standby. */
+#define BT_MESH_PROP_ID_LIGHT_CTRL_LIGHTNESS_STANDBY 0x0030
+/** Light control regulator accuracy. */
+#define BT_MESH_PROP_ID_LIGHT_CTRL_REG_ACCURACY 0x0031
+/** Light control regulator kid. */
+#define BT_MESH_PROP_ID_LIGHT_CTRL_REG_KID 0x0032
+/** Light control regulator kiu. */
+#define BT_MESH_PROP_ID_LIGHT_CTRL_REG_KIU 0x0033
+/** Light control regulator kpd. */
+#define BT_MESH_PROP_ID_LIGHT_CTRL_REG_KPD 0x0034
+/** Light control regulator kpu. */
+#define BT_MESH_PROP_ID_LIGHT_CTRL_REG_KPU 0x0035
+/** Light control time fade. */
+#define BT_MESH_PROP_ID_LIGHT_CTRL_TIME_FADE 0x0036
+/** Light control time fade on. */
+#define BT_MESH_PROP_ID_LIGHT_CTRL_TIME_FADE_ON 0x0037
+/** Light control time fade standby auto. */
+#define BT_MESH_PROP_ID_LIGHT_CTRL_TIME_FADE_STANDBY_AUTO 0x0038
+/** Light control time fade standby manual. */
+#define BT_MESH_PROP_ID_LIGHT_CTRL_TIME_FADE_STANDBY_MANUAL 0x0039
+/** Light control time occupancy delay. */
+#define BT_MESH_PROP_ID_LIGHT_CTRL_TIME_OCCUPANCY_DELAY 0x003A
+/** Light control time prolong. */
+#define BT_MESH_PROP_ID_LIGHT_CTRL_TIME_PROLONG 0x003B
+/** Light control time run on. */
+#define BT_MESH_PROP_ID_LIGHT_CTRL_TIME_RUN_ON 0x003C
+/** Lumen maintenance factor. */
+#define BT_MESH_PROP_ID_LUMEN_MAINTENANCE_FACTOR 0x003D
+/** Luminous efficacy. */
+#define BT_MESH_PROP_ID_LUMINOUS_EFFICACY 0x003E
+/** Luminous energy since turn on. */
+#define BT_MESH_PROP_ID_LUMINOUS_ENERGY_SINCE_TURN_ON 0x003F
+/** Luminous exposure. */
+#define BT_MESH_PROP_ID_LUMINOUS_EXPOSURE 0x0040
+/** Luminous flux range. */
+#define BT_MESH_PROP_ID_LUMINOUS_FLUX_RANGE 0x0041
+/** Motion sensed. */
+#define BT_MESH_PROP_ID_MOTION_SENSED 0x0042
+/** Motion threshold. */
+#define BT_MESH_PROP_ID_MOTION_THRESHOLD 0x0043
+/** Open circuit event statistics. */
+#define BT_MESH_PROP_ID_OPEN_CIRCUIT_EVT_STAT 0x0044
+/** Outdoor statistical values. */
+#define BT_MESH_PROP_ID_OUTDOOR_STAT_VALUES 0x0045
+/** Output current range. */
+#define BT_MESH_PROP_ID_OUTPUT_CURRENT_RANGE 0x0046
+/** Output current statistics. */
+#define BT_MESH_PROP_ID_OUTPUT_CURRENT_STAT 0x0047
+/** Output ripple voltage specification. */
+#define BT_MESH_PROP_ID_OUTPUT_RIPPLE_VOLTAGE_SPEC 0x0048
+/** Output voltage range. */
+#define BT_MESH_PROP_ID_OUTPUT_VOLTAGE_RANGE 0x0049
+/** Output voltage statistics. */
+#define BT_MESH_PROP_ID_OUTPUT_VOLTAGE_STAT 0x004A
+/** Over output ripple voltage event statistics. */
+#define BT_MESH_PROP_ID_OVER_OUTPUT_RIPPLE_VOLTAGE_EVT_STAT 0x004B
+/** People count. */
+#define BT_MESH_PROP_ID_PEOPLE_COUNT 0x004C
+/** Presence detected. */
+#define BT_MESH_PROP_ID_PRESENCE_DETECTED 0x004D
+/** Present ambient light level. */
+#define BT_MESH_PROP_ID_PRESENT_AMB_LIGHT_LEVEL 0x004E
+/** Present ambient temperature. */
+#define BT_MESH_PROP_ID_PRESENT_AMB_TEMP 0x004F
+/** Present CIE-1931 chromaticity coordinates. */
+#define BT_MESH_PROP_ID_PRESENT_CIE_1931_CHROMATICITY_COORDS 0x0050
+/** Present correlated color temperature. */
+#define BT_MESH_PROP_ID_PRESENT_CORRELATED_COL_TEMP 0x0051
+/** Present device input power. */
+#define BT_MESH_PROP_ID_PRESENT_DEV_INPUT_POWER 0x0052
+/** Present device operating efficiency. */
+#define BT_MESH_PROP_ID_PRESENT_DEV_OP_EFFICIENCY 0x0053
+/** Present device operating temperature. */
+#define BT_MESH_PROP_ID_PRESENT_DEV_OP_TEMP 0x0054
+/** Present illuminance. */
+#define BT_MESH_PROP_ID_PRESENT_ILLUMINANCE 0x0055
+/** Present indoor ambient temperature. */
+#define BT_MESH_PROP_ID_PRESENT_INDOOR_AMB_TEMP 0x0056
+/** Present input current. */
+#define BT_MESH_PROP_ID_PRESENT_INPUT_CURRENT 0x0057
+/** Present input ripple voltage. */
+#define BT_MESH_PROP_ID_PRESENT_INPUT_RIPPLE_VOLTAGE 0x0058
+/** Present input voltage. */
+#define BT_MESH_PROP_ID_PRESENT_INPUT_VOLTAGE 0x0059
+/** Present luminous flux. */
+#define BT_MESH_PROP_ID_PRESENT_LUMINOUS_FLUX 0x005A
+/** Present outdoor ambient temperature. */
+#define BT_MESH_PROP_ID_PRESENT_OUTDOOR_AMB_TEMP 0x005B
+/** Present output current. */
+#define BT_MESH_PROP_ID_PRESENT_OUTPUT_CURRENT 0x005C
+/** Present output voltage. */
+#define BT_MESH_PROP_ID_PRESENT_OUTPUT_VOLTAGE 0x005D
+/** Present planckian distance. */
+#define BT_MESH_PROP_ID_PRESENT_PLANCKIAN_DISTANCE 0x005E
+/** Present relative output ripple voltage. */
+#define BT_MESH_PROP_ID_PRESENT_REL_OUTPUT_RIPPLE_VOLTAGE 0x005F
+/** Relative device energy use in a period of day. */
+#define BT_MESH_PROP_ID_REL_DEV_ENERGY_USE_IN_A_PERIOD_OF_DAY 0x0060
+/** Relative device runtime in a generic level range. */
+#define BT_MESH_PROP_ID_REL_DEV_RUNTIME_IN_A_GENERIC_LEVEL_RANGE 0x0061
+/** Relative exposure time in an illuminance range. */
+#define BT_MESH_PROP_ID_REL_EXPOSURE_TIME_IN_AN_ILLUMINANCE_RANGE 0x0062
+/** Relative runtime in a correlated color temperature range. */
+#define BT_MESH_PROP_ID_REL_RUNTIME_IN_A_CORRELATED_COL_TEMP_RANGE 0x0063
+/** Relative runtime in a device operating temperature range. */
+#define BT_MESH_PROP_ID_REL_RUNTIME_IN_A_DEV_OP_TEMP_RANGE 0x0064
+/** Relative runtime in an input current range. */
+#define BT_MESH_PROP_ID_REL_RUNTIME_IN_AN_INPUT_CURRENT_RANGE 0x0065
+/** Relative runtime in an input voltage range. */
+#define BT_MESH_PROP_ID_REL_RUNTIME_IN_AN_INPUT_VOLTAGE_RANGE 0x0066
+/** Short circuit event statistics. */
+#define BT_MESH_PROP_ID_SHORT_CIRCUIT_EVT_STAT 0x0067
+/** Time since motion sensed. */
+#define BT_MESH_PROP_ID_TIME_SINCE_MOTION_SENSED 0x0068
+/** Time since presence detected. */
+#define BT_MESH_PROP_ID_TIME_SINCE_PRESENCE_DETECTED 0x0069
+/** Total device energy use. */
+#define BT_MESH_PROP_ID_TOT_DEV_ENERGY_USE 0x006A
+/** Total device off on cycles. */
+#define BT_MESH_PROP_ID_TOT_DEV_OFF_ON_CYCLES 0x006B
+/** Total device power on cycles. */
+#define BT_MESH_PROP_ID_TOT_DEV_POWER_ON_CYCLES 0x006C
+/** Total device power on time. */
+#define BT_MESH_PROP_ID_TOT_DEV_POWER_ON_TIME 0x006D
+/** Total device runtime. */
+#define BT_MESH_PROP_ID_TOT_DEV_RUNTIME 0x006E
+/** Total light exposure time. */
+#define BT_MESH_PROP_ID_TOT_LIGHT_EXPOSURE_TIME 0x006F
+/** Total luminous energy. */
+#define BT_MESH_PROP_ID_TOT_LUMINOUS_ENERGY 0x0070
+/** Desired ambient temperature. */
+#define BT_MESH_PROP_ID_DESIRED_AMB_TEMP 0x0071
+/** @} */
+
+#endif /* BT_MESH_PROPERTIES_H__ */
+
+/** @} */

--- a/include/bluetooth/mesh/properties.rst
+++ b/include/bluetooth/mesh/properties.rst
@@ -1,0 +1,23 @@
+.. _bt_mesh_properties_readme:
+
+Bluetooth Mesh Properties
+##########################
+
+The Bluetooth SIG defines a list of Bluetooth Mesh properties in the Mesh
+Device Properties Specification. Each property has an assigned ID and an
+associated Bluetooth GATT characteristic. The properties all represent
+values on a format defined by the associated characteristic.
+
+Only the list of Property IDs, as specified in the Bluetooth Mesh Device
+Properties Specification v1.1 are defined in the API. It's up to the
+application to implement property values that are compliant with the
+specified format.
+
+API documentation
+******************
+
+| Header file: :file:`include/bluetooth/mesh/properties.h`
+
+.. doxygengroup:: bt_mesh_property_ids
+   :project: nrf
+   :members:

--- a/subsys/bluetooth/CMakeLists.txt
+++ b/subsys/bluetooth/CMakeLists.txt
@@ -10,6 +10,7 @@ zephyr_sources_ifdef(CONFIG_BT_SCAN scan.c)
 zephyr_sources_ifdef(CONFIG_BT_CONN_CTX conn_ctx.c)
 
 add_subdirectory_ifdef(CONFIG_BT_LL_NRFXLIB controller)
+add_subdirectory_ifdef(CONFIG_BT_MESH_NORDIC_MODELS mesh)
 
 if (CONFIG_BT_GATT_BAS_C     OR
     CONFIG_BT_GATT_DFU_SMP_C OR

--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -17,6 +17,7 @@ rsource "Kconfig.pool"
 rsource "Kconfig.discovery"
 rsource "Kconfig.scan"
 rsource "Kconfig.link"
+rsource "mesh/Kconfig"
 
 rsource "services/Kconfig"
 

--- a/subsys/bluetooth/mesh/CMakeLists.txt
+++ b/subsys/bluetooth/mesh/CMakeLists.txt
@@ -26,3 +26,6 @@ zephyr_sources_ifdef(CONFIG_BT_MESH_BATTERY_CLI gen_battery_cli.c)
 
 zephyr_sources_ifdef(CONFIG_BT_MESH_LOC_SRV gen_loc_srv.c)
 zephyr_sources_ifdef(CONFIG_BT_MESH_LOC_CLI gen_loc_cli.c)
+
+zephyr_sources_ifdef(CONFIG_BT_MESH_PROP_SRV gen_prop_srv.c)
+zephyr_sources_ifdef(CONFIG_BT_MESH_PROP_CLI gen_prop_cli.c)

--- a/subsys/bluetooth/mesh/CMakeLists.txt
+++ b/subsys/bluetooth/mesh/CMakeLists.txt
@@ -11,3 +11,6 @@ zephyr_sources_ifdef(CONFIG_BT_MESH_ONOFF_CLI gen_onoff_cli.c)
 
 zephyr_sources_ifdef(CONFIG_BT_MESH_LVL_SRV gen_lvl_srv.c)
 zephyr_sources_ifdef(CONFIG_BT_MESH_LVL_CLI gen_lvl_cli.c)
+
+zephyr_sources_ifdef(CONFIG_BT_MESH_DTT_SRV gen_dtt_srv.c)
+zephyr_sources_ifdef(CONFIG_BT_MESH_DTT_CLI gen_dtt_cli.c)

--- a/subsys/bluetooth/mesh/CMakeLists.txt
+++ b/subsys/bluetooth/mesh/CMakeLists.txt
@@ -20,3 +20,6 @@ zephyr_sources_ifdef(CONFIG_BT_MESH_PONOFF_CLI gen_ponoff_cli.c)
 
 zephyr_sources_ifdef(CONFIG_BT_MESH_PLVL_SRV gen_plvl_srv.c)
 zephyr_sources_ifdef(CONFIG_BT_MESH_PLVL_CLI gen_plvl_cli.c)
+
+zephyr_sources_ifdef(CONFIG_BT_MESH_BATTERY_SRV gen_battery_srv.c)
+zephyr_sources_ifdef(CONFIG_BT_MESH_BATTERY_CLI gen_battery_cli.c)

--- a/subsys/bluetooth/mesh/CMakeLists.txt
+++ b/subsys/bluetooth/mesh/CMakeLists.txt
@@ -8,3 +8,6 @@ zephyr_sources_ifdef(CONFIG_BT_MESH_NORDIC_MODELS model_utils.c)
 
 zephyr_sources_ifdef(CONFIG_BT_MESH_ONOFF_SRV gen_onoff_srv.c)
 zephyr_sources_ifdef(CONFIG_BT_MESH_ONOFF_CLI gen_onoff_cli.c)
+
+zephyr_sources_ifdef(CONFIG_BT_MESH_LVL_SRV gen_lvl_srv.c)
+zephyr_sources_ifdef(CONFIG_BT_MESH_LVL_CLI gen_lvl_cli.c)

--- a/subsys/bluetooth/mesh/CMakeLists.txt
+++ b/subsys/bluetooth/mesh/CMakeLists.txt
@@ -5,3 +5,6 @@
 #
 
 zephyr_sources_ifdef(CONFIG_BT_MESH_NORDIC_MODELS model_utils.c)
+
+zephyr_sources_ifdef(CONFIG_BT_MESH_ONOFF_SRV gen_onoff_srv.c)
+zephyr_sources_ifdef(CONFIG_BT_MESH_ONOFF_CLI gen_onoff_cli.c)

--- a/subsys/bluetooth/mesh/CMakeLists.txt
+++ b/subsys/bluetooth/mesh/CMakeLists.txt
@@ -14,3 +14,6 @@ zephyr_sources_ifdef(CONFIG_BT_MESH_LVL_CLI gen_lvl_cli.c)
 
 zephyr_sources_ifdef(CONFIG_BT_MESH_DTT_SRV gen_dtt_srv.c)
 zephyr_sources_ifdef(CONFIG_BT_MESH_DTT_CLI gen_dtt_cli.c)
+
+zephyr_sources_ifdef(CONFIG_BT_MESH_PONOFF_SRV gen_ponoff_srv.c)
+zephyr_sources_ifdef(CONFIG_BT_MESH_PONOFF_CLI gen_ponoff_cli.c)

--- a/subsys/bluetooth/mesh/CMakeLists.txt
+++ b/subsys/bluetooth/mesh/CMakeLists.txt
@@ -17,3 +17,6 @@ zephyr_sources_ifdef(CONFIG_BT_MESH_DTT_CLI gen_dtt_cli.c)
 
 zephyr_sources_ifdef(CONFIG_BT_MESH_PONOFF_SRV gen_ponoff_srv.c)
 zephyr_sources_ifdef(CONFIG_BT_MESH_PONOFF_CLI gen_ponoff_cli.c)
+
+zephyr_sources_ifdef(CONFIG_BT_MESH_PLVL_SRV gen_plvl_srv.c)
+zephyr_sources_ifdef(CONFIG_BT_MESH_PLVL_CLI gen_plvl_cli.c)

--- a/subsys/bluetooth/mesh/CMakeLists.txt
+++ b/subsys/bluetooth/mesh/CMakeLists.txt
@@ -23,3 +23,6 @@ zephyr_sources_ifdef(CONFIG_BT_MESH_PLVL_CLI gen_plvl_cli.c)
 
 zephyr_sources_ifdef(CONFIG_BT_MESH_BATTERY_SRV gen_battery_srv.c)
 zephyr_sources_ifdef(CONFIG_BT_MESH_BATTERY_CLI gen_battery_cli.c)
+
+zephyr_sources_ifdef(CONFIG_BT_MESH_LOC_SRV gen_loc_srv.c)
+zephyr_sources_ifdef(CONFIG_BT_MESH_LOC_CLI gen_loc_cli.c)

--- a/subsys/bluetooth/mesh/CMakeLists.txt
+++ b/subsys/bluetooth/mesh/CMakeLists.txt
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2018 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+zephyr_sources_ifdef(CONFIG_BT_MESH_NORDIC_MODELS model_utils.c)

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -120,6 +120,41 @@ config BT_MESH_LOC_CLI
 	help
 	  Enable Mesh Generic Location Client model.
 
+config BT_MESH_PROP_SRV
+	bool "Generic Property Server"
+	select BT_MESH_NORDIC_MODELS
+	help
+	  Enable Mesh Generic Property Server models.
+
+config BT_MESH_PROP_CLI
+	bool "Generic Property Client"
+	select BT_MESH_NORDIC_MODELS
+	help
+	  Enable Mesh Generic Property Client models.
+
+menu "Generic Property Model configuration"
+
+config BT_MESH_PROP_MAXSIZE
+	int "Generic Property value max size"
+	default 8
+	range 1 376
+	help
+	  The upper boundary of a Generic Property value's size. The entire
+	  value with an 4 byte overhead must fit within a full TX packet
+	  payload (see BT_MESH_TX_SEG_MAX).
+
+config BT_MESH_PROP_MAXCOUNT
+	int "Generic Property value max count"
+	default 8
+	range 1 189
+	help
+	  The largest number of Generic Property values that can be listed by
+	  a Generic Property server. Each property ID is 2 bytes long, and
+	  the full list plus a 1 byte overhead must fit within a full TX packet
+	  payload (see BT_MESH_TX_SEG_MAX).
+
+endmenu
+
 endmenu
 
 endif # BT_MESH

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -14,6 +14,19 @@ config BT_MESH_NORDIC_MODELS
 	  Common Mesh model support modules, required by all Nordic BT Mesh
 	  models.
 
+
+config BT_MESH_ONOFF_SRV
+	bool "Generic OnOff Server"
+	select BT_MESH_NORDIC_MODELS
+	help
+	  Enable Mesh Generic OnOff Server model.
+
+config BT_MESH_ONOFF_CLI
+	bool "Generic OnOff Client"
+	select BT_MESH_NORDIC_MODELS
+	help
+	  Enable Mesh Generic OnOff Client model.
+
 endmenu
 
 endif # BT_MESH

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2019 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+if BT_MESH
+
+menu "nRF BT Mesh Models"
+
+config BT_MESH_NORDIC_MODELS
+	bool "nRF BT Mesh Model support"
+	help
+	  Common Mesh model support modules, required by all Nordic BT Mesh
+	  models.
+
+endmenu
+
+endif # BT_MESH

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -63,6 +63,22 @@ config BT_MESH_DTT_CLI
 	help
 	  Enable Mesh Generic Default Transition Time Client model.
 
+
+config BT_MESH_PONOFF_SRV
+	bool "Generic Power OnOff Server"
+	select BT_MESH_NORDIC_MODELS
+	select BT_MESH_DTT_SRV
+	select BT_MESH_ONOFF_SRV
+	imply BT_SETTINGS
+	help
+	  Enable Mesh Generic Power OnOff Server model.
+
+config BT_MESH_PONOFF_CLI
+	bool "Generic Power OnOff Client"
+	select BT_MESH_NORDIC_MODELS
+	help
+	  Enable Mesh Generic Power OnOff Client model.
+
 endmenu
 
 endif # BT_MESH

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -27,6 +27,19 @@ config BT_MESH_ONOFF_CLI
 	help
 	  Enable Mesh Generic OnOff Client model.
 
+
+config BT_MESH_LVL_SRV
+	bool "Generic Level Server"
+	select BT_MESH_NORDIC_MODELS
+	help
+	  Enable Mesh Generic Level Server model.
+
+config BT_MESH_LVL_CLI
+	bool "Generic Level Client"
+	select BT_MESH_NORDIC_MODELS
+	help
+	  Enable Mesh Generic Level Client model.
+
 endmenu
 
 endif # BT_MESH

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -107,6 +107,19 @@ config BT_MESH_BATTERY_CLI
 	help
 	  Enable Mesh Generic Battery Client model.
 
+
+config BT_MESH_LOC_SRV
+	bool "Generic Location Server"
+	select BT_MESH_NORDIC_MODELS
+	help
+	  Enable Mesh Generic Location Server model.
+
+config BT_MESH_LOC_CLI
+	bool "Generic Location Client"
+	select BT_MESH_NORDIC_MODELS
+	help
+	  Enable Mesh Generic Location Client model.
+
 endmenu
 
 endif # BT_MESH

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -40,6 +40,29 @@ config BT_MESH_LVL_CLI
 	help
 	  Enable Mesh Generic Level Client model.
 
+
+menuconfig BT_MESH_DTT_SRV
+	bool "Generic Default Transition Time Server"
+	select BT_MESH_NORDIC_MODELS
+	help
+	  Enable Mesh Generic Default Transition Time Server model.
+
+if BT_MESH_DTT_SRV && BT_SETTINGS
+
+config BT_MESH_DTT_SRV_PERSISTENT
+	bool "Store the Default Transition Time persistently"
+	default y
+	help
+	  Enable persistent storage for the Default Transition Time state.
+
+endif
+
+config BT_MESH_DTT_CLI
+	bool "Generic Default Transition Time Client"
+	select BT_MESH_NORDIC_MODELS
+	help
+	  Enable Mesh Generic Default Transition Time Client model.
+
 endmenu
 
 endif # BT_MESH

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -94,6 +94,19 @@ config BT_MESH_PLVL_CLI
 	help
 	  Enable Mesh Generic Power Level Client model.
 
+
+config BT_MESH_BATTERY_SRV
+	bool "Generic Battery Server"
+	select BT_MESH_NORDIC_MODELS
+	help
+	  Enable Mesh Generic Battery Server model.
+
+config BT_MESH_BATTERY_CLI
+	bool "Generic Battery Client"
+	select BT_MESH_NORDIC_MODELS
+	help
+	  Enable Mesh Generic Battery Client model.
+
 endmenu
 
 endif # BT_MESH

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -79,6 +79,21 @@ config BT_MESH_PONOFF_CLI
 	help
 	  Enable Mesh Generic Power OnOff Client model.
 
+
+config BT_MESH_PLVL_SRV
+	bool "Generic Power Level Server"
+	select BT_MESH_NORDIC_MODELS
+	select BT_MESH_LVL_SRV
+	select BT_MESH_PONOFF_SRV
+	help
+	  Enable Mesh Generic Power Level Server model.
+
+config BT_MESH_PLVL_CLI
+	bool "Generic Power Level Client"
+	select BT_MESH_NORDIC_MODELS
+	help
+	  Enable Mesh Generic Power Level Client model.
+
 endmenu
 
 endif # BT_MESH

--- a/subsys/bluetooth/mesh/gen_battery_cli.c
+++ b/subsys/bluetooth/mesh/gen_battery_cli.c
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#include <string.h>
+#include <bluetooth/mesh/gen_battery_cli.h>
+#include "model_utils.h"
+
+static void decode_status(struct net_buf_simple *buf,
+			  struct bt_mesh_battery_status *status)
+{
+	status->battery_lvl = net_buf_simple_pull_le16(buf);
+
+	u8_t *discharge_minutes = net_buf_simple_pull_mem(buf, 3);
+
+	status->discharge_minutes =
+		((discharge_minutes[0] >> 16) | (discharge_minutes[1] >> 8) |
+		 (discharge_minutes[2]));
+
+	u8_t *charge_minutes = net_buf_simple_pull_mem(buf, 3);
+
+	status->charge_minutes =
+		((charge_minutes[0] >> 16) | (charge_minutes[1] >> 8) |
+		 (charge_minutes[2]));
+
+	u8_t flags = net_buf_simple_pull_u8(buf);
+
+	status->presence = flags & BIT_MASK(2);
+	status->indicator = (flags >> 2) & BIT_MASK(2);
+	status->charging = (flags >> 4) & BIT_MASK(2);
+	status->service = (flags >> 6) & BIT_MASK(2);
+}
+
+static void handle_status(struct bt_mesh_model *model,
+			  struct bt_mesh_msg_ctx *ctx,
+			  struct net_buf_simple *buf)
+{
+	struct bt_mesh_battery_cli *cli = model->user_data;
+	struct bt_mesh_battery_status status;
+
+	decode_status(buf, &status);
+
+	if (model_ack_match(&cli->ack_ctx, BT_MESH_BATTERY_OP_STATUS, ctx)) {
+		struct bt_mesh_battery_status *rsp =
+			(struct bt_mesh_battery_status *)cli->ack_ctx.user_data;
+
+		*rsp = status;
+		model_ack_rx(&cli->ack_ctx);
+	}
+
+	if (cli->status_handler) {
+		cli->status_handler(cli, ctx, &status);
+	}
+}
+
+const struct bt_mesh_model_op _bt_mesh_battery_cli_op[] = {
+	{ BT_MESH_BATTERY_OP_STATUS, BT_MESH_BATTERY_MSG_LEN_STATUS,
+	  handle_status },
+	BT_MESH_MODEL_OP_END,
+};
+
+static int bt_mesh_battery_cli_init(struct bt_mesh_model *model)
+{
+	struct bt_mesh_battery_cli *cli = model->user_data;
+
+	cli->model = model;
+	return 0;
+}
+
+const struct bt_mesh_model_cb _bt_mesh_battery_cli_cb = {
+	.init = bt_mesh_battery_cli_init,
+};
+
+int bt_mesh_battery_cli_status_get(struct bt_mesh_battery_cli *cli,
+				   struct bt_mesh_msg_ctx *ctx,
+				   struct bt_mesh_battery_status *rsp)
+{
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_BATTERY_OP_GET,
+				 BT_MESH_BATTERY_MSG_LEN_GET);
+	bt_mesh_model_msg_init(&msg, BT_MESH_BATTERY_OP_GET);
+
+	return model_ackd_send(cli->model, ctx, &msg,
+			       rsp ? &cli->ack_ctx : NULL,
+			       BT_MESH_BATTERY_OP_STATUS, rsp);
+}

--- a/subsys/bluetooth/mesh/gen_battery_srv.c
+++ b/subsys/bluetooth/mesh/gen_battery_srv.c
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#include <string.h>
+#include <bluetooth/mesh/gen_battery_srv.h>
+#include <bluetooth/mesh/gen_dtt_srv.h>
+#include "model_utils.h"
+
+#define BATTERY_STATUS_DEFAULT                                                 \
+	{                                                                      \
+		.battery_lvl = BT_MESH_BATTERY_LVL_UNKNOWN,                    \
+		.discharge_minutes = BT_MESH_BATTERY_TIME_UNKNOWN,             \
+		.charge_minutes = BT_MESH_BATTERY_TIME_UNKNOWN,                \
+		.presence = BT_MESH_BATTERY_PRESENCE_UNKNOWN,                  \
+		.indicator = BT_MESH_BATTERY_INDICATOR_UNKNOWN,                \
+		.charging = BT_MESH_BATTERY_CHARGING_UNKNOWN,                  \
+		.service = BT_MESH_BATTERY_SERVICE_UNKNOWN,                    \
+	}
+
+static void encode_status(struct net_buf_simple *buf,
+			  const struct bt_mesh_battery_status *status)
+{
+	bt_mesh_model_msg_init(buf, BT_MESH_BATTERY_OP_STATUS);
+	net_buf_simple_add_u8(buf, status->battery_lvl);
+
+	u8_t *discharge = net_buf_simple_add(buf, 3);
+
+	discharge[0] = status->discharge_minutes;
+	discharge[1] = status->discharge_minutes >> 8;
+	discharge[2] = status->discharge_minutes >> 16;
+
+	u8_t *charge = net_buf_simple_add(buf, 3);
+
+	charge[0] = status->charge_minutes;
+	charge[1] = status->charge_minutes >> 8;
+	charge[2] = status->charge_minutes >> 16;
+
+	u8_t flags = ((status->presence & BIT_MASK(2)) |
+		      ((status->indicator & BIT_MASK(2)) << 2) |
+		      ((status->charging & BIT_MASK(2)) << 4) |
+		      ((status->service & BIT_MASK(2)) << 6));
+
+	net_buf_simple_add_u8(buf, flags);
+}
+
+static void rsp_status(struct bt_mesh_model *model,
+		       struct bt_mesh_msg_ctx *rx_ctx,
+		       const struct bt_mesh_battery_status *status)
+{
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_BATTERY_OP_STATUS,
+				 BT_MESH_BATTERY_MSG_LEN_STATUS);
+	encode_status(&msg, status);
+
+	(void)bt_mesh_model_send(model, rx_ctx, &msg, NULL, NULL);
+}
+
+static void handle_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+		       struct net_buf_simple *buf)
+{
+	struct bt_mesh_battery_srv *srv = model->user_data;
+	struct bt_mesh_battery_status status = BATTERY_STATUS_DEFAULT;
+
+	srv->get(srv, ctx, &status);
+
+	rsp_status(model, ctx, &status);
+}
+
+const struct bt_mesh_model_op _bt_mesh_battery_srv_op[] = {
+	{ BT_MESH_BATTERY_OP_GET, BT_MESH_BATTERY_MSG_LEN_GET, handle_get },
+	BT_MESH_MODEL_OP_END,
+};
+
+static int bt_mesh_battery_srv_init(struct bt_mesh_model *model)
+{
+	struct bt_mesh_battery_srv *srv = model->user_data;
+
+	srv->model = model;
+	return 0;
+}
+
+const struct bt_mesh_model_cb _bt_mesh_battery_srv_cb = {
+	.init = bt_mesh_battery_srv_init
+};
+
+int _bt_mesh_battery_srv_update_handler(struct bt_mesh_model *model)
+{
+	struct bt_mesh_battery_srv *srv = model->user_data;
+	struct bt_mesh_battery_status status = BATTERY_STATUS_DEFAULT;
+
+	srv->get(srv, NULL, &status);
+
+	encode_status(model->pub->msg, &status);
+
+	return 0;
+}
+
+s32_t bt_mesh_battery_srv_pub(struct bt_mesh_battery_srv *srv,
+			      struct bt_mesh_msg_ctx *ctx,
+			      const struct bt_mesh_battery_status *status)
+{
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_BATTERY_OP_STATUS,
+				 BT_MESH_BATTERY_MSG_LEN_STATUS);
+	encode_status(&msg, status);
+	return model_send(srv->model, ctx, &msg);
+}

--- a/subsys/bluetooth/mesh/gen_dtt_cli.c
+++ b/subsys/bluetooth/mesh/gen_dtt_cli.c
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#include <bluetooth/mesh/gen_dtt_cli.h>
+#include "model_utils.h"
+
+static void handle_status(struct bt_mesh_model *model,
+			  struct bt_mesh_msg_ctx *ctx,
+			  struct net_buf_simple *buf)
+{
+	if (buf->len != BT_MESH_DTT_MSG_LEN_STATUS) {
+		return;
+	}
+
+	struct bt_mesh_dtt_cli *cli = model->user_data;
+	s32_t transition_time =
+		model_transition_decode(net_buf_simple_pull_u8(buf));
+
+	if (model_ack_match(&cli->ack_ctx, BT_MESH_DTT_OP_STATUS, ctx)) {
+		s32_t *rsp = (s32_t *)cli->ack_ctx.user_data;
+		*rsp = transition_time;
+		model_ack_rx(&cli->ack_ctx);
+	}
+
+	if (cli->status_handler) {
+		cli->status_handler(cli, ctx, transition_time);
+	}
+}
+
+const struct bt_mesh_model_op _bt_mesh_dtt_cli_op[] = {
+	{ BT_MESH_DTT_OP_STATUS, BT_MESH_DTT_MSG_LEN_STATUS, handle_status },
+	BT_MESH_MODEL_OP_END,
+};
+
+static int bt_mesh_dtt_init(struct bt_mesh_model *mod)
+{
+	struct bt_mesh_dtt_cli *cli = mod->user_data;
+
+	cli->model = mod;
+	return 0;
+}
+
+const struct bt_mesh_model_cb _bt_mesh_dtt_cli_cb = {
+	.init = bt_mesh_dtt_init,
+};
+
+int bt_mesh_dtt_get(struct bt_mesh_dtt_cli *cli, struct bt_mesh_msg_ctx *ctx,
+		    s32_t *rsp_transition_time)
+{
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_DTT_OP_GET,
+				 BT_MESH_DTT_MSG_LEN_GET);
+	bt_mesh_model_msg_init(&msg, BT_MESH_DTT_OP_GET);
+
+	return model_ackd_send(cli->model, ctx, &msg,
+			       rsp_transition_time ? &cli->ack_ctx : NULL,
+			       BT_MESH_DTT_OP_STATUS, rsp_transition_time);
+}
+
+int bt_mesh_dtt_set(struct bt_mesh_dtt_cli *cli, struct bt_mesh_msg_ctx *ctx,
+		    u32_t transition_time, s32_t *rsp_transition_time)
+{
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_DTT_OP_SET,
+				 BT_MESH_DTT_MSG_LEN_SET);
+	bt_mesh_model_msg_init(&msg, rsp_transition_time ?
+					     BT_MESH_DTT_OP_SET :
+					     BT_MESH_DTT_OP_SET_UNACK);
+	net_buf_simple_add_u8(&msg,
+			      model_transition_encode((s32_t)transition_time));
+
+	return model_ackd_send(cli->model, ctx, &msg,
+			       rsp_transition_time ? &cli->ack_ctx : NULL,
+			       BT_MESH_DTT_OP_STATUS, rsp_transition_time);
+}

--- a/subsys/bluetooth/mesh/gen_dtt_srv.c
+++ b/subsys/bluetooth/mesh/gen_dtt_srv.c
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#include <string.h>
+#include <bluetooth/mesh/gen_dtt_srv.h>
+#include "common/log.h"
+#include "model_utils.h"
+
+static void encode_status(struct net_buf_simple *buf, u32_t transition_time)
+{
+	bt_mesh_model_msg_init(buf, BT_MESH_DTT_OP_STATUS);
+	net_buf_simple_add_u8(buf, model_transition_encode(transition_time));
+}
+
+static void rsp_status(struct bt_mesh_dtt_srv *srv,
+		       struct bt_mesh_msg_ctx *rx_ctx)
+{
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_DTT_OP_STATUS,
+				 BT_MESH_DTT_MSG_LEN_STATUS);
+	encode_status(&msg, srv->transition_time);
+
+	(void)bt_mesh_model_send(srv->model, rx_ctx, &msg, NULL, NULL);
+}
+
+static void handle_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+		       struct net_buf_simple *buf)
+{
+	if (buf->len != BT_MESH_DTT_MSG_LEN_GET) {
+		return;
+	}
+
+	struct bt_mesh_dtt_srv *srv = model->user_data;
+
+	rsp_status(srv, ctx);
+}
+
+static void set_dtt(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+		    struct net_buf_simple *buf, bool ack)
+{
+	if (buf->len != BT_MESH_DTT_MSG_LEN_SET) {
+		return;
+	}
+
+	struct bt_mesh_dtt_srv *srv = model->user_data;
+	u32_t old_transition_time = srv->transition_time;
+
+	srv->transition_time =
+		model_transition_decode(net_buf_simple_pull_u8(buf));
+
+	if (srv->update) {
+		srv->update(srv, ctx, old_transition_time,
+			    srv->transition_time);
+	}
+
+	if (ack) {
+		rsp_status(srv, ctx);
+	}
+
+	if (IS_ENABLED(CONFIG_BT_MESH_DTT_SRV_PERSISTENT)) {
+		(void)bt_mesh_model_data_store(model, false,
+					       &srv->transition_time,
+					       sizeof(srv->transition_time));
+	}
+
+	(void)bt_mesh_dtt_srv_pub(srv, NULL);
+}
+
+static void handle_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+		       struct net_buf_simple *buf)
+{
+	set_dtt(model, ctx, buf, true);
+}
+
+static void handle_set_unack(struct bt_mesh_model *model,
+			     struct bt_mesh_msg_ctx *ctx,
+			     struct net_buf_simple *buf)
+{
+	set_dtt(model, ctx, buf, false);
+}
+
+const struct bt_mesh_model_op _bt_mesh_dtt_srv_op[] = {
+	{ BT_MESH_DTT_OP_GET, BT_MESH_DTT_MSG_LEN_GET, handle_get },
+	{ BT_MESH_DTT_OP_SET, BT_MESH_DTT_MSG_LEN_SET, handle_set },
+	{ BT_MESH_DTT_OP_SET_UNACK, BT_MESH_DTT_MSG_LEN_SET, handle_set_unack },
+	BT_MESH_MODEL_OP_END,
+};
+
+static int bt_mesh_dtt_srv_init(struct bt_mesh_model *model)
+{
+	struct bt_mesh_dtt_srv *srv = model->user_data;
+
+	srv->model = model;
+	return 0;
+}
+
+#ifdef CONFIG_BT_MESH_DTT_SRV_PERSISTENT
+static int bt_mesh_dtt_srv_settings_set(struct bt_mesh_model *model,
+					size_t len_rd, settings_read_cb read_cb,
+					void *cb_arg)
+{
+	struct bt_mesh_dtt_srv *srv = model->user_data;
+
+	return read_cb(cb_arg, &srv->transition_time,
+		       sizeof(srv->transition_time));
+}
+#endif
+
+const struct bt_mesh_model_cb _bt_mesh_dtt_srv_cb = {
+	.init = bt_mesh_dtt_srv_init,
+#ifdef CONFIG_BT_MESH_DTT_SRV_PERSISTENT
+	.settings_set = bt_mesh_dtt_srv_settings_set,
+#endif
+};
+
+int _bt_mesh_dtt_srv_update_handler(struct bt_mesh_model *model)
+{
+	struct bt_mesh_dtt_srv *srv = model->user_data;
+
+	encode_status(srv->model->pub->msg, srv->transition_time);
+	return 0;
+}
+
+void bt_mesh_dtt_srv_set(struct bt_mesh_dtt_srv *srv, u32_t transition_time)
+{
+	u32_t old = srv->transition_time;
+
+	srv->transition_time = transition_time;
+
+	if (srv->update) {
+		srv->update(srv, NULL, old, srv->transition_time);
+	}
+
+	(void)bt_mesh_dtt_srv_pub(srv, NULL);
+}
+
+int bt_mesh_dtt_srv_pub(struct bt_mesh_dtt_srv *srv,
+			struct bt_mesh_msg_ctx *ctx)
+{
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_DTT_OP_STATUS,
+				 BT_MESH_DTT_MSG_LEN_STATUS);
+	encode_status(&msg, srv->transition_time);
+
+	return model_send(srv->model, ctx, &msg);
+}

--- a/subsys/bluetooth/mesh/gen_loc_cli.c
+++ b/subsys/bluetooth/mesh/gen_loc_cli.c
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#include <bluetooth/mesh/gen_loc_cli.h>
+#include "model_utils.h"
+#include "gen_loc_internal.h"
+
+static void handle_global_loc(struct bt_mesh_model *mod,
+			      struct bt_mesh_msg_ctx *ctx,
+			      struct net_buf_simple *buf)
+{
+	if (buf->len != BT_MESH_LOC_MSG_LEN_GLOBAL_STATUS) {
+		return;
+	}
+
+	struct bt_mesh_loc_cli *cli = mod->user_data;
+	struct bt_mesh_loc_global loc;
+
+	bt_mesh_loc_global_decode(buf, &loc);
+
+	if (model_ack_match(&cli->ack_ctx, BT_MESH_LOC_OP_GLOBAL_STATUS, ctx)) {
+		struct bt_mesh_loc_global *rsp =
+			(struct bt_mesh_loc_global *)cli->ack_ctx.user_data;
+
+		*rsp = loc;
+		model_ack_rx(&cli->ack_ctx);
+	}
+
+	if (cli->handlers && cli->handlers->global_status) {
+		cli->handlers->global_status(cli, ctx, &loc);
+	}
+}
+
+static void handle_local_loc(struct bt_mesh_model *mod,
+			     struct bt_mesh_msg_ctx *ctx,
+			     struct net_buf_simple *buf)
+{
+	if (buf->len != BT_MESH_LOC_MSG_LEN_LOCAL_STATUS) {
+		return;
+	}
+
+	struct bt_mesh_loc_cli *cli = mod->user_data;
+	struct bt_mesh_loc_local loc;
+
+	bt_mesh_loc_local_decode(buf, &loc);
+
+	if (model_ack_match(&cli->ack_ctx, BT_MESH_LOC_OP_LOCAL_STATUS, ctx)) {
+		struct bt_mesh_loc_local *rsp =
+			(struct bt_mesh_loc_local *)cli->ack_ctx.user_data;
+
+		*rsp = loc;
+		model_ack_rx(&cli->ack_ctx);
+	}
+
+	if (cli->handlers && cli->handlers->local_status) {
+		cli->handlers->local_status(cli, ctx, &loc);
+	}
+}
+
+const struct bt_mesh_model_op _bt_mesh_loc_cli_op[] = {
+	{ BT_MESH_LOC_OP_GLOBAL_STATUS, BT_MESH_LOC_MSG_LEN_GLOBAL_STATUS,
+	  handle_global_loc },
+	{ BT_MESH_LOC_OP_LOCAL_STATUS, BT_MESH_LOC_MSG_LEN_LOCAL_STATUS,
+	  handle_local_loc },
+	BT_MESH_MODEL_OP_END,
+};
+
+static int bt_mesh_loc_init(struct bt_mesh_model *mod)
+{
+	struct bt_mesh_loc_cli *cli = mod->user_data;
+
+	cli->model = mod;
+	return 0;
+}
+
+const struct bt_mesh_model_cb _bt_mesh_loc_cli_cb = {
+	.init = bt_mesh_loc_init,
+};
+
+int bt_mesh_loc_cli_global_get(struct bt_mesh_loc_cli *cli,
+			       struct bt_mesh_msg_ctx *ctx,
+			       struct bt_mesh_loc_global *rsp)
+{
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_LOC_OP_GLOBAL_GET,
+				 BT_MESH_LOC_MSG_LEN_GLOBAL_GET);
+
+	bt_mesh_model_msg_init(&msg, BT_MESH_LOC_OP_GLOBAL_GET);
+
+	return model_ackd_send(cli->model, ctx, &msg,
+			       rsp ? &cli->ack_ctx : NULL,
+			       BT_MESH_LOC_OP_GLOBAL_STATUS, rsp);
+}
+
+int bt_mesh_loc_cli_global_set(struct bt_mesh_loc_cli *cli,
+			       struct bt_mesh_msg_ctx *ctx,
+			       const struct bt_mesh_loc_global *loc,
+			       struct bt_mesh_loc_global *rsp)
+{
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_LOC_OP_GLOBAL_SET,
+				 BT_MESH_LOC_MSG_LEN_GLOBAL_SET);
+
+	bt_mesh_model_msg_init(&msg, rsp ? BT_MESH_LOC_OP_GLOBAL_SET :
+					   BT_MESH_LOC_OP_GLOBAL_SET_UNACK);
+	bt_mesh_loc_global_encode(&msg, loc);
+
+	return model_ackd_send(cli->model, ctx, &msg,
+			       rsp ? &cli->ack_ctx : NULL,
+			       BT_MESH_LOC_OP_GLOBAL_STATUS, rsp);
+}
+
+int bt_mesh_loc_cli_local_get(struct bt_mesh_loc_cli *cli,
+			      struct bt_mesh_msg_ctx *ctx,
+			      struct bt_mesh_loc_local *rsp)
+{
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_LOC_OP_LOCAL_GET,
+				 BT_MESH_LOC_MSG_LEN_LOCAL_GET);
+
+	bt_mesh_model_msg_init(&msg, BT_MESH_LOC_OP_LOCAL_GET);
+
+	return model_ackd_send(cli->model, ctx, &msg,
+			       rsp ? &cli->ack_ctx : NULL,
+			       BT_MESH_LOC_OP_LOCAL_STATUS, rsp);
+}
+
+int bt_mesh_loc_cli_local_set(struct bt_mesh_loc_cli *cli,
+			      struct bt_mesh_msg_ctx *ctx,
+			      const struct bt_mesh_loc_local *loc,
+			      struct bt_mesh_loc_local *rsp)
+{
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_LOC_OP_LOCAL_SET,
+				 BT_MESH_LOC_MSG_LEN_LOCAL_SET);
+
+	bt_mesh_model_msg_init(&msg, rsp ? BT_MESH_LOC_OP_LOCAL_SET :
+					   BT_MESH_LOC_OP_LOCAL_SET_UNACK);
+	bt_mesh_loc_local_encode(&msg, loc);
+
+	return model_ackd_send(cli->model, ctx, &msg,
+			       rsp ? &cli->ack_ctx : NULL,
+			       BT_MESH_LOC_OP_LOCAL_STATUS, rsp);
+}

--- a/subsys/bluetooth/mesh/gen_loc_internal.h
+++ b/subsys/bluetooth/mesh/gen_loc_internal.h
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/**
+ * @file
+ * @defgroup bt_mesh_loc_internal Generic Location Model internals
+ * @{
+ * @brief Internal defines and functions for the Generic Location models.
+ */
+#ifndef BT_MESH_GEN_LOC_INTERNAL_H__
+#define BT_MESH_GEN_LOC_INTERNAL_H__
+
+#include <bluetooth/mesh/gen_loc.h>
+
+#define BT_MESH_LOC_LATITUDE_FACTOR                                            \
+	(23860929.411111) /* ((INT32_MAX - 1) / 90) */
+#define BT_MESH_LOC_LONGITUDE_FACTOR                                           \
+	(11930464.705556) /* ((INT32_MAX - 1) / 180)                           \
+			   */
+
+static inline void
+bt_mesh_loc_global_encode(struct net_buf_simple *buf,
+			  const struct bt_mesh_loc_global *loc)
+{
+	u32_t latitude = (u32_t)(loc->latitude * BT_MESH_LOC_LATITUDE_FACTOR);
+	u32_t longitude =
+		(u32_t)(loc->longitude * BT_MESH_LOC_LONGITUDE_FACTOR);
+
+	net_buf_simple_add_le32(buf, latitude);
+	net_buf_simple_add_le32(buf, longitude);
+	net_buf_simple_add_le16(buf, loc->altitude);
+}
+
+static inline void bt_mesh_loc_global_decode(struct net_buf_simple *buf,
+					     struct bt_mesh_loc_global *loc)
+{
+	loc->latitude =
+		(net_buf_simple_pull_le32(buf) / BT_MESH_LOC_LATITUDE_FACTOR);
+	loc->longitude =
+		(net_buf_simple_pull_le32(buf) / BT_MESH_LOC_LONGITUDE_FACTOR);
+	loc->altitude = net_buf_simple_pull_le16(buf);
+}
+
+static inline u8_t bt_mesh_loc_4bit_log2_encode(u32_t value)
+{
+	for (u8_t x = 0; x < 15; x++) {
+		if (value <= (125U << x)) {
+			return x;
+		}
+	}
+	return BIT_MASK(4U);
+}
+
+static inline void bt_mesh_loc_local_encode(struct net_buf_simple *buf,
+					    const struct bt_mesh_loc_local *loc)
+{
+	net_buf_simple_add_le16(buf, loc->north);
+	net_buf_simple_add_le16(buf, loc->east);
+	net_buf_simple_add_le16(buf, loc->altitude);
+
+	u8_t enc_floor;
+
+	switch (loc->floor_number) {
+	case BT_MESH_LOC_FLOOR_NUMBER_GROUND_FLOOR_0:
+	case BT_MESH_LOC_FLOOR_NUMBER_GROUND_FLOOR_1:
+	case BT_MESH_LOC_FLOOR_NUMBER_UNKNOWN:
+		enc_floor = loc->floor_number;
+		break;
+	default:
+		if (loc->floor_number > BT_MESH_LOC_FLOOR_NUMBER_MAX) {
+			enc_floor = BT_MESH_LOC_FLOOR_NUMBER_MAX;
+		} else if (loc->floor_number < BT_MESH_LOC_FLOOR_NUMBER_MIN) {
+			enc_floor = BT_MESH_LOC_FLOOR_NUMBER_MIN;
+		} else {
+			enc_floor = loc->floor_number + 20;
+		}
+		break;
+	}
+	net_buf_simple_add_u8(buf, enc_floor);
+
+	/* Encoding for the update time and precision is t = 2^(x - 3) */
+	u8_t enc_update_time =
+		loc->time_delta >= 0 ?
+			bt_mesh_loc_4bit_log2_encode(loc->time_delta) :
+			BIT_MASK(4U);
+	u8_t enc_precision = bt_mesh_loc_4bit_log2_encode(loc->precision_mm);
+
+	u16_t uncertainty = (loc->is_mobile) |
+			    ((enc_update_time & BIT_MASK(4U)) << 7U) |
+			    ((enc_precision & BIT_MASK(4U)) << 12U);
+
+	net_buf_simple_add_le16(buf, uncertainty);
+}
+
+static inline void bt_mesh_loc_local_decode(struct net_buf_simple *buf,
+					    struct bt_mesh_loc_local *loc)
+{
+	loc->north = net_buf_simple_pull_le16(buf);
+	loc->east = net_buf_simple_pull_le16(buf);
+	loc->altitude = net_buf_simple_pull_le16(buf);
+
+	u8_t enc_floor = net_buf_simple_pull_u8(buf);
+
+	switch (enc_floor) {
+	case BT_MESH_LOC_FLOOR_NUMBER_GROUND_FLOOR_0:
+	case BT_MESH_LOC_FLOOR_NUMBER_GROUND_FLOOR_1:
+	case BT_MESH_LOC_FLOOR_NUMBER_UNKNOWN:
+		loc->floor_number = enc_floor;
+		break;
+	default:
+		loc->floor_number = enc_floor - 20;
+		break;
+	}
+
+	u16_t uncertainty = net_buf_simple_pull_le16(buf);
+
+	loc->is_mobile = uncertainty & BIT_MASK(1);
+	loc->time_delta = (125 << ((uncertainty >> 8) & BIT_MASK(4)));
+	loc->precision_mm = (125 << ((uncertainty >> 12) & BIT_MASK(4)));
+}
+
+#endif /* BT_MESH_GEN_LOC_INTERNAL_H__ */
+
+/** @} */

--- a/subsys/bluetooth/mesh/gen_loc_srv.c
+++ b/subsys/bluetooth/mesh/gen_loc_srv.c
@@ -1,0 +1,255 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#include <bluetooth/mesh/gen_loc_srv.h>
+#include <bluetooth/mesh/gen_dtt_srv.h>
+#include <string.h>
+#include "model_utils.h"
+#include "gen_loc_internal.h"
+
+#define LOC_GLOBAL_DEFAULT                                                     \
+	{                                                                      \
+		.latitude = 0.0, .longitude = 0.0,                             \
+		.altitude = BT_MESH_LOC_ALTITUDE_UNKNOWN,                      \
+	}
+
+#define LOC_LOCAL_DEFAULT                                                      \
+	{                                                                      \
+		.north = 0, .east = 0,                                         \
+		.altitude = BT_MESH_LOC_ALTITUDE_UNKNOWN,                      \
+		.floor_number = BT_MESH_LOC_FLOOR_NUMBER_UNKNOWN,              \
+		.is_mobile = false, .time_delta = 0, .precision_mm = 4096000,  \
+	}
+
+static bool pub_in_progress(struct bt_mesh_loc_srv *srv)
+{
+	return (k_delayed_work_remaining_get(&srv->pub.timer) > 0) ||
+	       k_work_pending(&srv->pub.timer.work);
+}
+
+/* Global location */
+
+static void rsp_global(struct bt_mesh_model *model,
+		       struct bt_mesh_msg_ctx *rx_ctx,
+		       const struct bt_mesh_loc_global *loc)
+{
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_LOC_OP_GLOBAL_STATUS,
+				 BT_MESH_LOC_MSG_LEN_GLOBAL_STATUS);
+
+	bt_mesh_model_msg_init(&msg, BT_MESH_LOC_OP_GLOBAL_STATUS);
+	bt_mesh_loc_global_encode(&msg, loc);
+
+	(void)bt_mesh_model_send(model, rx_ctx, &msg, NULL, NULL);
+}
+
+static void handle_global_get(struct bt_mesh_model *model,
+			      struct bt_mesh_msg_ctx *ctx,
+			      struct net_buf_simple *buf)
+{
+	if (buf->len != BT_MESH_LOC_MSG_LEN_GLOBAL_GET) {
+		return;
+	}
+
+	struct bt_mesh_loc_srv *srv = model->user_data;
+	struct bt_mesh_loc_global global = LOC_GLOBAL_DEFAULT;
+
+	srv->handlers->global_get(srv, ctx, &global);
+
+	rsp_global(model, ctx, &global);
+}
+
+static void global_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+		       struct net_buf_simple *buf, bool ack)
+{
+	if (buf->len != BT_MESH_LOC_MSG_LEN_GLOBAL_SET) {
+		return;
+	}
+
+	struct bt_mesh_loc_srv *srv = model->user_data;
+	struct bt_mesh_loc_global global;
+
+	bt_mesh_loc_global_decode(buf, &global);
+
+	srv->handlers->global_set(srv, ctx, &global);
+
+	if (ack) {
+		rsp_global(model, ctx, &global);
+	}
+
+	if (!pub_in_progress(srv) ||
+	    srv->pub_op != BT_MESH_LOC_OP_GLOBAL_STATUS) {
+		(void)bt_mesh_loc_srv_global_pub(srv, NULL, &global);
+	}
+}
+
+static void handle_global_set(struct bt_mesh_model *model,
+			      struct bt_mesh_msg_ctx *ctx,
+			      struct net_buf_simple *buf)
+{
+	global_set(model, ctx, buf, true);
+}
+
+static void handle_global_set_unack(struct bt_mesh_model *model,
+				    struct bt_mesh_msg_ctx *ctx,
+				    struct net_buf_simple *buf)
+{
+	global_set(model, ctx, buf, false);
+}
+
+/* Local location */
+
+static void rsp_local(struct bt_mesh_model *model,
+		      struct bt_mesh_msg_ctx *rx_ctx,
+		      const struct bt_mesh_loc_local *loc)
+{
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_LOC_OP_LOCAL_STATUS,
+				 BT_MESH_LOC_MSG_LEN_LOCAL_STATUS);
+
+	bt_mesh_model_msg_init(&msg, BT_MESH_LOC_OP_LOCAL_STATUS);
+	bt_mesh_loc_local_encode(&msg, loc);
+
+	(void)bt_mesh_model_send(model, rx_ctx, &msg, NULL, NULL);
+}
+
+static void handle_local_get(struct bt_mesh_model *model,
+			     struct bt_mesh_msg_ctx *ctx,
+			     struct net_buf_simple *buf)
+{
+	if (buf->len != BT_MESH_LOC_MSG_LEN_LOCAL_GET) {
+		return;
+	}
+
+	struct bt_mesh_loc_srv *srv = model->user_data;
+	struct bt_mesh_loc_local local = LOC_LOCAL_DEFAULT;
+
+	srv->handlers->local_get(srv, ctx, &local);
+
+	rsp_local(model, ctx, &local);
+}
+
+static void local_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+		      struct net_buf_simple *buf, bool ack)
+{
+	if (buf->len != BT_MESH_LOC_MSG_LEN_LOCAL_SET) {
+		return;
+	}
+
+	struct bt_mesh_loc_srv *srv = model->user_data;
+	struct bt_mesh_loc_local local;
+
+	bt_mesh_loc_local_decode(buf, &local);
+
+	srv->handlers->local_set(srv, ctx, &local);
+
+	if (ack) {
+		rsp_local(model, ctx, &local);
+	}
+
+	if (!pub_in_progress(srv) ||
+	    srv->pub_op != BT_MESH_LOC_OP_LOCAL_STATUS) {
+		(void)bt_mesh_loc_srv_local_pub(srv, NULL, &local);
+	}
+}
+
+static void handle_local_set(struct bt_mesh_model *model,
+			     struct bt_mesh_msg_ctx *ctx,
+			     struct net_buf_simple *buf)
+{
+	local_set(model, ctx, buf, true);
+}
+
+static void handle_local_set_unack(struct bt_mesh_model *model,
+				   struct bt_mesh_msg_ctx *ctx,
+				   struct net_buf_simple *buf)
+{
+	local_set(model, ctx, buf, false);
+}
+
+const struct bt_mesh_model_op _bt_mesh_loc_srv_op[] = {
+	{ BT_MESH_LOC_OP_GLOBAL_GET, BT_MESH_LOC_MSG_LEN_GLOBAL_GET,
+	  handle_global_get },
+	{ BT_MESH_LOC_OP_LOCAL_GET, BT_MESH_LOC_MSG_LEN_LOCAL_GET,
+	  handle_local_get },
+	BT_MESH_MODEL_OP_END
+};
+const struct bt_mesh_model_op _bt_mesh_loc_setup_srv_op[] = {
+	{ BT_MESH_LOC_OP_GLOBAL_SET, BT_MESH_LOC_MSG_LEN_GLOBAL_SET,
+	  handle_global_set },
+	{ BT_MESH_LOC_OP_GLOBAL_SET_UNACK, BT_MESH_LOC_MSG_LEN_GLOBAL_SET,
+	  handle_global_set_unack },
+	{ BT_MESH_LOC_OP_LOCAL_SET, BT_MESH_LOC_MSG_LEN_LOCAL_SET,
+	  handle_local_set },
+	{ BT_MESH_LOC_OP_LOCAL_SET_UNACK, BT_MESH_LOC_MSG_LEN_LOCAL_SET,
+	  handle_local_set_unack },
+	BT_MESH_MODEL_OP_END
+};
+
+static int bt_mesh_loc_srv_init(struct bt_mesh_model *model)
+{
+	struct bt_mesh_loc_srv *srv = model->user_data;
+
+	srv->model = model;
+	return 0;
+}
+
+const struct bt_mesh_model_cb _bt_mesh_loc_srv_cb = {
+	.init = bt_mesh_loc_srv_init
+};
+
+int _bt_mesh_loc_srv_update_handler(struct bt_mesh_model *model)
+{
+	struct bt_mesh_loc_srv *srv = model->user_data;
+
+	if (srv->pub_op == BT_MESH_LOC_OP_GLOBAL_STATUS) {
+		struct bt_mesh_loc_global loc = LOC_GLOBAL_DEFAULT;
+
+		srv->handlers->global_get(srv, NULL, &loc);
+
+		bt_mesh_model_msg_init(srv->pub.msg,
+				       BT_MESH_LOC_OP_GLOBAL_STATUS);
+		bt_mesh_loc_global_encode(srv->pub.msg, &loc);
+	} else if (srv->pub_op == BT_MESH_LOC_OP_LOCAL_STATUS) {
+		struct bt_mesh_loc_local loc = LOC_LOCAL_DEFAULT;
+
+		srv->handlers->local_get(srv, NULL, &loc);
+
+		bt_mesh_model_msg_init(srv->pub.msg,
+				       BT_MESH_LOC_OP_LOCAL_STATUS);
+		bt_mesh_loc_local_encode(srv->pub.msg, &loc);
+	} else {
+		return -EINVAL;
+	}
+
+	return 0;
+}
+
+s32_t bt_mesh_loc_srv_global_pub(struct bt_mesh_loc_srv *srv,
+				 struct bt_mesh_msg_ctx *ctx,
+				 const struct bt_mesh_loc_global *global)
+{
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_LOC_OP_GLOBAL_STATUS,
+				 BT_MESH_LOC_MSG_LEN_GLOBAL_STATUS);
+
+	bt_mesh_model_msg_init(&msg, BT_MESH_LOC_OP_GLOBAL_STATUS);
+	bt_mesh_loc_global_encode(&msg, global);
+	srv->pub_op = BT_MESH_LOC_OP_GLOBAL_STATUS;
+
+	return model_send(srv->model, ctx, &msg);
+}
+
+s32_t bt_mesh_loc_srv_local_pub(struct bt_mesh_loc_srv *srv,
+				struct bt_mesh_msg_ctx *ctx,
+				const struct bt_mesh_loc_local *local)
+{
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_LOC_OP_LOCAL_STATUS,
+				 BT_MESH_LOC_MSG_LEN_LOCAL_STATUS);
+
+	bt_mesh_model_msg_init(&msg, BT_MESH_LOC_OP_LOCAL_STATUS);
+	bt_mesh_loc_local_encode(&msg, local);
+	srv->pub_op = BT_MESH_LOC_OP_LOCAL_STATUS;
+
+	return model_send(srv->model, ctx, &msg);
+}

--- a/subsys/bluetooth/mesh/gen_lvl_cli.c
+++ b/subsys/bluetooth/mesh/gen_lvl_cli.c
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#include <bluetooth/mesh/gen_lvl_cli.h>
+#include "model_utils.h"
+
+static void handle_status(struct bt_mesh_model *mod,
+			  struct bt_mesh_msg_ctx *ctx,
+			  struct net_buf_simple *buf)
+{
+	if (buf->len != BT_MESH_LVL_MSG_MINLEN_STATUS &&
+	    buf->len != BT_MESH_LVL_MSG_MAXLEN_STATUS) {
+		return;
+	}
+
+	struct bt_mesh_lvl_cli *cli = mod->user_data;
+	struct bt_mesh_lvl_status status;
+
+	status.current = net_buf_simple_pull_le16(buf);
+	if (buf->len == 2) {
+		status.target = net_buf_simple_pull_le16(buf);
+		status.remaining_time = net_buf_simple_pull_u8(buf);
+	} else {
+		status.target = status.current;
+		status.remaining_time = 0;
+	}
+
+	if (model_ack_match(&cli->ack_ctx, BT_MESH_LVL_OP_STATUS, ctx)) {
+		struct bt_mesh_lvl_status *rsp =
+			(struct bt_mesh_lvl_status *)cli->ack_ctx.user_data;
+
+		*rsp = status;
+		model_ack_rx(&cli->ack_ctx);
+	}
+
+	if (cli->status_handler) {
+		cli->status_handler(cli, ctx, &status);
+	}
+}
+
+const struct bt_mesh_model_op _bt_mesh_lvl_cli_op[] = {
+	{ BT_MESH_LVL_OP_STATUS, BT_MESH_LVL_MSG_MINLEN_STATUS, handle_status },
+	BT_MESH_MODEL_OP_END,
+};
+
+static int bt_mesh_lvl_init(struct bt_mesh_model *mod)
+{
+	struct bt_mesh_lvl_cli *cli = mod->user_data;
+
+	cli->model = mod;
+	return 0;
+}
+
+const struct bt_mesh_model_cb _bt_mesh_lvl_cli_cb = {
+	.init = bt_mesh_lvl_init,
+};
+
+int bt_mesh_lvl_cli_get(struct bt_mesh_lvl_cli *cli,
+			struct bt_mesh_msg_ctx *ctx,
+			struct bt_mesh_lvl_status *rsp)
+{
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_LVL_OP_GET,
+				 BT_MESH_LVL_MSG_LEN_GET);
+	bt_mesh_model_msg_init(&msg, BT_MESH_LVL_OP_GET);
+
+	return model_ackd_send(cli->model, ctx, &msg,
+			       rsp ? &cli->ack_ctx : NULL,
+			       BT_MESH_LVL_OP_STATUS, rsp);
+}
+
+int bt_mesh_lvl_cli_set(struct bt_mesh_lvl_cli *cli,
+			struct bt_mesh_msg_ctx *ctx,
+			const struct bt_mesh_lvl_set *set,
+			struct bt_mesh_lvl_status *rsp)
+{
+	if (set->new_transaction) {
+		cli->tid++;
+	}
+
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_LVL_OP_SET,
+				 BT_MESH_LVL_MSG_MAXLEN_SET);
+	bt_mesh_model_msg_init(&msg, rsp ? BT_MESH_LVL_OP_SET :
+					   BT_MESH_LVL_OP_SET_UNACK);
+
+	net_buf_simple_add_le16(&msg, set->lvl);
+	net_buf_simple_add_u8(&msg, cli->tid);
+	if (set->transition) {
+		model_transition_buf_add(&msg, set->transition);
+	}
+
+	return model_ackd_send(cli->model, ctx, &msg,
+			       rsp ? &cli->ack_ctx : NULL,
+			       BT_MESH_LVL_OP_STATUS, rsp);
+}
+
+int bt_mesh_lvl_cli_delta_set(struct bt_mesh_lvl_cli *cli,
+			      struct bt_mesh_msg_ctx *ctx,
+			      const struct bt_mesh_lvl_delta_set *delta_set,
+			      struct bt_mesh_lvl_status *rsp)
+{
+	if (delta_set->new_transaction) {
+		cli->tid++;
+	}
+
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_LVL_OP_DELTA_SET,
+				 BT_MESH_LVL_MSG_MAXLEN_DELTA_SET);
+	bt_mesh_model_msg_init(&msg, rsp ? BT_MESH_LVL_OP_DELTA_SET :
+					   BT_MESH_LVL_OP_DELTA_SET_UNACK);
+
+	net_buf_simple_add_le32(&msg, delta_set->delta);
+	net_buf_simple_add_u8(&msg, cli->tid);
+	if (delta_set->transition) {
+		model_transition_buf_add(&msg, delta_set->transition);
+	}
+
+	return model_ackd_send(cli->model, ctx, &msg,
+			       rsp ? &cli->ack_ctx : NULL,
+			       BT_MESH_LVL_OP_STATUS, rsp);
+}
+
+int bt_mesh_lvl_cli_move_set(struct bt_mesh_lvl_cli *cli,
+			     struct bt_mesh_msg_ctx *ctx,
+			     const struct bt_mesh_lvl_move_set *move_set,
+			     struct bt_mesh_lvl_status *rsp)
+{
+	if (move_set->new_transaction) {
+		cli->tid++;
+	}
+
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_LVL_OP_MOVE_SET,
+				 BT_MESH_LVL_MSG_MAXLEN_MOVE_SET);
+	bt_mesh_model_msg_init(&msg, rsp ? BT_MESH_LVL_OP_MOVE_SET :
+					   BT_MESH_LVL_OP_MOVE_SET_UNACK);
+
+	net_buf_simple_add_le16(&msg, move_set->delta);
+	net_buf_simple_add_u8(&msg, cli->tid);
+
+	if (move_set->transition) {
+		model_transition_buf_add(&msg, move_set->transition);
+	}
+
+	return model_ackd_send(cli->model, ctx, &msg,
+			       rsp ? &cli->ack_ctx : NULL,
+			       BT_MESH_LVL_OP_STATUS, rsp);
+}

--- a/subsys/bluetooth/mesh/gen_lvl_srv.c
+++ b/subsys/bluetooth/mesh/gen_lvl_srv.c
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#include <string.h>
+#include <bluetooth/mesh/gen_lvl_srv.h>
+#include <bluetooth/mesh/gen_dtt_srv.h>
+#include "model_utils.h"
+
+static void encode_status(const struct bt_mesh_lvl_status *status,
+			  struct net_buf_simple *buf)
+{
+	net_buf_simple_add_le16(buf, status->current);
+
+	if (status->remaining_time == 0) {
+		return;
+	}
+
+	net_buf_simple_add_le16(buf, status->target);
+	net_buf_simple_add_u8(buf,
+			      model_transition_encode(status->remaining_time));
+}
+
+static void transition_get(struct bt_mesh_lvl_srv *srv,
+			   struct bt_mesh_model_transition *transition,
+			   struct net_buf_simple *buf)
+{
+	if (buf->len == 2) {
+		model_transition_buf_pull(buf, transition);
+	} else {
+		bt_mesh_dtt_srv_transition_get(srv->model, transition);
+	}
+}
+
+static void rsp_status(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+		       const struct bt_mesh_lvl_status *status)
+{
+	BT_MESH_MODEL_BUF_DEFINE(rsp, BT_MESH_LVL_OP_STATUS,
+				 BT_MESH_LVL_MSG_MAXLEN_STATUS);
+	bt_mesh_model_msg_init(&rsp, BT_MESH_LVL_OP_STATUS);
+	encode_status(status, &rsp);
+
+	bt_mesh_model_send(model, ctx, &rsp, NULL, 0);
+}
+
+static void handle_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+		       struct net_buf_simple *buf)
+{
+	if (buf->len != BT_MESH_LVL_MSG_LEN_GET) {
+		return;
+	}
+
+	struct bt_mesh_lvl_srv *srv = model->user_data;
+	struct bt_mesh_lvl_status status = { 0 };
+
+	srv->handlers->get(srv, ctx, &status);
+
+	rsp_status(model, ctx, &status);
+}
+
+static void set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+		struct net_buf_simple *buf, bool ack)
+{
+	if (buf->len != BT_MESH_LVL_MSG_MINLEN_SET &&
+	    buf->len != BT_MESH_LVL_MSG_MAXLEN_SET) {
+		return;
+	}
+
+	struct bt_mesh_lvl_srv *srv = model->user_data;
+	struct bt_mesh_lvl_status status = { 0 };
+	struct bt_mesh_model_transition transition;
+	struct bt_mesh_lvl_set set;
+
+	set.lvl = net_buf_simple_pull_le16(buf);
+	set.new_transaction = !tid_check_and_update(
+		&srv->tid, net_buf_simple_pull_u8(buf), ctx);
+	transition_get(srv, &transition, buf);
+	set.transition = &transition;
+
+	srv->handlers->set(srv, ctx, &set, &status);
+
+	if (ack) {
+		rsp_status(model, ctx, &status);
+	}
+
+	(void)bt_mesh_lvl_srv_pub(srv, NULL, &status);
+}
+
+static void delta_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+		      struct net_buf_simple *buf, bool ack)
+{
+	if (buf->len != BT_MESH_LVL_MSG_MINLEN_DELTA_SET &&
+	    buf->len != BT_MESH_LVL_MSG_MAXLEN_DELTA_SET) {
+		return;
+	}
+
+	struct bt_mesh_lvl_srv *srv = model->user_data;
+	struct bt_mesh_lvl_status status = { 0 };
+	struct bt_mesh_lvl_delta_set delta_set;
+	struct bt_mesh_model_transition transition;
+
+	delta_set.delta = net_buf_simple_pull_le32(buf);
+	delta_set.new_transaction = !tid_check_and_update(
+		&srv->tid, net_buf_simple_pull_u8(buf), ctx);
+	transition_get(srv, &transition, buf);
+	delta_set.transition = &transition;
+
+	srv->handlers->delta_set(srv, ctx, &delta_set, &status);
+
+	if (ack) {
+		rsp_status(model, ctx, &status);
+	}
+
+	(void)bt_mesh_lvl_srv_pub(srv, NULL, &status);
+}
+
+static void move_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+		     struct net_buf_simple *buf, bool ack)
+{
+	if (buf->len != BT_MESH_LVL_MSG_MINLEN_MOVE_SET &&
+	    buf->len != BT_MESH_LVL_MSG_MAXLEN_MOVE_SET) {
+		return;
+	}
+
+	struct bt_mesh_lvl_srv *srv = model->user_data;
+	struct bt_mesh_lvl_status status = { 0 };
+	struct bt_mesh_model_transition transition;
+	struct bt_mesh_lvl_move_set move_set;
+
+	move_set.delta = net_buf_simple_pull_le16(buf);
+	move_set.new_transaction = !tid_check_and_update(
+		&srv->tid, net_buf_simple_pull_u8(buf), ctx);
+	transition_get(srv, &transition, buf);
+	move_set.transition = &transition;
+
+	srv->handlers->move_set(srv, ctx, &move_set, &status);
+
+	if (ack) {
+		rsp_status(model, ctx, &status);
+	}
+
+	(void)bt_mesh_lvl_srv_pub(srv, ctx, &status);
+}
+
+/* Message handlers */
+
+static void handle_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+		       struct net_buf_simple *buf)
+{
+	set(model, ctx, buf, true);
+}
+
+static void handle_set_unack(struct bt_mesh_model *model,
+			     struct bt_mesh_msg_ctx *ctx,
+			     struct net_buf_simple *buf)
+{
+	set(model, ctx, buf, false);
+}
+
+static void handle_delta_set(struct bt_mesh_model *model,
+			     struct bt_mesh_msg_ctx *ctx,
+			     struct net_buf_simple *buf)
+{
+	delta_set(model, ctx, buf, true);
+}
+
+static void handle_delta_set_unack(struct bt_mesh_model *model,
+				   struct bt_mesh_msg_ctx *ctx,
+				   struct net_buf_simple *buf)
+{
+	delta_set(model, ctx, buf, false);
+}
+
+static void handle_move_set(struct bt_mesh_model *model,
+			    struct bt_mesh_msg_ctx *ctx,
+			    struct net_buf_simple *buf)
+{
+	move_set(model, ctx, buf, true);
+}
+
+static void handle_move_set_unack(struct bt_mesh_model *model,
+				  struct bt_mesh_msg_ctx *ctx,
+				  struct net_buf_simple *buf)
+{
+	move_set(model, ctx, buf, false);
+}
+
+const struct bt_mesh_model_op _bt_mesh_lvl_srv_op[] = {
+	{ BT_MESH_LVL_OP_GET, BT_MESH_LVL_MSG_LEN_GET, handle_get },
+	{ BT_MESH_LVL_OP_SET, BT_MESH_LVL_MSG_MINLEN_SET, handle_set },
+	{ BT_MESH_LVL_OP_SET_UNACK, BT_MESH_LVL_MSG_MINLEN_SET,
+	  handle_set_unack },
+	{ BT_MESH_LVL_OP_DELTA_SET, BT_MESH_LVL_MSG_MINLEN_DELTA_SET,
+	  handle_delta_set },
+	{ BT_MESH_LVL_OP_DELTA_SET_UNACK, BT_MESH_LVL_MSG_MINLEN_DELTA_SET,
+	  handle_delta_set_unack },
+	{ BT_MESH_LVL_OP_MOVE_SET, BT_MESH_LVL_MSG_MINLEN_MOVE_SET,
+	  handle_move_set },
+	{ BT_MESH_LVL_OP_MOVE_SET_UNACK, BT_MESH_LVL_MSG_MINLEN_MOVE_SET,
+	  handle_move_set_unack },
+	BT_MESH_MODEL_OP_END,
+};
+
+static int bt_mesh_lvl_srv_init(struct bt_mesh_model *model)
+{
+	struct bt_mesh_lvl_srv *srv = model->user_data;
+
+	srv->model = model;
+	return 0;
+}
+
+const struct bt_mesh_model_cb _bt_mesh_lvl_srv_cb = {
+	.init = bt_mesh_lvl_srv_init,
+};
+
+int _bt_mesh_lvl_srv_update_handler(struct bt_mesh_model *model)
+{
+	struct bt_mesh_lvl_srv *srv = model->user_data;
+	struct bt_mesh_lvl_status status = { 0 };
+
+	srv->handlers->get(srv, NULL, &status);
+
+	bt_mesh_model_msg_init(model->pub->msg, BT_MESH_LVL_OP_STATUS);
+	encode_status(&status, model->pub->msg);
+	return 0;
+}
+
+int bt_mesh_lvl_srv_pub(struct bt_mesh_lvl_srv *srv,
+			struct bt_mesh_msg_ctx *ctx,
+			const struct bt_mesh_lvl_status *status)
+{
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_LVL_OP_STATUS,
+				 BT_MESH_LVL_MSG_MAXLEN_STATUS);
+	bt_mesh_model_msg_init(&msg, BT_MESH_LVL_OP_STATUS);
+	encode_status(status, &msg);
+
+	return model_send(srv->model, ctx, &msg);
+}

--- a/subsys/bluetooth/mesh/gen_onoff_cli.c
+++ b/subsys/bluetooth/mesh/gen_onoff_cli.c
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#include <string.h>
+#include <bluetooth/mesh/gen_onoff_cli.h>
+#include "model_utils.h"
+
+static void decode_status(struct net_buf_simple *buf,
+			  struct bt_mesh_onoff_status *status)
+{
+	status->present_on_off = net_buf_simple_pull_u8(buf);
+
+	if (buf->len == 2) {
+		status->target_on_off = net_buf_simple_pull_u8(buf);
+		status->remaining_time =
+			model_transition_decode(net_buf_simple_pull_u8(buf));
+	} else {
+		status->target_on_off = status->present_on_off;
+		status->remaining_time = 0;
+	}
+}
+
+static void handle_status(struct bt_mesh_model *model,
+			  struct bt_mesh_msg_ctx *ctx,
+			  struct net_buf_simple *buf)
+{
+	if (buf->len != BT_MESH_ONOFF_MSG_MINLEN_STATUS &&
+	    buf->len != BT_MESH_ONOFF_MSG_MAXLEN_STATUS) {
+		return;
+	}
+
+	struct bt_mesh_onoff_cli *cli = model->user_data;
+	struct bt_mesh_onoff_status status;
+
+	decode_status(buf, &status);
+
+	if (model_ack_match(&cli->ack_ctx, BT_MESH_ONOFF_OP_STATUS, ctx)) {
+		struct bt_mesh_onoff_status *rsp =
+			(struct bt_mesh_onoff_status *)cli->ack_ctx.user_data;
+
+		*rsp = status;
+		model_ack_rx(&cli->ack_ctx);
+	}
+
+	if (cli->status_handler) {
+		cli->status_handler(cli, ctx, &status);
+	}
+}
+
+const struct bt_mesh_model_op _bt_mesh_onoff_cli_op[] = {
+	{ BT_MESH_ONOFF_OP_STATUS, BT_MESH_ONOFF_MSG_MINLEN_STATUS,
+	  handle_status },
+	BT_MESH_MODEL_OP_END,
+};
+
+static int bt_mesh_onoff_cli_init(struct bt_mesh_model *model)
+{
+	struct bt_mesh_onoff_cli *cli = model->user_data;
+
+	cli->model = model;
+	return 0;
+}
+
+const struct bt_mesh_model_cb _bt_mesh_onoff_cli_cb = {
+	.init = bt_mesh_onoff_cli_init,
+};
+
+int bt_mesh_onoff_cli_status_get(struct bt_mesh_onoff_cli *cli,
+				 struct bt_mesh_msg_ctx *ctx,
+				 struct bt_mesh_onoff_status *rsp)
+{
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_ONOFF_OP_GET,
+				 BT_MESH_ONOFF_MSG_LEN_GET);
+	bt_mesh_model_msg_init(&msg, BT_MESH_ONOFF_OP_GET);
+
+	return model_ackd_send(cli->model, ctx, &msg,
+			       rsp ? &cli->ack_ctx : NULL,
+			       BT_MESH_ONOFF_OP_STATUS, rsp);
+}
+
+int bt_mesh_onoff_cli_set(struct bt_mesh_onoff_cli *cli,
+			  struct bt_mesh_msg_ctx *ctx,
+			  const struct bt_mesh_onoff_set *set,
+			  struct bt_mesh_onoff_status *rsp)
+{
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_ONOFF_OP_SET,
+				 BT_MESH_ONOFF_MSG_MAXLEN_SET);
+	bt_mesh_model_msg_init(&msg, (rsp ? BT_MESH_ONOFF_OP_SET :
+					    BT_MESH_ONOFF_OP_SET_UNACK));
+
+	net_buf_simple_add_u8(&msg, set->on_off);
+	net_buf_simple_add_u8(&msg, cli->tid++);
+	if (set->transition) {
+		model_transition_buf_add(&msg, set->transition);
+	}
+
+	return model_ackd_send(cli->model, ctx, &msg,
+			       rsp ? &cli->ack_ctx : NULL,
+			       BT_MESH_ONOFF_OP_STATUS, rsp);
+}

--- a/subsys/bluetooth/mesh/gen_onoff_srv.c
+++ b/subsys/bluetooth/mesh/gen_onoff_srv.c
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#include <string.h>
+#include <bluetooth/mesh/gen_onoff_srv.h>
+#include <bluetooth/mesh/gen_dtt_srv.h>
+#include "model_utils.h"
+
+static void encode_status(struct net_buf_simple *buf,
+			  const struct bt_mesh_onoff_status *status)
+{
+	bt_mesh_model_msg_init(buf, BT_MESH_ONOFF_OP_STATUS);
+	net_buf_simple_add_u8(buf, !!status->present_on_off);
+
+	if (status->remaining_time != 0) {
+		net_buf_simple_add_u8(buf, status->target_on_off);
+		net_buf_simple_add_u8(
+			buf, model_transition_encode(status->remaining_time));
+	}
+}
+
+static void rsp_status(struct bt_mesh_model *model,
+		       struct bt_mesh_msg_ctx *rx_ctx,
+		       const struct bt_mesh_onoff_status *status)
+{
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_ONOFF_OP_STATUS,
+				 BT_MESH_ONOFF_MSG_MAXLEN_STATUS);
+	encode_status(&msg, status);
+
+	(void)bt_mesh_model_send(model, rx_ctx, &msg, NULL, NULL);
+}
+
+static void handle_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+		       struct net_buf_simple *buf)
+{
+	if (buf->len != BT_MESH_ONOFF_MSG_LEN_GET) {
+		return;
+	}
+
+	struct bt_mesh_onoff_srv *srv = model->user_data;
+	struct bt_mesh_onoff_status status = { 0 };
+
+	srv->handlers->get(srv, ctx, &status);
+
+	rsp_status(model, ctx, &status);
+}
+
+static void onoff_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+		      struct net_buf_simple *buf, bool ack)
+{
+	if (buf->len != BT_MESH_ONOFF_MSG_MINLEN_SET &&
+	    buf->len != BT_MESH_ONOFF_MSG_MAXLEN_SET) {
+		return;
+	}
+
+	struct bt_mesh_onoff_srv *srv = model->user_data;
+	struct bt_mesh_onoff_status status = { 0 };
+	struct bt_mesh_model_transition transition;
+	struct bt_mesh_onoff_set set;
+
+	set.on_off = net_buf_simple_pull_u8(buf);
+	u8_t tid = net_buf_simple_pull_u8(buf);
+
+	if (tid_check_and_update(&srv->prev_transaction, tid, ctx) != 0) {
+		/* If this is the same transaction, we don't need to send it
+		 * to the app, but we still have to respond with a status.
+		 */
+		srv->handlers->get(srv, NULL, &status);
+		goto respond;
+	}
+
+	if (buf->len == 2) {
+		model_transition_buf_pull(buf, &transition);
+	} else {
+		bt_mesh_dtt_srv_transition_get(srv->model, &transition);
+	}
+
+	set.transition = &transition;
+
+	srv->handlers->set(srv, ctx, &set, &status);
+
+	(void)bt_mesh_onoff_srv_pub(srv, NULL, &status);
+
+respond:
+	if (ack) {
+		rsp_status(model, ctx, &status);
+	}
+}
+
+static void handle_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+		       struct net_buf_simple *buf)
+{
+	onoff_set(model, ctx, buf, true);
+}
+
+static void handle_set_unack(struct bt_mesh_model *model,
+			     struct bt_mesh_msg_ctx *ctx,
+			     struct net_buf_simple *buf)
+{
+	onoff_set(model, ctx, buf, false);
+}
+
+const struct bt_mesh_model_op _bt_mesh_onoff_srv_op[] = {
+	{ BT_MESH_ONOFF_OP_GET, BT_MESH_ONOFF_MSG_LEN_GET, handle_get },
+	{ BT_MESH_ONOFF_OP_SET, BT_MESH_ONOFF_MSG_MINLEN_SET, handle_set },
+	{ BT_MESH_ONOFF_OP_SET_UNACK, BT_MESH_ONOFF_MSG_MINLEN_SET,
+	  handle_set_unack },
+	BT_MESH_MODEL_OP_END,
+};
+
+static int bt_mesh_onoff_srv_init(struct bt_mesh_model *model)
+{
+	struct bt_mesh_onoff_srv *srv = model->user_data;
+
+	srv->model = model;
+	return 0;
+}
+
+const struct bt_mesh_model_cb _bt_mesh_onoff_srv_cb = {
+	.init = bt_mesh_onoff_srv_init
+};
+
+int _bt_mesh_onoff_srv_update_handler(struct bt_mesh_model *model)
+{
+	struct bt_mesh_onoff_srv *srv = model->user_data;
+	struct bt_mesh_onoff_status status = { 0 };
+
+	srv->handlers->get(srv, NULL, &status);
+	encode_status(model->pub->msg, &status);
+
+	return 0;
+}
+
+s32_t bt_mesh_onoff_srv_pub(struct bt_mesh_onoff_srv *srv,
+			    struct bt_mesh_msg_ctx *ctx,
+			    const struct bt_mesh_onoff_status *status)
+{
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_ONOFF_OP_STATUS,
+				 BT_MESH_ONOFF_MSG_MAXLEN_STATUS);
+	encode_status(&msg, status);
+	return model_send(srv->model, ctx, &msg);
+}

--- a/subsys/bluetooth/mesh/gen_plvl_cli.c
+++ b/subsys/bluetooth/mesh/gen_plvl_cli.c
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+#include <bluetooth/mesh/gen_plvl_cli.h>
+#include "model_utils.h"
+
+static void handle_power_status(struct bt_mesh_model *mod,
+				struct bt_mesh_msg_ctx *ctx,
+				struct net_buf_simple *buf)
+{
+	if (buf->len != BT_MESH_PLVL_MSG_MINLEN_LEVEL_STATUS &&
+	    buf->len != BT_MESH_PLVL_MSG_MAXLEN_LEVEL_STATUS) {
+		return;
+	}
+
+	struct bt_mesh_plvl_cli *cli = mod->user_data;
+	struct bt_mesh_plvl_status status;
+
+	status.current = net_buf_simple_pull_le16(buf);
+	if (buf->len == 3) {
+		status.target = net_buf_simple_pull_le16(buf);
+		status.remaining_time =
+			model_transition_decode(net_buf_simple_pull_u8(buf));
+	} else {
+		status.target = status.current;
+		status.remaining_time = 0;
+	}
+
+	if (model_ack_match(&cli->ack_ctx, BT_MESH_PLVL_OP_LEVEL_STATUS, ctx)) {
+		struct bt_mesh_plvl_status *rsp = cli->ack_ctx.user_data;
+		*rsp = status;
+		model_ack_rx(&cli->ack_ctx);
+	}
+
+	if (cli->handlers && cli->handlers->power_status) {
+		cli->handlers->power_status(cli, ctx, &status);
+	}
+}
+
+static void handle_last_status(struct bt_mesh_model *mod,
+			       struct bt_mesh_msg_ctx *ctx,
+			       struct net_buf_simple *buf)
+{
+	if (buf->len != BT_MESH_PLVL_MSG_LEN_LAST_STATUS) {
+		return;
+	}
+
+	struct bt_mesh_plvl_cli *cli = mod->user_data;
+	u16_t last = net_buf_simple_pull_le16(buf);
+
+	if (model_ack_match(&cli->ack_ctx, BT_MESH_PLVL_OP_LEVEL_STATUS, ctx)) {
+		u16_t *rsp = cli->ack_ctx.user_data;
+		*rsp = last;
+		model_ack_rx(&cli->ack_ctx);
+	}
+
+	if (cli->handlers && cli->handlers->last_status) {
+		cli->handlers->last_status(cli, ctx, last);
+	}
+}
+
+static void handle_default_status(struct bt_mesh_model *mod,
+				  struct bt_mesh_msg_ctx *ctx,
+				  struct net_buf_simple *buf)
+{
+	if (buf->len != BT_MESH_PLVL_MSG_LEN_DEFAULT_STATUS) {
+		return;
+	}
+
+	struct bt_mesh_plvl_cli *cli = mod->user_data;
+	u16_t default_lvl = net_buf_simple_pull_le16(buf);
+
+	if (model_ack_match(&cli->ack_ctx, BT_MESH_PLVL_OP_LEVEL_STATUS, ctx)) {
+		u16_t *rsp = cli->ack_ctx.user_data;
+		*rsp = default_lvl;
+		model_ack_rx(&cli->ack_ctx);
+	}
+
+	if (cli->handlers && cli->handlers->default_status) {
+		cli->handlers->default_status(cli, ctx, default_lvl);
+	}
+}
+
+static void handle_range_status(struct bt_mesh_model *mod,
+				struct bt_mesh_msg_ctx *ctx,
+				struct net_buf_simple *buf)
+{
+	if (buf->len != BT_MESH_PLVL_MSG_LEN_RANGE_STATUS) {
+		return;
+	}
+
+	struct bt_mesh_plvl_cli *cli = mod->user_data;
+	struct bt_mesh_plvl_range_status status;
+
+	status.status = net_buf_simple_pull_u8(buf);
+	status.range.min = net_buf_simple_pull_le16(buf);
+	status.range.max = net_buf_simple_pull_le16(buf);
+
+	if (model_ack_match(&cli->ack_ctx, BT_MESH_PLVL_OP_LEVEL_STATUS, ctx)) {
+		struct bt_mesh_plvl_range_status *rsp = cli->ack_ctx.user_data;
+		*rsp = status;
+		model_ack_rx(&cli->ack_ctx);
+	}
+
+	if (cli->handlers && cli->handlers->range_status) {
+		cli->handlers->range_status(cli, ctx, &status);
+	}
+}
+
+const struct bt_mesh_model_op _bt_mesh_plvl_cli_op[] = {
+	{ BT_MESH_PLVL_OP_LEVEL_STATUS, BT_MESH_PLVL_MSG_MINLEN_LEVEL_STATUS,
+	  handle_power_status },
+	{ BT_MESH_PLVL_OP_LAST_STATUS, BT_MESH_PLVL_MSG_LEN_LAST_STATUS,
+	  handle_last_status },
+	{ BT_MESH_PLVL_OP_DEFAULT_STATUS, BT_MESH_PLVL_MSG_LEN_DEFAULT_STATUS,
+	  handle_default_status },
+	{ BT_MESH_PLVL_OP_RANGE_STATUS, BT_MESH_PLVL_MSG_LEN_RANGE_STATUS,
+	  handle_range_status },
+	BT_MESH_MODEL_OP_END,
+};
+
+static int bt_mesh_lvl_cli_init(struct bt_mesh_model *mod)
+{
+	struct bt_mesh_plvl_cli *cli = mod->user_data;
+
+	cli->model = mod;
+	return 0;
+}
+
+const struct bt_mesh_model_cb _bt_mesh_plvl_cli_cb = {
+	.init = bt_mesh_lvl_cli_init,
+};
+
+int bt_mesh_plvl_cli_power_get(struct bt_mesh_plvl_cli *cli,
+			       struct bt_mesh_msg_ctx *ctx,
+			       struct bt_mesh_plvl_status *rsp)
+{
+	BT_MESH_MODEL_BUF_DEFINE(buf, BT_MESH_PLVL_OP_LEVEL_GET,
+				 BT_MESH_PLVL_MSG_LEN_LEVEL_GET);
+	bt_mesh_model_msg_init(&buf, BT_MESH_PLVL_OP_LEVEL_GET);
+
+	return model_ackd_send(cli->model, ctx, &buf,
+			       rsp ? &cli->ack_ctx : NULL,
+			       BT_MESH_PLVL_OP_LEVEL_STATUS, rsp);
+}
+
+int bt_mesh_plvl_cli_power_set(struct bt_mesh_plvl_cli *cli,
+			       struct bt_mesh_msg_ctx *ctx,
+			       const struct bt_mesh_plvl_set *set,
+			       struct bt_mesh_plvl_status *rsp)
+{
+	BT_MESH_MODEL_BUF_DEFINE(buf, BT_MESH_PLVL_OP_LEVEL_SET,
+				 BT_MESH_PLVL_MSG_MAXLEN_LEVEL_SET);
+	bt_mesh_model_msg_init(&buf, BT_MESH_PLVL_OP_LEVEL_SET);
+
+	net_buf_simple_add_le16(&buf, set->power_lvl);
+	net_buf_simple_add_u8(&buf, cli->tid++);
+	if (set->transition) {
+		model_transition_buf_add(&buf, set->transition);
+	}
+
+	return model_ackd_send(cli->model, ctx, &buf,
+			       rsp ? &cli->ack_ctx : NULL,
+			       BT_MESH_PLVL_OP_LEVEL_STATUS, rsp);
+}
+
+int bt_mesh_plvl_cli_range_get(struct bt_mesh_plvl_cli *cli,
+			       struct bt_mesh_msg_ctx *ctx,
+			       struct bt_mesh_plvl_range_status *rsp)
+{
+	BT_MESH_MODEL_BUF_DEFINE(buf, BT_MESH_PLVL_OP_RANGE_GET,
+				 BT_MESH_PLVL_MSG_LEN_RANGE_GET);
+	bt_mesh_model_msg_init(&buf, BT_MESH_PLVL_OP_RANGE_GET);
+
+	return model_ackd_send(cli->model, ctx, &buf,
+			       rsp ? &cli->ack_ctx : NULL,
+			       BT_MESH_PLVL_OP_RANGE_STATUS, rsp);
+}
+
+int bt_mesh_plvl_cli_range_set(struct bt_mesh_plvl_cli *cli,
+			       struct bt_mesh_msg_ctx *ctx,
+			       const struct bt_mesh_plvl_range *range,
+			       struct bt_mesh_plvl_range_status *rsp)
+{
+	BT_MESH_MODEL_BUF_DEFINE(buf, BT_MESH_PLVL_OP_RANGE_SET,
+				 BT_MESH_PLVL_MSG_LEN_RANGE_SET);
+	bt_mesh_model_msg_init(&buf, BT_MESH_PLVL_OP_RANGE_SET);
+	net_buf_simple_add_le16(&buf, range->min);
+	net_buf_simple_add_le16(&buf, range->max);
+
+	return model_ackd_send(cli->model, ctx, &buf,
+			       rsp ? &cli->ack_ctx : NULL,
+			       BT_MESH_PLVL_OP_RANGE_STATUS, rsp);
+}
+
+int bt_mesh_plvl_cli_default_get(struct bt_mesh_plvl_cli *cli,
+				 struct bt_mesh_msg_ctx *ctx, u16_t *rsp)
+{
+	BT_MESH_MODEL_BUF_DEFINE(buf, BT_MESH_PLVL_OP_DEFAULT_GET,
+				 BT_MESH_PLVL_MSG_LEN_DEFAULT_GET);
+	bt_mesh_model_msg_init(&buf, BT_MESH_PLVL_OP_DEFAULT_GET);
+
+	return model_ackd_send(cli->model, ctx, &buf,
+			       rsp ? &cli->ack_ctx : NULL,
+			       BT_MESH_PLVL_OP_DEFAULT_STATUS, rsp);
+}
+
+int bt_mesh_plvl_cli_default_set(struct bt_mesh_plvl_cli *cli,
+				 struct bt_mesh_msg_ctx *ctx,
+				 u16_t default_power, u16_t *rsp)
+{
+	BT_MESH_MODEL_BUF_DEFINE(buf, BT_MESH_PLVL_OP_DEFAULT_SET,
+				 BT_MESH_PLVL_MSG_LEN_DEFAULT_SET);
+	bt_mesh_model_msg_init(&buf, BT_MESH_PLVL_OP_DEFAULT_SET);
+	net_buf_simple_add_le16(&buf, default_power);
+
+	return model_ackd_send(cli->model, ctx, &buf,
+			       rsp ? &cli->ack_ctx : NULL,
+			       BT_MESH_PLVL_OP_DEFAULT_STATUS, rsp);
+}
+
+int bt_mesh_plvl_cli_last_get(struct bt_mesh_plvl_cli *cli,
+			      struct bt_mesh_msg_ctx *ctx, u16_t *rsp)
+{
+	BT_MESH_MODEL_BUF_DEFINE(buf, BT_MESH_PLVL_OP_LAST_GET,
+				 BT_MESH_PLVL_MSG_LEN_LAST_GET);
+	bt_mesh_model_msg_init(&buf, BT_MESH_PLVL_OP_LAST_GET);
+
+	return model_ackd_send(cli->model, ctx, &buf,
+			       rsp ? &cli->ack_ctx : NULL,
+			       BT_MESH_PLVL_OP_LAST_STATUS, rsp);
+}

--- a/subsys/bluetooth/mesh/gen_plvl_srv.c
+++ b/subsys/bluetooth/mesh/gen_plvl_srv.c
@@ -1,0 +1,604 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+#include <bluetooth/mesh/gen_plvl_srv.h>
+#include "model_utils.h"
+
+#define LVL_TO_POWER(_lvl) ((_lvl) + 32768)
+#define POWER_TO_LVL(_power) ((_power)-32768)
+
+/** Persistent storage handling */
+struct bt_mesh_plvl_srv_settings_data {
+	struct bt_mesh_plvl_range range;
+	u16_t default_power;
+	u16_t last;
+	bool is_on;
+} __packed;
+
+static int store_state(struct bt_mesh_plvl_srv *srv)
+{
+	if (!IS_ENABLED(CONFIG_BT_SETTINGS)) {
+		return 0;
+	}
+
+	struct bt_mesh_plvl_srv_settings_data data = {
+		.default_power = srv->default_power,
+		.last = srv->last,
+		.is_on = srv->is_on,
+		.range = srv->range,
+	};
+
+	return bt_mesh_model_data_store(srv->plvl_model, false, &data,
+					sizeof(data));
+}
+
+static void lvl_status_encode(struct net_buf_simple *buf,
+			      const struct bt_mesh_plvl_status *status)
+{
+	bt_mesh_model_msg_init(buf, BT_MESH_PLVL_OP_LEVEL_STATUS);
+
+	net_buf_simple_add_le16(buf, status->current);
+	if (status->remaining_time != 0) {
+		net_buf_simple_add_le16(buf, status->target);
+		net_buf_simple_add_u8(
+			buf, model_transition_encode(status->remaining_time));
+	}
+}
+
+static void transition_get(struct bt_mesh_plvl_srv *srv,
+			   struct bt_mesh_model_transition *transition,
+			   struct net_buf_simple *buf)
+{
+	if (buf->len == 2) {
+		model_transition_buf_pull(buf, transition);
+	} else {
+		bt_mesh_dtt_srv_transition_get(srv->plvl_model, transition);
+	}
+}
+
+static void rsp_plvl_status(struct bt_mesh_model *mod,
+			    struct bt_mesh_msg_ctx *ctx,
+			    struct bt_mesh_plvl_status *status)
+{
+	BT_MESH_MODEL_BUF_DEFINE(rsp, BT_MESH_PLVL_OP_LEVEL_STATUS,
+				 BT_MESH_PLVL_MSG_MAXLEN_LEVEL_STATUS);
+	lvl_status_encode(&rsp, status);
+
+	bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
+}
+
+static void handle_lvl_get(struct bt_mesh_model *mod,
+			   struct bt_mesh_msg_ctx *ctx,
+			   struct net_buf_simple *buf)
+{
+	if (buf->len != BT_MESH_PLVL_MSG_LEN_LEVEL_GET) {
+		return;
+	}
+
+	struct bt_mesh_plvl_srv *srv = mod->user_data;
+	struct bt_mesh_plvl_status status = { 0 };
+
+	srv->handlers->power_get(srv, ctx, &status);
+
+	rsp_plvl_status(mod, ctx, &status);
+}
+
+static void change_lvl(struct bt_mesh_plvl_srv *srv,
+		       struct bt_mesh_msg_ctx *ctx,
+		       struct bt_mesh_plvl_set *set,
+		       struct bt_mesh_plvl_status *status)
+{
+	bool state_change = (srv->is_on == (set->power_lvl == 0));
+
+	if (set->power_lvl != 0) {
+		if (set->power_lvl > srv->range.max) {
+			set->power_lvl = srv->range.max;
+		} else if (set->power_lvl < srv->range.min) {
+			set->power_lvl = srv->range.min;
+		}
+
+		state_change |= (srv->last != set->power_lvl);
+		srv->last = set->power_lvl;
+	}
+
+	if (state_change) {
+		store_state(srv);
+	}
+
+	memset(status, 0, sizeof(*status));
+	srv->handlers->power_set(srv, ctx, set, status);
+}
+
+static void plvl_set(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+		     struct net_buf_simple *buf, bool ack)
+{
+	if (buf->len != BT_MESH_PLVL_MSG_MINLEN_LEVEL_SET &&
+	    buf->len != BT_MESH_PLVL_MSG_MAXLEN_LEVEL_SET) {
+		return;
+	}
+
+	struct bt_mesh_plvl_srv *srv = mod->user_data;
+	struct bt_mesh_model_transition transition;
+	struct bt_mesh_plvl_status status;
+	struct bt_mesh_plvl_set set;
+
+	set.power_lvl = net_buf_simple_pull_le16(buf);
+	transition_get(srv, &transition, buf);
+	set.transition = &transition;
+
+	if (tid_check_and_update(&srv->tid, net_buf_simple_pull_u8(buf), ctx)) {
+		srv->handlers->power_get(srv, NULL, &status);
+	} else {
+		change_lvl(srv, ctx, &set, &status);
+	}
+
+	if (ack) {
+		rsp_plvl_status(mod, ctx, &status);
+	}
+
+	(void)bt_mesh_plvl_srv_pub(srv, NULL, &status);
+}
+
+static void handle_plvl_set(struct bt_mesh_model *mod,
+			    struct bt_mesh_msg_ctx *ctx,
+			    struct net_buf_simple *buf)
+{
+	plvl_set(mod, ctx, buf, true);
+}
+
+static void handle_plvl_set_unack(struct bt_mesh_model *mod,
+				  struct bt_mesh_msg_ctx *ctx,
+				  struct net_buf_simple *buf)
+{
+	plvl_set(mod, ctx, buf, false);
+}
+
+static void handle_last_get(struct bt_mesh_model *mod,
+			    struct bt_mesh_msg_ctx *ctx,
+			    struct net_buf_simple *buf)
+{
+	if (buf->len != BT_MESH_PLVL_MSG_LEN_LAST_GET) {
+		return;
+	}
+
+	struct bt_mesh_plvl_srv *srv = mod->user_data;
+
+	BT_MESH_MODEL_BUF_DEFINE(rsp, BT_MESH_PLVL_OP_LAST_STATUS,
+				 BT_MESH_PLVL_MSG_LEN_LAST_STATUS);
+	bt_mesh_model_msg_init(&rsp, BT_MESH_PLVL_OP_LAST_STATUS);
+
+	net_buf_simple_add_le16(&rsp, srv->last);
+	bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
+}
+
+static void handle_default_get(struct bt_mesh_model *mod,
+			       struct bt_mesh_msg_ctx *ctx,
+			       struct net_buf_simple *buf)
+{
+	if (buf->len != BT_MESH_PLVL_MSG_LEN_DEFAULT_GET) {
+		return;
+	}
+
+	struct bt_mesh_plvl_srv *srv = mod->user_data;
+
+	BT_MESH_MODEL_BUF_DEFINE(rsp, BT_MESH_PLVL_OP_DEFAULT_STATUS,
+				 BT_MESH_PLVL_MSG_LEN_DEFAULT_STATUS);
+	bt_mesh_model_msg_init(&rsp, BT_MESH_PLVL_OP_DEFAULT_STATUS);
+
+	net_buf_simple_add_le16(&rsp, srv->default_power);
+	bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
+}
+
+static void set_default(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+			struct net_buf_simple *buf, bool ack)
+{
+	if (buf->len != BT_MESH_PLVL_MSG_LEN_DEFAULT_SET) {
+		return;
+	}
+
+	struct bt_mesh_plvl_srv *srv = mod->user_data;
+	u8_t new = net_buf_simple_pull_le16(buf);
+
+	if (new != srv->default_power) {
+		u8_t old = srv->default_power;
+
+		srv->default_power = new;
+		if (srv->handlers->default_update) {
+			srv->handlers->default_update(srv, ctx, old, new);
+		}
+
+		store_state(srv);
+	}
+
+	if (!ack) {
+		return;
+	}
+
+	BT_MESH_MODEL_BUF_DEFINE(rsp, BT_MESH_PLVL_OP_DEFAULT_STATUS,
+				 BT_MESH_PLVL_MSG_LEN_DEFAULT_STATUS);
+	bt_mesh_model_msg_init(&rsp, BT_MESH_PLVL_OP_DEFAULT_STATUS);
+	net_buf_simple_add_le16(&rsp, srv->default_power);
+
+	bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
+}
+
+static void handle_default_set(struct bt_mesh_model *mod,
+			       struct bt_mesh_msg_ctx *ctx,
+			       struct net_buf_simple *buf)
+{
+	set_default(mod, ctx, buf, true);
+}
+
+static void handle_default_set_unack(struct bt_mesh_model *mod,
+				     struct bt_mesh_msg_ctx *ctx,
+				     struct net_buf_simple *buf)
+{
+	set_default(mod, ctx, buf, false);
+}
+
+static void handle_range_get(struct bt_mesh_model *mod,
+			     struct bt_mesh_msg_ctx *ctx,
+			     struct net_buf_simple *buf)
+{
+	if (buf->len != BT_MESH_PLVL_MSG_LEN_RANGE_GET) {
+		return;
+	}
+
+	struct bt_mesh_plvl_srv *srv = mod->user_data;
+
+	BT_MESH_MODEL_BUF_DEFINE(rsp, BT_MESH_PLVL_OP_DEFAULT_STATUS,
+				 BT_MESH_PLVL_MSG_LEN_DEFAULT_STATUS);
+	bt_mesh_model_msg_init(&rsp, BT_MESH_PLVL_OP_DEFAULT_STATUS);
+
+	net_buf_simple_add_u8(&rsp, BT_MESH_MODEL_SUCCESS);
+	net_buf_simple_add_le16(&rsp, srv->range.min);
+	net_buf_simple_add_le16(&rsp, srv->range.max);
+
+	bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
+}
+
+static void set_range(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+		      struct net_buf_simple *buf, bool ack)
+{
+	if (buf->len != BT_MESH_PLVL_MSG_LEN_RANGE_SET) {
+		return;
+	}
+
+	struct bt_mesh_plvl_srv *srv = mod->user_data;
+	enum bt_mesh_model_status status = BT_MESH_MODEL_SUCCESS;
+	struct bt_mesh_plvl_range new;
+
+	new.min = net_buf_simple_pull_le16(buf);
+	new.max = net_buf_simple_pull_le16(buf);
+	if (new.min != srv->range.min || new.max != srv->range.max) {
+		if (new.min > new.max) {
+			status = BT_MESH_MODEL_ERROR_INVALID_RANGE_MIN;
+		} else {
+			struct bt_mesh_plvl_range old = srv->range;
+
+			srv->range = new;
+			if (srv->handlers->range_update) {
+				srv->handlers->range_update(srv, ctx, &old,
+							    &new);
+			}
+
+			store_state(srv);
+		}
+	}
+
+	if (!ack) {
+		return;
+	}
+
+	BT_MESH_MODEL_BUF_DEFINE(rsp, BT_MESH_PLVL_OP_DEFAULT_STATUS,
+				 BT_MESH_PLVL_MSG_LEN_DEFAULT_STATUS);
+	bt_mesh_model_msg_init(&rsp, BT_MESH_PLVL_OP_DEFAULT_STATUS);
+
+	net_buf_simple_add_u8(&rsp, status);
+	net_buf_simple_add_le16(&rsp, srv->range.min);
+	net_buf_simple_add_le16(&rsp, srv->range.max);
+
+	bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
+}
+
+static void handle_range_set(struct bt_mesh_model *mod,
+			     struct bt_mesh_msg_ctx *ctx,
+			     struct net_buf_simple *buf)
+{
+	set_range(mod, ctx, buf, true);
+}
+
+static void handle_range_set_unack(struct bt_mesh_model *mod,
+				   struct bt_mesh_msg_ctx *ctx,
+				   struct net_buf_simple *buf)
+{
+	set_range(mod, ctx, buf, false);
+}
+
+const struct bt_mesh_model_op _bt_mesh_plvl_srv_op[] = {
+	{ BT_MESH_PLVL_OP_LEVEL_GET, BT_MESH_PLVL_MSG_LEN_LEVEL_GET,
+	  handle_lvl_get },
+	{ BT_MESH_PLVL_OP_LEVEL_SET, BT_MESH_PLVL_MSG_MINLEN_LEVEL_SET,
+	  handle_plvl_set },
+	{ BT_MESH_PLVL_OP_LEVEL_SET_UNACK, BT_MESH_PLVL_MSG_MINLEN_LEVEL_SET,
+	  handle_plvl_set_unack },
+	{ BT_MESH_PLVL_OP_LAST_GET, BT_MESH_PLVL_MSG_LEN_LAST_GET,
+	  handle_last_get },
+	{ BT_MESH_PLVL_OP_DEFAULT_GET, BT_MESH_PLVL_MSG_LEN_DEFAULT_GET,
+	  handle_default_get },
+	{ BT_MESH_PLVL_OP_RANGE_GET, BT_MESH_PLVL_MSG_LEN_RANGE_GET,
+	  handle_range_get },
+	BT_MESH_MODEL_OP_END,
+};
+
+const struct bt_mesh_model_op _bt_mesh_plvl_setup_srv_op[] = {
+	{ BT_MESH_PLVL_OP_DEFAULT_SET, BT_MESH_PLVL_MSG_LEN_DEFAULT_SET,
+	  handle_default_set },
+	{ BT_MESH_PLVL_OP_DEFAULT_SET_UNACK, BT_MESH_PLVL_MSG_LEN_DEFAULT_SET,
+	  handle_default_set_unack },
+	{ BT_MESH_PLVL_OP_RANGE_SET, BT_MESH_PLVL_MSG_LEN_RANGE_SET,
+	  handle_range_set },
+	{ BT_MESH_PLVL_OP_RANGE_SET_UNACK, BT_MESH_PLVL_MSG_LEN_RANGE_SET,
+	  handle_range_set_unack },
+	BT_MESH_MODEL_OP_END,
+};
+
+static void lvl_get(struct bt_mesh_lvl_srv *lvl_srv,
+		    struct bt_mesh_msg_ctx *ctx, struct bt_mesh_lvl_status *rsp)
+{
+	struct bt_mesh_plvl_srv *srv =
+		CONTAINER_OF(lvl_srv, struct bt_mesh_plvl_srv, lvl);
+	struct bt_mesh_plvl_status status = { 0 };
+
+	srv->handlers->power_get(srv, ctx, &status);
+
+	rsp->current = POWER_TO_LVL(status.current);
+	rsp->target = POWER_TO_LVL(status.target);
+	rsp->remaining_time = status.remaining_time;
+}
+
+static void lvl_set(struct bt_mesh_lvl_srv *lvl_srv,
+		    struct bt_mesh_msg_ctx *ctx,
+		    const struct bt_mesh_lvl_set *lvl_set,
+		    struct bt_mesh_lvl_status *rsp)
+{
+	struct bt_mesh_plvl_srv *srv =
+		CONTAINER_OF(lvl_srv, struct bt_mesh_plvl_srv, lvl);
+	struct bt_mesh_plvl_set set = {
+		.power_lvl = LVL_TO_POWER(lvl_set->lvl),
+		.transition = lvl_set->transition,
+	};
+	struct bt_mesh_plvl_status status;
+
+	change_lvl(srv, ctx, &set, &status);
+
+	if (rsp) {
+		rsp->current = POWER_TO_LVL(status.current);
+		rsp->target = POWER_TO_LVL(status.target);
+		rsp->remaining_time = status.remaining_time;
+	}
+}
+
+static void lvl_delta_set(struct bt_mesh_lvl_srv *lvl_srv,
+			  struct bt_mesh_msg_ctx *ctx,
+			  const struct bt_mesh_lvl_delta_set *delta_set,
+			  struct bt_mesh_lvl_status *rsp)
+{
+	struct bt_mesh_plvl_srv *srv =
+		CONTAINER_OF(lvl_srv, struct bt_mesh_plvl_srv, lvl);
+	struct bt_mesh_plvl_status status = { 0 };
+
+	srv->handlers->power_get(srv, NULL, &status);
+
+	struct bt_mesh_plvl_set set = {
+		.power_lvl = status.current + delta_set->delta,
+		.transition = delta_set->transition,
+	};
+
+	change_lvl(srv, ctx, &set, &status);
+
+	if (rsp) {
+		rsp->current = POWER_TO_LVL(status.current);
+		rsp->target = POWER_TO_LVL(status.target);
+		rsp->remaining_time = status.remaining_time;
+	}
+}
+
+static void lvl_move_set(struct bt_mesh_lvl_srv *lvl_srv,
+			 struct bt_mesh_msg_ctx *ctx,
+			 const struct bt_mesh_lvl_move_set *move_set,
+			 struct bt_mesh_lvl_status *rsp)
+{
+	struct bt_mesh_plvl_srv *srv =
+		CONTAINER_OF(lvl_srv, struct bt_mesh_plvl_srv, lvl);
+	struct bt_mesh_plvl_status status = { 0 };
+	u16_t target;
+
+	srv->handlers->power_get(srv, NULL, &status);
+
+	if (move_set->delta > 0) {
+		target = srv->range.max;
+	} else if (move_set->delta < 0) {
+		target = srv->range.min;
+	} else {
+		target = status.current;
+	}
+
+	struct bt_mesh_plvl_set set = {
+		.power_lvl = target,
+	};
+	struct bt_mesh_model_transition transition;
+
+	if (move_set->delta != 0 && move_set->transition) {
+		s32_t distance = target - status.current;
+
+		s32_t time_to_edge = (distance * move_set->transition->time) /
+				     move_set->delta;
+
+		if (time_to_edge > 0) {
+			transition.delay = move_set->transition->delay;
+			transition.time = time_to_edge;
+			set.transition = &transition;
+		}
+	}
+
+	change_lvl(srv, ctx, &set, &status);
+
+	if (rsp) {
+		rsp->current = POWER_TO_LVL(status.current);
+		rsp->target = POWER_TO_LVL(status.target);
+		rsp->remaining_time = status.remaining_time;
+	}
+}
+
+const struct bt_mesh_lvl_srv_handlers bt_mesh_plvl_srv_lvl_handlers = {
+	.get = lvl_get,
+	.set = lvl_set,
+	.delta_set = lvl_delta_set,
+	.move_set = lvl_move_set,
+};
+
+static void onoff_set(struct bt_mesh_onoff_srv *onoff_srv,
+		      struct bt_mesh_msg_ctx *ctx,
+		      const struct bt_mesh_onoff_set *onoff_set,
+		      struct bt_mesh_onoff_status *rsp)
+{
+	struct bt_mesh_plvl_srv *srv =
+		CONTAINER_OF(onoff_srv, struct bt_mesh_plvl_srv, ponoff.onoff);
+	struct bt_mesh_plvl_set set = {
+		.transition = onoff_set->transition,
+	};
+	struct bt_mesh_plvl_status status;
+
+	if (onoff_set->on_off) {
+		set.power_lvl =
+			(srv->default_power ? srv->default_power : srv->last);
+	} else {
+		set.power_lvl = 0;
+	}
+
+	change_lvl(srv, ctx, &set, &status);
+
+	if (rsp) {
+		rsp->present_on_off = (status.current > 0);
+		rsp->remaining_time = status.remaining_time;
+		rsp->target_on_off = (status.target > 0);
+	}
+}
+
+static void onoff_get(struct bt_mesh_onoff_srv *onoff_srv,
+		      struct bt_mesh_msg_ctx *ctx,
+		      struct bt_mesh_onoff_status *rsp)
+{
+	struct bt_mesh_plvl_srv *srv =
+		CONTAINER_OF(onoff_srv, struct bt_mesh_plvl_srv, ponoff.onoff);
+	struct bt_mesh_plvl_status status = { 0 };
+
+	srv->handlers->power_get(srv, ctx, &status);
+
+	rsp->present_on_off = (status.current > 0);
+	rsp->remaining_time = status.remaining_time;
+	rsp->target_on_off = (status.target > 0);
+}
+
+const struct bt_mesh_onoff_srv_handlers bt_mesh_plvl_srv_onoff_handlers = {
+	.set = onoff_set,
+	.get = onoff_get,
+};
+
+static void bt_mesh_plvl_srv_reset(struct bt_mesh_model *mod)
+{
+	struct bt_mesh_plvl_srv *srv = mod->user_data;
+
+	srv->range.min = 0;
+	srv->range.max = UINT16_MAX;
+	srv->default_power = 0;
+	srv->last = UINT16_MAX;
+	srv->is_on = false;
+}
+
+static int bt_mesh_plvl_srv_init(struct bt_mesh_model *mod)
+{
+	struct bt_mesh_plvl_srv *srv = mod->user_data;
+
+	srv->plvl_model = mod;
+	bt_mesh_plvl_srv_reset(mod);
+
+	return 0;
+}
+
+#ifdef CONFIG_BT_SETTINGS
+static int bt_mesh_plvl_srv_settings_set(struct bt_mesh_model *mod,
+					 size_t len_rd,
+					 settings_read_cb read_cb, void *cb_arg)
+{
+	struct bt_mesh_plvl_srv *srv = mod->user_data;
+	struct bt_mesh_plvl_srv_settings_data data;
+
+	if (read_cb(cb_arg, &data, sizeof(data)) != sizeof(data)) {
+		return -EINVAL;
+	}
+
+	srv->default_power = data.default_power;
+	srv->range = data.range;
+	srv->last = data.last;
+	srv->is_on = data.is_on;
+
+	return 0;
+}
+
+static int bt_mesh_plvl_srv_settings_commit(struct bt_mesh_model *mod)
+{
+	struct bt_mesh_plvl_srv *srv = mod->user_data;
+	struct bt_mesh_plvl_status dummy = { 0 };
+	struct bt_mesh_plvl_set set;
+
+	switch (srv->ponoff.on_power_up) {
+	case BT_MESH_ON_POWER_UP_OFF:
+		set.power_lvl = 0;
+		break;
+	case BT_MESH_ON_POWER_UP_ON:
+		set.power_lvl =
+			(srv->default_power ? srv->default_power : srv->last);
+		break;
+	case BT_MESH_ON_POWER_UP_RESTORE:
+		set.power_lvl = srv->is_on ? srv->last : 0;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	srv->handlers->power_set(srv, NULL, &set, &dummy);
+	return 0;
+}
+#endif
+
+const struct bt_mesh_model_cb _bt_mesh_plvl_srv_cb = {
+	.init = bt_mesh_plvl_srv_init,
+	.reset = bt_mesh_plvl_srv_reset,
+#ifdef CONFIG_BT_SETTINGS
+	.settings_set = bt_mesh_plvl_srv_settings_set,
+	.settings_commit = bt_mesh_plvl_srv_settings_commit,
+#endif
+};
+
+int bt_mesh_plvl_srv_pub(struct bt_mesh_plvl_srv *srv,
+			 struct bt_mesh_msg_ctx *ctx,
+			 const struct bt_mesh_plvl_status *status)
+{
+	lvl_status_encode(srv->pub.msg, status);
+
+	return model_send(srv->plvl_model, ctx, srv->pub.msg);
+}
+
+int _bt_mesh_plvl_srv_update_handler(struct bt_mesh_model *model)
+{
+	struct bt_mesh_plvl_srv *srv = model->user_data;
+	struct bt_mesh_plvl_status status = { 0 };
+
+	srv->handlers->power_get(srv, NULL, &status);
+	lvl_status_encode(model->pub->msg, &status);
+	return 0;
+}

--- a/subsys/bluetooth/mesh/gen_ponoff_cli.c
+++ b/subsys/bluetooth/mesh/gen_ponoff_cli.c
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#include <bluetooth/mesh/gen_ponoff_cli.h>
+#include "model_utils.h"
+
+static void handle_status(struct bt_mesh_model *model,
+			  struct bt_mesh_msg_ctx *ctx,
+			  struct net_buf_simple *buf)
+{
+	if (buf->len != BT_MESH_PONOFF_MSG_LEN_STATUS) {
+		return;
+	}
+
+	struct bt_mesh_ponoff_cli *cli = model->user_data;
+	enum bt_mesh_on_power_up on_power_up = net_buf_simple_pull_u8(buf);
+
+	if (model_ack_match(&cli->ack_ctx, BT_MESH_PONOFF_OP_STATUS, ctx)) {
+		enum bt_mesh_on_power_up *rsp =
+			(enum bt_mesh_on_power_up *)cli->ack_ctx.user_data;
+		*rsp = on_power_up;
+
+		model_ack_rx(&cli->ack_ctx);
+	}
+
+	if (cli->status_handler) {
+		cli->status_handler(cli, ctx, on_power_up);
+	}
+}
+
+const struct bt_mesh_model_op _bt_mesh_ponoff_cli_op[] = {
+	{ BT_MESH_PONOFF_OP_STATUS, BT_MESH_PONOFF_MSG_LEN_STATUS,
+	  handle_status },
+	BT_MESH_MODEL_OP_END,
+};
+
+static int bt_mesh_ponoff_cli_init(struct bt_mesh_model *mod)
+{
+	struct bt_mesh_ponoff_cli *cli = mod->user_data;
+
+	cli->model = mod;
+	return 0;
+}
+
+const struct bt_mesh_model_cb _bt_mesh_ponoff_cli_cb = {
+	.init = bt_mesh_ponoff_cli_init,
+};
+
+int bt_mesh_ponoff_cli_on_power_up_get(struct bt_mesh_ponoff_cli *cli,
+				       struct bt_mesh_msg_ctx *ctx,
+				       enum bt_mesh_on_power_up *rsp)
+{
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_PONOFF_OP_GET,
+				 BT_MESH_PONOFF_MSG_LEN_GET);
+	bt_mesh_model_msg_init(&msg, BT_MESH_PONOFF_OP_GET);
+
+	return model_ackd_send(cli->model, ctx, &msg,
+			       (rsp ? &cli->ack_ctx : NULL),
+			       BT_MESH_PONOFF_OP_STATUS, rsp);
+}
+
+int bt_mesh_ponoff_cli_on_power_up_set(struct bt_mesh_ponoff_cli *cli,
+				       struct bt_mesh_msg_ctx *ctx,
+				       enum bt_mesh_on_power_up on_power_up,
+				       enum bt_mesh_on_power_up *rsp)
+{
+	if (on_power_up >= BT_MESH_ON_POWER_UP_INVALID) {
+		return -EINVAL;
+	}
+
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_PONOFF_OP_SET,
+				 BT_MESH_PONOFF_MSG_LEN_SET);
+	bt_mesh_model_msg_init(&msg, BT_MESH_PONOFF_OP_SET);
+	net_buf_simple_add_u8(&msg, on_power_up);
+
+	return model_ackd_send(cli->model, ctx, &msg,
+			       (rsp ? &cli->ack_ctx : NULL),
+			       BT_MESH_PONOFF_OP_STATUS, rsp);
+}

--- a/subsys/bluetooth/mesh/gen_ponoff_srv.c
+++ b/subsys/bluetooth/mesh/gen_ponoff_srv.c
@@ -1,0 +1,261 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#include <bluetooth/mesh/gen_ponoff_srv.h>
+
+#include <string.h>
+#include <settings/settings.h>
+#include <stdlib.h>
+#include "model_utils.h"
+
+/** Persistent storage handling */
+struct ponoff_settings_data {
+	u8_t on_power_up;
+	bool on_off;
+} __packed;
+
+static int store(struct bt_mesh_ponoff_srv *srv,
+		 const struct bt_mesh_onoff_status *onoff_status)
+{
+	if (!IS_ENABLED(CONFIG_BT_SETTINGS)) {
+		return 0;
+	}
+
+	struct ponoff_settings_data data;
+
+	data.on_power_up = (u8_t)srv->on_power_up;
+
+	switch (srv->on_power_up) {
+	case BT_MESH_ON_POWER_UP_OFF:
+		data.on_off = false;
+		break;
+	case BT_MESH_ON_POWER_UP_ON:
+		data.on_off = true;
+		break;
+	case BT_MESH_ON_POWER_UP_RESTORE:
+		data.on_off = onoff_status->remaining_time > 0 ?
+				      onoff_status->target_on_off :
+				      onoff_status->present_on_off;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	return bt_mesh_model_data_store(srv->ponoff_model, false, &data,
+					sizeof(data));
+}
+
+static void send_rsp(struct bt_mesh_ponoff_srv *srv,
+		     struct bt_mesh_msg_ctx *ctx)
+{
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_PONOFF_OP_STATUS,
+				 BT_MESH_PONOFF_MSG_LEN_STATUS);
+	bt_mesh_model_msg_init(&msg, BT_MESH_PONOFF_OP_STATUS);
+	net_buf_simple_add_u8(&msg, srv->on_power_up);
+	bt_mesh_model_send(srv->ponoff_model, ctx, &msg, NULL, NULL);
+}
+
+static void handle_get(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+		       struct net_buf_simple *buf)
+{
+	if (buf->len != BT_MESH_PONOFF_MSG_LEN_STATUS) {
+		return;
+	}
+
+	send_rsp(model->user_data, ctx);
+}
+
+static void set_on_power_up(struct bt_mesh_ponoff_srv *srv,
+			    struct bt_mesh_msg_ctx *ctx,
+			    enum bt_mesh_on_power_up new)
+{
+	if (new >= BT_MESH_ON_POWER_UP_INVALID || new == srv->on_power_up) {
+		return;
+	}
+
+	enum bt_mesh_on_power_up old = srv->on_power_up;
+
+	srv->on_power_up = new;
+
+	bt_mesh_model_msg_init(srv->ponoff_model->pub->msg,
+			       BT_MESH_PONOFF_OP_STATUS);
+	net_buf_simple_add_u8(srv->ponoff_model->pub->msg, srv->on_power_up);
+
+	if (srv->update) {
+		srv->update(srv, ctx, old, new);
+	}
+
+	struct bt_mesh_onoff_status onoff_status = { 0 };
+
+	srv->onoff.handlers->get(&srv->onoff, NULL, &onoff_status);
+
+	store(srv, &onoff_status);
+}
+
+static void handle_set_msg(struct bt_mesh_model *model,
+			   struct bt_mesh_msg_ctx *ctx,
+			   struct net_buf_simple *buf, bool ack)
+{
+	if (buf->len != BT_MESH_PONOFF_MSG_LEN_SET) {
+		return;
+	}
+
+	struct bt_mesh_ponoff_srv *srv = model->user_data;
+	enum bt_mesh_on_power_up new = net_buf_simple_pull_u8(buf);
+
+	set_on_power_up(srv, ctx, new);
+
+	if (ack) {
+		send_rsp(model->user_data, ctx);
+	}
+
+	(void)bt_mesh_ponoff_srv_pub(srv, NULL);
+}
+
+static void handle_set(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,
+		       struct net_buf_simple *buf)
+{
+	handle_set_msg(model, ctx, buf, true);
+}
+
+static void handle_set_unack(struct bt_mesh_model *model,
+			     struct bt_mesh_msg_ctx *ctx,
+			     struct net_buf_simple *buf)
+{
+	handle_set_msg(model, ctx, buf, false);
+}
+
+/* Need to intercept the onoff state to get the right value on power up. */
+static void onoff_intercept_set(struct bt_mesh_onoff_srv *onoff_srv,
+				struct bt_mesh_msg_ctx *ctx,
+				const struct bt_mesh_onoff_set *set,
+				struct bt_mesh_onoff_status *status)
+{
+	struct bt_mesh_ponoff_srv *srv =
+		CONTAINER_OF(onoff_srv, struct bt_mesh_ponoff_srv, onoff);
+
+	srv->onoff_handlers->set(onoff_srv, ctx, set, status);
+
+	if (srv->on_power_up == BT_MESH_ON_POWER_UP_RESTORE) {
+		store(srv, status);
+	}
+}
+
+static void onoff_intercept_get(struct bt_mesh_onoff_srv *onoff_srv,
+				struct bt_mesh_msg_ctx *ctx,
+				struct bt_mesh_onoff_status *out)
+{
+	struct bt_mesh_ponoff_srv *srv =
+		CONTAINER_OF(onoff_srv, struct bt_mesh_ponoff_srv, onoff);
+
+	srv->onoff_handlers->get(onoff_srv, ctx, out);
+}
+
+const struct bt_mesh_model_op _bt_mesh_ponoff_srv_op[] = {
+	{ BT_MESH_PONOFF_OP_GET, BT_MESH_PONOFF_MSG_LEN_GET, handle_get },
+	BT_MESH_MODEL_OP_END,
+};
+
+const struct bt_mesh_model_op _bt_mesh_ponoff_setup_srv_op[] = {
+	{ BT_MESH_PONOFF_OP_SET, BT_MESH_PONOFF_MSG_LEN_SET, handle_set },
+	{ BT_MESH_PONOFF_OP_SET_UNACK, BT_MESH_PONOFF_MSG_LEN_SET,
+	  handle_set_unack },
+	BT_MESH_MODEL_OP_END,
+};
+
+const struct bt_mesh_onoff_srv_handlers _bt_mesh_ponoff_onoff_intercept = {
+	.set = onoff_intercept_set,
+	.get = onoff_intercept_get,
+};
+
+static int bt_mesh_ponoff_srv_init(struct bt_mesh_model *model)
+{
+	struct bt_mesh_ponoff_srv *srv = model->user_data;
+
+	srv->ponoff_model = model;
+	return 0;
+}
+
+static void bt_mesh_ponoff_srv_reset(struct bt_mesh_model *model)
+{
+	struct bt_mesh_ponoff_srv *srv = model->user_data;
+
+	srv->on_power_up = BT_MESH_ON_POWER_UP_OFF;
+}
+
+#ifdef CONFIG_BT_SETTINGS
+static int bt_mesh_ponoff_srv_settings_set(struct bt_mesh_model *model,
+					   size_t len_rd,
+					   settings_read_cb read_cb,
+					   void *cb_arg)
+{
+	struct bt_mesh_ponoff_srv *srv = model->user_data;
+	struct ponoff_settings_data data;
+
+	if (read_cb(cb_arg, &data, sizeof(data)) != sizeof(data)) {
+		return -EINVAL;
+	}
+
+	set_on_power_up(srv, NULL, (enum bt_mesh_on_power_up)data.on_power_up);
+
+	struct bt_mesh_onoff_set onoff_set = { 0 };
+
+	switch (data.on_power_up) {
+	case BT_MESH_ON_POWER_UP_OFF:
+		onoff_set.on_off = false;
+		break;
+	case BT_MESH_ON_POWER_UP_ON:
+		onoff_set.on_off = true;
+		break;
+	case BT_MESH_ON_POWER_UP_RESTORE:
+		onoff_set.on_off = data.on_off;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	srv->onoff.handlers->set(&srv->onoff, NULL, &onoff_set, NULL);
+
+	return 0;
+}
+#endif
+
+const struct bt_mesh_model_cb _bt_mesh_ponoff_srv_cb = {
+	.init = bt_mesh_ponoff_srv_init,
+	.reset = bt_mesh_ponoff_srv_reset,
+#ifdef CONFIG_BT_SETTINGS
+	.settings_set = bt_mesh_ponoff_srv_settings_set,
+#endif
+};
+
+int _bt_mesh_ponoff_srv_update_handler(struct bt_mesh_model *model)
+{
+	struct bt_mesh_ponoff_srv *srv = model->user_data;
+
+	bt_mesh_model_msg_init(srv->ponoff_model->pub->msg,
+			       BT_MESH_PONOFF_OP_STATUS);
+	net_buf_simple_add_u8(srv->ponoff_model->pub->msg, srv->on_power_up);
+	return 0;
+}
+
+void bt_mesh_ponoff_srv_set(struct bt_mesh_ponoff_srv *srv,
+			    enum bt_mesh_on_power_up on_power_up)
+{
+	set_on_power_up(srv, NULL, on_power_up);
+
+	(void)bt_mesh_ponoff_srv_pub(srv, NULL);
+}
+
+int bt_mesh_ponoff_srv_pub(struct bt_mesh_ponoff_srv *srv,
+			   struct bt_mesh_msg_ctx *ctx)
+{
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_PONOFF_OP_STATUS,
+				 BT_MESH_PONOFF_MSG_LEN_STATUS);
+	bt_mesh_model_msg_init(&msg, BT_MESH_PONOFF_OP_STATUS);
+	net_buf_simple_add_u8(&msg, srv->on_power_up);
+
+	return model_send(srv->ponoff_model, ctx, &msg);
+}

--- a/subsys/bluetooth/mesh/gen_prop_cli.c
+++ b/subsys/bluetooth/mesh/gen_prop_cli.c
@@ -1,0 +1,254 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+#include <bluetooth/mesh/gen_prop_cli.h>
+#include <sys/util.h>
+#include "gen_prop_internal.h"
+#include "model_utils.h"
+
+BUILD_ASSERT_MSG(BT_MESH_MODEL_BUF_LEN(BT_MESH_PROP_OP_MFR_PROP_STATUS,
+				       BT_MESH_PROP_MSG_MAXLEN_PROP_STATUS) <=
+			 CONFIG_BT_MESH_RX_SDU_MAX,
+		 "The property list must fit inside an application SDU.");
+BUILD_ASSERT_MSG(BT_MESH_MODEL_BUF_LEN(BT_MESH_PROP_OP_MFR_PROPS_STATUS,
+				       BT_MESH_PROP_MSG_MAXLEN_PROPS_STATUS) <=
+			 (CONFIG_BT_MESH_TX_SEG_MAX * 12),
+		 "The property value must fit inside an application SDU.");
+
+struct prop_list_ctx {
+	struct bt_mesh_prop_list *list;
+	int status;
+};
+
+static void properties_status(struct bt_mesh_model *mod,
+			      struct bt_mesh_msg_ctx *ctx,
+			      struct net_buf_simple *buf,
+			      enum bt_mesh_prop_srv_kind kind)
+{
+	if ((buf->len % 2) != 0) {
+		return;
+	}
+
+	struct bt_mesh_prop_cli *cli = mod->user_data;
+	struct bt_mesh_prop_list list;
+
+	list.count = buf->len / 2;
+	list.ids = (u16_t *)net_buf_simple_pull_mem(buf, buf->len);
+
+	if (model_ack_match(&cli->ack_ctx,
+			    op_get(BT_MESH_PROP_OP_PROPS_STATUS, kind), ctx)) {
+		struct prop_list_ctx *rsp = cli->ack_ctx.user_data;
+
+		if (list.count > rsp->list->count) {
+			/* Buffer can't hold all entries */
+			rsp->status = -ENOBUFS;
+			list.count = rsp->list->count;
+		}
+
+		memcpy(rsp->list->ids, list.ids, list.count * 2);
+		rsp->list->count = list.count;
+	}
+
+	if (cli->prop_list) {
+		cli->prop_list(cli, ctx, kind, &list);
+	}
+}
+
+static void handle_mfr_properties_status(struct bt_mesh_model *mod,
+					 struct bt_mesh_msg_ctx *ctx,
+					 struct net_buf_simple *buf)
+{
+	properties_status(mod, ctx, buf, BT_MESH_PROP_SRV_KIND_MFR);
+}
+
+static void handle_admin_properties_status(struct bt_mesh_model *mod,
+					   struct bt_mesh_msg_ctx *ctx,
+					   struct net_buf_simple *buf)
+{
+	properties_status(mod, ctx, buf, BT_MESH_PROP_SRV_KIND_ADMIN);
+}
+
+static void handle_user_properties_status(struct bt_mesh_model *mod,
+					  struct bt_mesh_msg_ctx *ctx,
+					  struct net_buf_simple *buf)
+{
+	properties_status(mod, ctx, buf, BT_MESH_PROP_SRV_KIND_USER);
+}
+
+static void property_status(struct bt_mesh_model *mod,
+			    struct bt_mesh_msg_ctx *ctx,
+			    struct net_buf_simple *buf,
+			    enum bt_mesh_prop_srv_kind kind)
+{
+	if (buf->len < BT_MESH_PROP_MSG_MINLEN_PROP_STATUS ||
+	    buf->len > BT_MESH_PROP_MSG_MAXLEN_PROP_STATUS) {
+		return;
+	}
+
+	struct bt_mesh_prop_cli *cli = mod->user_data;
+	struct bt_mesh_prop_val val;
+
+	val.meta.id = net_buf_simple_pull_le16(buf);
+	val.meta.user_access = net_buf_simple_pull_u8(buf);
+	val.size = MIN(buf->len, sizeof(val.value));
+	memcpy(val.value, net_buf_simple_pull_mem(buf, val.size), val.size);
+
+	if (model_ack_match(&cli->ack_ctx,
+			    op_get(BT_MESH_PROP_OP_PROP_STATUS, kind), ctx)) {
+		struct bt_mesh_prop_val *rsp = cli->ack_ctx.user_data;
+
+		*rsp = val;
+	}
+
+	if (cli->prop_list) {
+		cli->prop_status(cli, ctx, kind, &val);
+	}
+}
+
+static void handle_mfr_property_status(struct bt_mesh_model *mod,
+				       struct bt_mesh_msg_ctx *ctx,
+				       struct net_buf_simple *buf)
+{
+	property_status(mod, ctx, buf, BT_MESH_PROP_SRV_KIND_MFR);
+}
+
+static void handle_admin_property_status(struct bt_mesh_model *mod,
+					 struct bt_mesh_msg_ctx *ctx,
+					 struct net_buf_simple *buf)
+{
+	property_status(mod, ctx, buf, BT_MESH_PROP_SRV_KIND_ADMIN);
+}
+
+static void handle_user_property_status(struct bt_mesh_model *mod,
+					struct bt_mesh_msg_ctx *ctx,
+					struct net_buf_simple *buf)
+{
+	property_status(mod, ctx, buf, BT_MESH_PROP_SRV_KIND_USER);
+}
+
+const struct bt_mesh_model_op _bt_mesh_prop_cli_op[] = {
+	{ BT_MESH_PROP_OP_MFR_PROPS_STATUS,
+	  BT_MESH_PROP_MSG_MINLEN_PROPS_STATUS, handle_mfr_properties_status },
+	{ BT_MESH_PROP_OP_ADMIN_PROPS_STATUS,
+	  BT_MESH_PROP_MSG_MINLEN_PROPS_STATUS,
+	  handle_admin_properties_status },
+	{ BT_MESH_PROP_OP_USER_PROPS_STATUS,
+	  BT_MESH_PROP_MSG_MINLEN_PROPS_STATUS, handle_user_properties_status },
+	{ BT_MESH_PROP_OP_MFR_PROP_STATUS, BT_MESH_PROP_MSG_MINLEN_PROP_STATUS,
+	  handle_mfr_property_status },
+	{ BT_MESH_PROP_OP_ADMIN_PROP_STATUS,
+	  BT_MESH_PROP_MSG_MINLEN_PROP_STATUS, handle_admin_property_status },
+	{ BT_MESH_PROP_OP_USER_PROP_STATUS, BT_MESH_PROP_MSG_MINLEN_PROP_STATUS,
+	  handle_user_property_status },
+	BT_MESH_MODEL_OP_END,
+};
+
+static int bt_mesh_prop_cli_init(struct bt_mesh_model *mod)
+{
+	struct bt_mesh_prop_cli *cli = mod->user_data;
+
+	cli->model = mod;
+	return 0;
+}
+
+const struct bt_mesh_model_cb _bt_mesh_prop_cli_cb = {
+	.init = bt_mesh_prop_cli_init,
+};
+
+int bt_mesh_prop_cli_props_get(struct bt_mesh_prop_cli *cli,
+			       struct bt_mesh_msg_ctx *ctx,
+			       enum bt_mesh_prop_srv_kind kind,
+			       struct bt_mesh_prop_list *rsp)
+{
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_PROP_OP_ADMIN_PROPS_GET,
+				 BT_MESH_PROP_MSG_LEN_PROPS_GET);
+
+	bt_mesh_model_msg_init(&msg, op_get(BT_MESH_PROP_OP_PROPS_GET, kind));
+
+	struct prop_list_ctx block_ctx = {
+		.list = rsp,
+	};
+	int status = model_ackd_send(cli->model, ctx, &msg,
+				     rsp ? &cli->ack_ctx : NULL,
+				     op_get(BT_MESH_PROP_OP_PROPS_STATUS, kind),
+				     &block_ctx);
+
+	if (status == 0) {
+		status = block_ctx.status;
+	}
+	return status;
+}
+
+int bt_mesh_prop_cli_prop_get(struct bt_mesh_prop_cli *cli,
+			      struct bt_mesh_msg_ctx *ctx,
+			      enum bt_mesh_prop_srv_kind kind, u16_t id,
+			      struct bt_mesh_prop_val *rsp)
+{
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_PROP_OP_ADMIN_PROP_GET,
+				 BT_MESH_PROP_MSG_LEN_PROP_GET);
+
+	bt_mesh_model_msg_init(&msg, op_get(BT_MESH_PROP_OP_PROP_GET, kind));
+	net_buf_simple_add_le16(&msg, id);
+
+	return model_ackd_send(cli->model, ctx, &msg,
+			       rsp ? &cli->ack_ctx : NULL,
+			       op_get(BT_MESH_PROP_OP_PROP_STATUS, kind), rsp);
+}
+
+int bt_mesh_prop_cli_user_prop_set(struct bt_mesh_prop_cli *cli,
+				   struct bt_mesh_msg_ctx *ctx,
+				   const struct bt_mesh_prop_val *val,
+				   struct bt_mesh_prop_val *rsp)
+{
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_PROP_OP_USER_PROP_SET,
+				 BT_MESH_PROP_MSG_MAXLEN_USER_PROP_SET);
+
+	bt_mesh_model_msg_init(&msg, rsp ? BT_MESH_PROP_OP_USER_PROP_SET :
+					   BT_MESH_PROP_OP_USER_PROP_SET_UNACK);
+	net_buf_simple_add_le16(&msg, val->meta.id);
+	net_buf_simple_add_mem(&msg, val->value, val->size);
+
+	return model_ackd_send(cli->model, ctx, &msg,
+			       rsp ? &cli->ack_ctx : NULL,
+			       BT_MESH_PROP_OP_PROPS_STATUS, rsp);
+}
+
+int bt_mesh_prop_cli_admin_prop_set(struct bt_mesh_prop_cli *cli,
+				    struct bt_mesh_msg_ctx *ctx,
+				    const struct bt_mesh_prop_val *val,
+				    struct bt_mesh_prop_val *rsp)
+{
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_PROP_OP_ADMIN_PROP_SET,
+				 BT_MESH_PROP_MSG_MAXLEN_ADMIN_PROP_SET);
+
+	bt_mesh_model_msg_init(&msg,
+			       rsp ? BT_MESH_PROP_OP_ADMIN_PROP_SET :
+				     BT_MESH_PROP_OP_ADMIN_PROP_SET_UNACK);
+	net_buf_simple_add_le16(&msg, val->meta.id);
+	net_buf_simple_add_u8(&msg, val->meta.user_access);
+	net_buf_simple_add_mem(&msg, val->value, val->size);
+
+	return model_ackd_send(cli->model, ctx, &msg,
+			       rsp ? &cli->ack_ctx : NULL,
+			       BT_MESH_PROP_OP_PROPS_STATUS, rsp);
+}
+
+int bt_mesh_prop_cli_mfr_prop_set(struct bt_mesh_prop_cli *cli,
+				  struct bt_mesh_msg_ctx *ctx,
+				  const struct bt_mesh_prop *prop,
+				  struct bt_mesh_prop_val *rsp)
+{
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_PROP_OP_MFR_PROP_SET,
+				 BT_MESH_PROP_MSG_LEN_MFR_PROP_SET);
+
+	bt_mesh_model_msg_init(&msg, rsp ? BT_MESH_PROP_OP_MFR_PROP_SET :
+					   BT_MESH_PROP_OP_MFR_PROP_SET_UNACK);
+	net_buf_simple_add_le16(&msg, prop->id);
+	net_buf_simple_add_u8(&msg, prop->user_access);
+
+	return model_ackd_send(cli->model, ctx, &msg,
+			       rsp ? &cli->ack_ctx : NULL,
+			       BT_MESH_PROP_OP_PROPS_STATUS, rsp);
+}

--- a/subsys/bluetooth/mesh/gen_prop_internal.h
+++ b/subsys/bluetooth/mesh/gen_prop_internal.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/**
+ * @file
+ * @defgroup bt_mesh_prop_internal Generic Property model internals
+ * @ingroup bt_mesh_prop
+ * @{
+ * @brief Common internal API for the Generic Property models.
+ */
+
+#ifndef BT_MESH_GEN_PROP_INTERNAL_H__
+#define BT_MESH_GEN_PROP_INTERNAL_H__
+
+#include <bluetooth/mesh/gen_prop.h>
+
+/** Common opcode types for lookup */
+enum bt_mesh_prop_op_type {
+	BT_MESH_PROP_OP_PROPS_GET,
+	BT_MESH_PROP_OP_PROPS_STATUS,
+	BT_MESH_PROP_OP_PROP_GET,
+	BT_MESH_PROP_OP_PROP_SET,
+	BT_MESH_PROP_OP_PROP_SET_UNACK,
+	BT_MESH_PROP_OP_PROP_STATUS,
+};
+
+static inline enum bt_mesh_prop_srv_kind
+srv_kind(const struct bt_mesh_model *mod)
+{
+	switch (mod->id) {
+	case BT_MESH_MODEL_ID_GEN_ADMIN_PROP_SRV:
+		return BT_MESH_PROP_SRV_KIND_ADMIN;
+	case BT_MESH_MODEL_ID_GEN_MANUFACTURER_PROP_SRV:
+		return BT_MESH_PROP_SRV_KIND_MFR;
+	case BT_MESH_MODEL_ID_GEN_USER_PROP_SRV:
+		return BT_MESH_PROP_SRV_KIND_USER;
+	case BT_MESH_MODEL_ID_GEN_CLIENT_PROP_SRV:
+		return BT_MESH_PROP_SRV_KIND_CLIENT;
+	}
+	return 0;
+}
+
+static inline u32_t op_get(enum bt_mesh_prop_op_type op_type,
+			   enum bt_mesh_prop_srv_kind kind)
+{
+	u32_t offset = 0;
+
+	switch (kind) {
+	case BT_MESH_PROP_SRV_KIND_MFR:
+		offset = 0;
+		break;
+	case BT_MESH_PROP_SRV_KIND_ADMIN:
+		offset = 1;
+		break;
+	case BT_MESH_PROP_SRV_KIND_USER:
+		offset = 2;
+		break;
+	case BT_MESH_PROP_SRV_KIND_CLIENT:
+		switch (op_type) {
+		case BT_MESH_PROP_OP_PROPS_GET:
+			return BT_MESH_PROP_OP_CLIENT_PROPS_GET;
+		case BT_MESH_PROP_OP_PROPS_STATUS:
+			return BT_MESH_PROP_OP_CLIENT_PROPS_STATUS;
+		default:
+			return 0;
+		}
+		break;
+	}
+
+	switch (op_type) {
+	case BT_MESH_PROP_OP_PROPS_GET:
+	case BT_MESH_PROP_OP_PROP_GET:
+		return BT_MESH_PROP_OP_MFR_PROPS_GET + op_type + 2 * offset;
+	case BT_MESH_PROP_OP_PROPS_STATUS:
+	case BT_MESH_PROP_OP_PROP_SET:
+	case BT_MESH_PROP_OP_PROP_SET_UNACK:
+	case BT_MESH_PROP_OP_PROP_STATUS:
+		return BT_MESH_PROP_OP_MFR_PROPS_STATUS + op_type + 4 * offset;
+	}
+	return 0;
+}
+
+#endif /* BT_MESH_GEN_PROP_INTERNAL_H__ */
+
+/** @} */

--- a/subsys/bluetooth/mesh/gen_prop_srv.c
+++ b/subsys/bluetooth/mesh/gen_prop_srv.c
@@ -1,0 +1,586 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+#include <bluetooth/mesh/gen_prop_srv.h>
+#include <sys/util.h>
+#include <string.h>
+#include "gen_prop_internal.h"
+#include "model_utils.h"
+
+#define PROP_FOREACH(_srv, _prop)                                              \
+	for (_prop = &(_srv)->properties[0];                                   \
+	     _prop != &(_srv)->properties[(_srv)->property_count]; _prop++)
+
+#define IS_MFR_SRV(_mod)                                                       \
+	((_mod)->id == BT_MESH_MODEL_ID_GEN_MANUFACTURER_PROP_SRV)
+
+BUILD_ASSERT_MSG(BT_MESH_MODEL_BUF_LEN(BT_MESH_PROP_OP_MFR_PROP_STATUS,
+				       BT_MESH_PROP_MSG_MAXLEN_PROP_STATUS) <=
+			 CONFIG_BT_MESH_RX_SDU_MAX,
+		 "The property list must fit inside an application SDU.");
+BUILD_ASSERT_MSG(BT_MESH_MODEL_BUF_LEN(BT_MESH_PROP_OP_MFR_PROPS_STATUS,
+				       BT_MESH_PROP_MSG_MAXLEN_PROPS_STATUS) <=
+			 (CONFIG_BT_MESH_TX_SEG_MAX * 12),
+		 "The property value must fit inside an application SDU.");
+
+static struct bt_mesh_prop *prop_get(const struct bt_mesh_prop_srv *srv,
+				     u16_t id)
+{
+	if (!srv || id == BT_MESH_PROP_ID_PROHIBITED) {
+		return NULL;
+	}
+
+	struct bt_mesh_prop *prop;
+
+	PROP_FOREACH(srv, prop)
+	{
+		if (prop->id == id) {
+			return prop;
+		}
+	}
+
+	return NULL;
+}
+
+static void store_props(const struct bt_mesh_prop_srv *srv)
+{
+	if (!IS_ENABLED(CONFIG_BT_SETTINGS)) {
+		return;
+	}
+
+	u8_t user_access[CONFIG_BT_MESH_PROP_MAXCOUNT];
+
+	for (u8_t i = 0; i < srv->property_count; ++i) {
+		user_access[i] = srv->properties[i].user_access;
+	}
+
+	(void)bt_mesh_model_data_store(srv->mod, false, user_access,
+				       srv->property_count);
+}
+
+static void set_user_access(const struct bt_mesh_prop_srv *srv,
+			    struct bt_mesh_prop *prop,
+			    enum bt_mesh_prop_access user_access)
+{
+	enum bt_mesh_prop_access old_access = prop->user_access;
+
+	if (IS_MFR_SRV(srv->mod)) {
+		/* Cannot write to manufacturer properties */
+		user_access &= ~BT_MESH_PROP_ACCESS_WRITE;
+	}
+
+	prop->user_access = user_access;
+
+	if (old_access != user_access) {
+		store_props(srv);
+	}
+}
+
+static void pub_list_build(const struct bt_mesh_prop_srv *srv,
+			   struct net_buf_simple *buf)
+{
+	bt_mesh_model_msg_init(buf, op_get(BT_MESH_PROP_OP_PROPS_STATUS,
+					   srv_kind(srv->mod)));
+
+	struct bt_mesh_prop *prop;
+
+	PROP_FOREACH(srv, prop)
+	{
+		net_buf_simple_add_le16(buf, prop->id);
+	}
+}
+
+/* Owner properties */
+
+static void handle_owner_properties_get(struct bt_mesh_model *mod,
+					struct bt_mesh_msg_ctx *ctx,
+					struct net_buf_simple *buf)
+{
+	if (buf->len != BT_MESH_PROP_MSG_LEN_PROPS_GET) {
+		return;
+	}
+
+	BT_MESH_MODEL_BUF_DEFINE(rsp, BT_MESH_PROP_OP_ADMIN_PROPS_STATUS,
+				 BT_MESH_PROP_MSG_MAXLEN_PROPS_STATUS);
+
+	pub_list_build(mod->user_data, &rsp);
+	bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
+}
+
+static void handle_owner_property_get(struct bt_mesh_model *mod,
+				      struct bt_mesh_msg_ctx *ctx,
+				      struct net_buf_simple *buf)
+{
+	if (buf->len != BT_MESH_PROP_MSG_LEN_PROP_GET) {
+		return;
+	}
+
+	struct bt_mesh_prop_srv *srv = mod->user_data;
+	u16_t id = net_buf_simple_pull_le16(buf);
+	const struct bt_mesh_prop *prop = prop_get(srv, id);
+
+	BT_MESH_MODEL_BUF_DEFINE(rsp, BT_MESH_PROP_OP_ADMIN_PROP_STATUS,
+				 BT_MESH_PROP_MSG_MAXLEN_PROP_STATUS);
+
+	bt_mesh_model_msg_init(&rsp, op_get(BT_MESH_PROP_OP_PROP_STATUS,
+					    srv_kind(mod)));
+	net_buf_simple_add_le16(&rsp, id);
+
+	if (!prop) {
+		/* If the prop doesn't exist, we should only send the ID as a
+		 * response.
+		 */
+		goto respond;
+	}
+
+	net_buf_simple_add_u8(&rsp, prop->user_access);
+
+	struct bt_mesh_prop_val value = {
+		.meta = *prop,
+		.value = net_buf_simple_tail(&rsp),
+		.size = CONFIG_BT_MESH_PROP_MAXSIZE,
+	};
+
+	srv->get(srv, ctx, &value);
+
+	net_buf_simple_add(&rsp, value.size);
+
+respond:
+	bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
+}
+
+static void owner_property_set(struct bt_mesh_model *mod,
+			       struct bt_mesh_msg_ctx *ctx,
+			       struct net_buf_simple *buf, bool ack)
+{
+	if ((IS_MFR_SRV(mod) && (buf->len != 3)) ||
+	    (buf->len > BT_MESH_PROP_MSG_MAXLEN_ADMIN_PROP_SET ||
+	     buf->len < BT_MESH_PROP_MSG_MINLEN_ADMIN_PROP_SET)) {
+		return;
+	}
+
+	struct bt_mesh_prop_srv *srv = mod->user_data;
+	u16_t id = net_buf_simple_pull_le16(buf);
+	enum bt_mesh_prop_access user_access = net_buf_simple_pull_u8(buf);
+
+	BT_MESH_MODEL_BUF_DEFINE(rsp, BT_MESH_PROP_OP_ADMIN_PROP_STATUS,
+				 BT_MESH_PROP_MSG_MAXLEN_PROP_STATUS);
+
+	bt_mesh_model_msg_init(&rsp, op_get(BT_MESH_PROP_OP_PROP_STATUS,
+					    srv_kind(mod)));
+	net_buf_simple_add_le16(&rsp, id);
+
+	struct bt_mesh_prop *prop = prop_get(srv, id);
+
+	if (!prop) {
+		/* If the prop doesn't exist, we should only send the ID as a
+		 * response.
+		 */
+		goto respond;
+	}
+
+	set_user_access(srv, prop, user_access);
+
+	net_buf_simple_add_u8(&rsp, prop->user_access);
+
+	struct bt_mesh_prop_val value = {
+		.meta = *prop,
+		.value = net_buf_simple_tail(&rsp),
+	};
+
+	if (IS_MFR_SRV(mod)) {
+		if (!ack) {
+			return;
+		}
+
+		/* Since the manufacturer properties can't be set, we'll just
+		 * call the getter to fetch the response value.
+		 */
+		value.size = CONFIG_BT_MESH_PROP_MAXSIZE;
+		srv->get(srv, ctx, &value);
+	} else {
+		value.size = buf->len;
+		memcpy(value.value, net_buf_simple_pull_mem(buf, value.size),
+		       value.size);
+		srv->set(srv, ctx, &value);
+	}
+
+	net_buf_simple_add(&rsp, value.size);
+
+respond:
+	if (ack) {
+		bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
+	}
+}
+
+static void handle_owner_property_set(struct bt_mesh_model *mod,
+				      struct bt_mesh_msg_ctx *ctx,
+				      struct net_buf_simple *buf)
+{
+	owner_property_set(mod, ctx, buf, true);
+}
+
+static void handle_owner_property_set_unack(struct bt_mesh_model *mod,
+					    struct bt_mesh_msg_ctx *ctx,
+					    struct net_buf_simple *buf)
+{
+	owner_property_set(mod, ctx, buf, false);
+}
+
+const struct bt_mesh_model_op _bt_mesh_prop_admin_srv_op[] = {
+	{ BT_MESH_PROP_OP_ADMIN_PROPS_GET, BT_MESH_PROP_MSG_LEN_PROPS_GET,
+	  handle_owner_properties_get },
+	{ BT_MESH_PROP_OP_ADMIN_PROP_GET, BT_MESH_PROP_MSG_LEN_PROP_GET,
+	  handle_owner_property_get },
+	{ BT_MESH_PROP_OP_ADMIN_PROP_SET,
+	  BT_MESH_PROP_MSG_MINLEN_ADMIN_PROP_SET, handle_owner_property_set },
+	{ BT_MESH_PROP_OP_ADMIN_PROP_SET_UNACK,
+	  BT_MESH_PROP_MSG_MINLEN_ADMIN_PROP_SET,
+	  handle_owner_property_set_unack },
+	BT_MESH_MODEL_OP_END,
+};
+
+const struct bt_mesh_model_op _bt_mesh_prop_mfr_srv_op[] = {
+	{ BT_MESH_PROP_OP_MFR_PROPS_GET, BT_MESH_PROP_MSG_LEN_PROPS_GET,
+	  handle_owner_properties_get },
+	{ BT_MESH_PROP_OP_MFR_PROP_GET, BT_MESH_PROP_MSG_LEN_PROP_GET,
+	  handle_owner_property_get },
+	{ BT_MESH_PROP_OP_MFR_PROP_SET, BT_MESH_PROP_MSG_LEN_MFR_PROP_SET,
+	  handle_owner_property_set },
+	{ BT_MESH_PROP_OP_MFR_PROP_SET_UNACK, BT_MESH_PROP_MSG_LEN_MFR_PROP_SET,
+	  handle_owner_property_set_unack },
+	BT_MESH_MODEL_OP_END,
+};
+
+const struct bt_mesh_model_op _bt_mesh_prop_client_srv_op[] = {
+	{ BT_MESH_PROP_OP_CLIENT_PROPS_GET, BT_MESH_PROP_MSG_LEN_PROPS_GET,
+	  handle_owner_properties_get },
+	BT_MESH_MODEL_OP_END,
+};
+
+/* User properties */
+
+static struct bt_mesh_prop_srv *prop_srv_get(struct bt_mesh_model *user_srv_mod,
+					     u16_t model_id)
+{
+	struct bt_mesh_model *mod =
+		bt_mesh_model_find(bt_mesh_model_elem(user_srv_mod), model_id);
+
+	return mod ? mod->user_data : NULL;
+}
+
+static struct bt_mesh_prop *user_prop_get(struct bt_mesh_model *mod, u16_t id,
+					  struct bt_mesh_prop_srv **srv)
+{
+	struct bt_mesh_prop_srv *const srvs[] = {
+		prop_srv_get(mod, BT_MESH_MODEL_ID_GEN_MANUFACTURER_PROP_SRV),
+		prop_srv_get(mod, BT_MESH_MODEL_ID_GEN_ADMIN_PROP_SRV),
+	};
+
+	for (int i = 0; i < ARRAY_SIZE(srvs); ++i) {
+		struct bt_mesh_prop *prop = prop_get(srvs[i], id);
+
+		if (prop &&
+		    prop->user_access != BT_MESH_PROP_ACCESS_PROHIBITED) {
+			*srv = srvs[i];
+			return prop;
+		}
+	}
+
+	*srv = NULL;
+	return NULL;
+}
+
+static void handle_user_properties_get(struct bt_mesh_model *mod,
+				       struct bt_mesh_msg_ctx *ctx,
+				       struct net_buf_simple *buf)
+{
+	if (buf->len != BT_MESH_PROP_MSG_LEN_PROPS_GET) {
+		return;
+	}
+
+	BT_MESH_MODEL_BUF_DEFINE(rsp, BT_MESH_PROP_OP_PROPS_STATUS,
+				 BT_MESH_PROP_MSG_MAXLEN_PROPS_STATUS);
+
+	bt_mesh_model_msg_init(&rsp, BT_MESH_PROP_OP_USER_PROPS_STATUS);
+
+	const struct bt_mesh_prop_srv *srvs[] = {
+		prop_srv_get(mod, BT_MESH_MODEL_ID_GEN_MANUFACTURER_PROP_SRV),
+		prop_srv_get(mod, BT_MESH_MODEL_ID_GEN_ADMIN_PROP_SRV),
+	};
+
+	for (int i = 0; i < ARRAY_SIZE(srvs); ++i) {
+		if (!srvs[i]) {
+			continue;
+		}
+
+		struct bt_mesh_prop *prop;
+
+		PROP_FOREACH(srvs[i], prop)
+		{
+			if (net_buf_simple_tailroom(&rsp) < 6) {
+				break;
+			}
+
+			if (prop->user_access ==
+			    BT_MESH_PROP_ACCESS_PROHIBITED) {
+				continue;
+			}
+
+			net_buf_simple_add_le16(&rsp, prop->id);
+		}
+	}
+
+	bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
+}
+
+static void handle_user_property_get(struct bt_mesh_model *mod,
+				     struct bt_mesh_msg_ctx *ctx,
+				     struct net_buf_simple *buf)
+{
+	if (buf->len != BT_MESH_PROP_MSG_LEN_PROP_GET) {
+		return;
+	}
+
+	u16_t id = net_buf_simple_pull_le16(buf);
+
+	BT_MESH_MODEL_BUF_DEFINE(rsp, BT_MESH_PROP_OP_USER_PROP_STATUS,
+				 BT_MESH_PROP_MSG_MAXLEN_PROP_STATUS);
+
+	bt_mesh_model_msg_init(&rsp, BT_MESH_PROP_OP_USER_PROP_STATUS);
+	net_buf_simple_add_le16(&rsp, id);
+
+	struct bt_mesh_prop_srv *srv;
+	struct bt_mesh_prop *prop = user_prop_get(mod, id, &srv);
+
+	if (!prop) {
+		/* If the prop doesn't exist, we should only send the ID as a
+		 * response.
+		 */
+		goto respond;
+	}
+
+	net_buf_simple_add_u8(&rsp, prop->user_access);
+
+	if (!(prop->user_access & BT_MESH_PROP_ACCESS_READ)) {
+		goto respond;
+	}
+
+	struct bt_mesh_prop_val value = {
+		.meta = *prop,
+		.value = net_buf_simple_tail(&rsp),
+		.size = CONFIG_BT_MESH_PROP_MAXSIZE,
+	};
+
+	srv->get(srv, ctx, &value);
+
+	net_buf_simple_add(&rsp, value.size);
+
+respond:
+	bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
+}
+
+static void user_property_set(struct bt_mesh_model *mod,
+			      struct bt_mesh_msg_ctx *ctx,
+			      struct net_buf_simple *buf, bool ack)
+{
+	if (buf->len < BT_MESH_PROP_MSG_MINLEN_USER_PROP_SET ||
+	    buf->len > BT_MESH_PROP_MSG_MAXLEN_USER_PROP_SET) {
+		return;
+	}
+
+	u16_t id = net_buf_simple_pull_le16(buf);
+
+	BT_MESH_MODEL_BUF_DEFINE(rsp, BT_MESH_PROP_OP_USER_PROP_STATUS,
+				 BT_MESH_PROP_MSG_MAXLEN_PROP_STATUS);
+
+	bt_mesh_model_msg_init(&rsp, BT_MESH_PROP_OP_USER_PROP_STATUS);
+
+	net_buf_simple_add_le16(&rsp, id);
+
+	struct bt_mesh_prop_srv *srv;
+	struct bt_mesh_prop *prop = user_prop_get(mod, id, &srv);
+
+	if (!prop) {
+		/* If the prop doesn't exist, we should only send the ID as a
+		 * response.
+		 */
+		goto respond;
+	}
+
+	net_buf_simple_add_u8(&rsp, prop->user_access);
+
+	if (!(prop->user_access & BT_MESH_PROP_ACCESS_WRITE) ||
+	    IS_MFR_SRV(srv->mod)) {
+		goto respond;
+	}
+
+	struct bt_mesh_prop_val value = {
+		.meta = *prop,
+		.value = net_buf_simple_tail(&rsp),
+		.size = buf->len,
+	};
+
+	memcpy(value.value, net_buf_simple_pull_mem(buf, value.size),
+	       value.size);
+
+	srv->set(srv, ctx, &value);
+
+	net_buf_simple_add(&rsp, value.size);
+
+respond:
+	if (ack) {
+		bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
+	}
+}
+
+static void handle_user_property_set(struct bt_mesh_model *mod,
+				     struct bt_mesh_msg_ctx *ctx,
+				     struct net_buf_simple *buf)
+{
+	user_property_set(mod, ctx, buf, true);
+}
+
+static void handle_user_property_set_unack(struct bt_mesh_model *mod,
+					   struct bt_mesh_msg_ctx *ctx,
+					   struct net_buf_simple *buf)
+{
+	user_property_set(mod, ctx, buf, false);
+}
+
+const struct bt_mesh_model_op _bt_mesh_prop_user_srv_op[] = {
+	{ BT_MESH_PROP_OP_USER_PROPS_GET, 0, handle_user_properties_get },
+	{ BT_MESH_PROP_OP_USER_PROP_GET, 2, handle_user_property_get },
+	{ BT_MESH_PROP_OP_USER_PROP_SET, 2, handle_user_property_set },
+	{ BT_MESH_PROP_OP_USER_PROP_SET_UNACK, 2,
+	  handle_user_property_set_unack },
+	BT_MESH_MODEL_OP_END,
+};
+
+static int bt_mesh_prop_srv_init(struct bt_mesh_model *mod)
+{
+	struct bt_mesh_prop_srv *srv = mod->user_data;
+
+	srv->mod = mod;
+
+	if (IS_MFR_SRV(mod)) {
+		/* Manufacturer properties aren't writable */
+		struct bt_mesh_prop *prop;
+
+		PROP_FOREACH(srv, prop)
+		{
+			prop->user_access &= ~BT_MESH_PROP_ACCESS_WRITE;
+		}
+	}
+	return 0;
+}
+
+#ifdef CONFIG_BT_SETTINGS
+static int bt_mesh_prop_srv_settings_set(struct bt_mesh_model *model,
+					 size_t len_rd,
+					 settings_read_cb read_cb, void *cb_arg)
+{
+	struct bt_mesh_prop_srv *srv = model->user_data;
+	u8_t entries[CONFIG_BT_MESH_PROP_MAXCOUNT];
+	ssize_t size = MIN(sizeof(entries), len_rd);
+
+	size = read_cb(cb_arg, &entries, size);
+
+	if (size < srv->property_count) {
+		return -EINVAL;
+	}
+
+	for (u8_t i = 0; i < srv->property_count; ++i) {
+		srv->properties[i].user_access = entries[i];
+	}
+
+	return 0;
+}
+#endif
+
+const struct bt_mesh_model_cb _bt_mesh_prop_srv_cb = {
+	.init = bt_mesh_prop_srv_init,
+#ifdef CONFIG_BT_SETTINGS
+	.settings_set = bt_mesh_prop_srv_settings_set,
+#endif
+};
+
+int _bt_mesh_prop_srv_update_handler(struct bt_mesh_model *mod)
+{
+	struct bt_mesh_prop_srv *srv = mod->user_data;
+	struct bt_mesh_prop_val value;
+	struct bt_mesh_prop *prop;
+
+	switch (srv->pub_state) {
+	case BT_MESH_PROP_SRV_STATE_NONE:
+		return 0;
+	case BT_MESH_PROP_SRV_STATE_LIST:
+		pub_list_build(srv, srv->pub.msg);
+		return 0;
+	case BT_MESH_PROP_SRV_STATE_PROP:
+		bt_mesh_model_msg_init(srv->pub.msg,
+				       op_get(BT_MESH_PROP_OP_PROP_STATUS,
+					      srv_kind(mod)));
+		net_buf_simple_add_le16(srv->pub.msg, srv->pub_id);
+
+		prop = prop_get(srv, srv->pub_id);
+		if (!prop) {
+			return -ENOENT;
+		}
+
+		net_buf_simple_add_u8(srv->pub.msg, prop->user_access);
+
+		value.meta = *prop;
+		value.value = net_buf_simple_tail(srv->pub.msg);
+		value.size = CONFIG_BT_MESH_PROP_MAXSIZE;
+
+		srv->get(srv, NULL, &value);
+
+		net_buf_simple_add(srv->pub.msg, value.size);
+	}
+
+	return 0;
+}
+
+int bt_mesh_prop_srv_pub_list(struct bt_mesh_prop_srv *srv,
+			      struct bt_mesh_msg_ctx *ctx)
+{
+	srv->pub_id = 0;
+	srv->pub_state = BT_MESH_PROP_SRV_STATE_LIST;
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_PROP_OP_MFR_PROPS_STATUS,
+				 BT_MESH_PROP_MSG_MAXLEN_PROPS_STATUS);
+
+	pub_list_build(srv, &msg);
+
+	return model_send(srv->mod, ctx, &msg);
+}
+
+int bt_mesh_prop_srv_pub(struct bt_mesh_prop_srv *srv,
+			 struct bt_mesh_msg_ctx *ctx,
+			 const struct bt_mesh_prop_val *val)
+{
+	if (srv->mod->id == BT_MESH_MODEL_ID_GEN_CLIENT_PROP_SRV) {
+		return -EINVAL;
+	}
+
+	if (val->size > CONFIG_BT_MESH_PROP_MAXSIZE) {
+		return -EMSGSIZE;
+	}
+
+	srv->pub_id = val->meta.id;
+	srv->pub_state = BT_MESH_PROP_SRV_STATE_PROP;
+
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_PROP_OP_ADMIN_PROP_STATUS,
+				 BT_MESH_PROP_MSG_MAXLEN_PROP_STATUS);
+
+	bt_mesh_model_msg_init(&msg, op_get(BT_MESH_PROP_OP_PROP_STATUS,
+					    srv_kind(srv->mod)));
+
+	net_buf_simple_add_le16(&msg, val->meta.id);
+	net_buf_simple_add_u8(&msg, val->meta.user_access);
+	net_buf_simple_add_mem(&msg, val->value, val->size);
+
+	return model_send(srv->mod, ctx, &msg);
+}

--- a/subsys/bluetooth/mesh/model_utils.c
+++ b/subsys/bluetooth/mesh/model_utils.c
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+#include <bluetooth/mesh/models.h>
+#include "model_utils.h"
+
+/** Unknown encoded transition time value */
+#define TRANSITION_TIME_UNKNOWN (0x3F)
+
+/** Delay field step factor in milliseconds */
+#define DELAY_TIME_STEP_MS (5)
+/** Maximum encoded value of the delay field */
+#define DELAY_TIME_STEP_MAX (0xFF)
+/** Maximum permisible delay time in milliseconds */
+#define DELAY_TIME_MAX_MS (DELAY_TIME_STEP_MAX * DELAY_TIME_STEP_FACTOR_MS)
+
+#define MOD_ACKD_TIMEOUT_BASE 200
+#define MOD_ACKD_TIMEOUT_PER_HOP 50
+
+int tid_check_and_update(struct bt_mesh_tid_ctx *prev_transaction, u8_t tid,
+			 const struct bt_mesh_msg_ctx *ctx)
+{
+	/* This updates the timestamp in the progress: */
+	s64_t uptime_delta = k_uptime_delta(&prev_transaction->timestamp);
+
+	if (prev_transaction->src == ctx->addr &&
+	    prev_transaction->dst == ctx->recv_dst &&
+	    prev_transaction->tid == tid && uptime_delta < 6000) {
+		return -EALREADY;
+	}
+
+	prev_transaction->src = ctx->addr;
+	prev_transaction->dst = ctx->recv_dst;
+	prev_transaction->tid = tid;
+
+	return 0;
+}
+
+static const u32_t model_transition_res[] = {
+	K_MSEC(100),
+	K_SECONDS(1),
+	K_SECONDS(10),
+	K_MINUTES(10),
+};
+
+s32_t model_transition_decode(u8_t encoded_transition)
+{
+	u8_t steps = (encoded_transition & 0x3f);
+	u8_t res = (encoded_transition >> 6);
+
+	return (steps == TRANSITION_TIME_UNKNOWN) ?
+		       K_FOREVER :
+		       (model_transition_res[res] * steps);
+}
+
+u8_t model_transition_encode(s32_t transition_time)
+{
+	if (transition_time == 0) {
+		return 0;
+	}
+	if (transition_time == K_FOREVER) {
+		return TRANSITION_TIME_UNKNOWN;
+	}
+
+	/* Even though we're only able to encode values up to 6200 ms in
+	 * 100 ms step resolution, values between 6200 and 6600 ms are closer
+	 * to 6200 ms than 7000 ms, which would be the nearest 1-second step
+	 * representation. Similar cases exist for the other step resolutions
+	 * too, so we'll use these custom limits instead of checking against
+	 * the max value of each step resolution. The formula for the limit is
+	 * ((0x3e * res[i]) + (((0x3e * res[i]) / res[i+1]) + 1) * res[i+1])/2.
+	 */
+	const s32_t limits[] = {
+		K_MSEC(6600),
+		K_SECONDS(66),
+		K_SECONDS(910),
+		K_MINUTES(620),
+	};
+
+	for (u8_t i = 0; i < ARRAY_SIZE(model_transition_res); ++i) {
+		if (transition_time > limits[i]) {
+			continue;
+		}
+
+		u8_t steps = ((transition_time + model_transition_res[i] / 2) /
+			      model_transition_res[i]);
+		steps = MAX(1, steps);
+		steps = MIN(0x3e, steps);
+		return (i << 6) | steps;
+	}
+
+	return TRANSITION_TIME_UNKNOWN;
+}
+
+u8_t model_delay_encode(u32_t delay)
+{
+	return delay / DELAY_TIME_STEP_MS;
+}
+
+s32_t model_delay_decode(u8_t encoded_delay)
+{
+	return encoded_delay * 5;
+}
+
+int model_send(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+	       struct net_buf_simple *buf)
+{
+	if (!ctx && !mod->pub) {
+		return -ENOTSUP;
+	}
+
+	if (ctx) {
+		return bt_mesh_model_send(mod, ctx, buf, NULL, 0);
+	}
+
+	net_buf_simple_reset(mod->pub->msg);
+	memcpy(net_buf_simple_add(mod->pub->msg, buf->len), buf->data,
+	       buf->len);
+	return bt_mesh_model_publish(mod);
+}
+
+int model_ackd_send(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+		    struct net_buf_simple *buf,
+		    struct bt_mesh_model_ack_ctx *ack, u32_t rsp_op,
+		    void *user_data)
+{
+	if (ack &&
+	    model_ack_ctx_prepare(ack, rsp_op, ctx ? ctx->addr : mod->pub->addr,
+				  user_data) != 0) {
+		return -EALREADY;
+	}
+
+	int retval = model_send(mod, ctx, buf);
+
+	if (ack) {
+		if (retval == 0) {
+			u8_t ttl = (ctx ? ctx->send_ttl : mod->pub->ttl);
+			s32_t time = (MOD_ACKD_TIMEOUT_BASE +
+				      ttl * MOD_ACKD_TIMEOUT_PER_HOP);
+			return model_ack_wait(ack, time);
+		}
+
+		model_ack_clear(ack);
+	}
+	return retval;
+}

--- a/subsys/bluetooth/mesh/model_utils.h
+++ b/subsys/bluetooth/mesh/model_utils.h
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+/**
+ * @file
+ * @defgroup bt_mesh_model_utils Model utility functions.
+ * @{
+ * @brief Internal utility functions for mesh model implementations.
+ */
+#ifndef MODEL_UTILS_H__
+#define MODEL_UTILS_H__
+
+#include <string.h>
+#include <bluetooth/mesh/model_types.h>
+
+/** @brief Send a model message.
+ *
+ * Sends a model message with the given context. If the context is NULL, this
+ * updates the publish message, and publishes with the configured parameters.
+ *
+ * @param mod Model to send on.
+ * @param ctx Context to send with, or NULL to publish on the configured
+ * publish parameters.
+ * @param buf Message to send.
+ *
+ * @retval 0 The message was sent successfully.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ */
+int model_send(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+	       struct net_buf_simple *buf);
+
+/** @brief Send an acknowledged model message.
+ *
+ * If a message context is not provided, the message is published using the
+ * model's configured publish parameters, if supported. If a response context
+ * is provided, the call is blocking until the response context is either
+ * released or the request times out.
+ *
+ * If a response context is provided, the call blocks for
+ * 200 + TTL * 50 milliseconds, or until the acknowledgment is received.
+ *
+ * @param mod Model to send the message on.
+ * @param ctx Message context, or NULL to send with the configured publish
+ * parameters.
+ * @param buf Message to send.
+ * @param ack Message response context, or NULL if no response is expected.
+ * @param rsp_op Expected response opcode.
+ * @param user_data User defined parameter.
+ *
+ * @retval 0 The message was sent successfully.
+ * @retval -EALREADY A blocking request is already in progress.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
+ */
+int model_ackd_send(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+		    struct net_buf_simple *buf,
+		    struct bt_mesh_model_ack_ctx *ack, u32_t rsp_op,
+		    void *user_data);
+
+static inline int model_ack_ctx_prepare(struct bt_mesh_model_ack_ctx *ack,
+					u32_t op, u16_t dst, void *user_data)
+{
+	if (ack->op != 0) {
+		return -EALREADY;
+	}
+	ack->op = op;
+	ack->user_data = user_data;
+	ack->dst = dst;
+	return 0;
+}
+
+static inline bool model_ack_match(const struct bt_mesh_model_ack_ctx *ack_ctx,
+				   u32_t op,
+				   const struct bt_mesh_msg_ctx *msg_ctx)
+{
+	return (ack_ctx->op == op &&
+		(ack_ctx->dst == msg_ctx->addr || ack_ctx->dst == 0));
+}
+
+static inline int model_ack_wait(struct bt_mesh_model_ack_ctx *ack,
+				 s32_t timeout)
+{
+	int status = k_sem_take(&ack->sem, timeout);
+
+	ack->op = 0;
+	return status;
+}
+
+static inline bool model_ack_busy(struct bt_mesh_model_ack_ctx *ack)
+{
+	return (ack->op != 0);
+}
+
+static inline void model_ack_rx(struct bt_mesh_model_ack_ctx *ack)
+{
+	k_sem_give(&ack->sem);
+}
+
+static inline void model_ack_clear(struct bt_mesh_model_ack_ctx *ack)
+{
+	ack->op = 0;
+}
+
+/** @brief Compare the TID of an incoming message with the previous
+ * transaction, and update it if it's new.
+ *
+ * @param prev_transaction Previous transaction.
+ * @param tid Transaction ID of the incoming message.
+ * @param ctx Message context of the incoming message.
+ *
+ * @retval 0 The TID is new, and the @p prev_transaction structure has been
+ * updated.
+ * @retval -EAGAIN The incoming message is of the same transaction.
+ */
+int tid_check_and_update(struct bt_mesh_tid_ctx *prev_transaction, u8_t tid,
+			 const struct bt_mesh_msg_ctx *ctx);
+
+u8_t model_delay_encode(u32_t delay);
+s32_t model_delay_decode(u8_t encoded_delay);
+s32_t model_transition_decode(u8_t encoded_transition);
+u8_t model_transition_encode(s32_t transition_time);
+
+static inline void
+model_transition_buf_add(struct net_buf_simple *buf,
+			 const struct bt_mesh_model_transition *transition)
+{
+	net_buf_simple_add_u8(buf, model_transition_encode(transition->time));
+	net_buf_simple_add_u8(buf, model_delay_encode(transition->delay));
+}
+
+static inline void
+model_transition_buf_pull(struct net_buf_simple *buf,
+			  struct bt_mesh_model_transition *transition)
+{
+	transition->time = model_transition_decode(net_buf_simple_pull_u8(buf));
+	transition->delay = model_delay_decode(net_buf_simple_pull_u8(buf));
+}
+
+static inline bool
+model_transition_is_active(const struct bt_mesh_model_transition *transition)
+{
+	return (transition->time > 0 || transition->delay > 0);
+}
+
+#endif /* MODEL_UTILS_H__ */
+
+/** @} */


### PR DESCRIPTION
Establishes the bluetooth/mesh subsystem, adding implementations of all generic models. 

## Models in the specification 

Models are the GATT Services of the Bluetooth Mesh. Each model defines a specific behavior, like setting a power level or reporting the battery status of a device.

Each model type typically has a client and a server, where the server normally holds a set of states, that the client can access across the mesh, similar to Bluetooth GATT services. Models can extend other models (see for instance the ponoff server), which makes them inherit the states, opcodes and behavior of the extended model. When a model extends another, the model's states may be "bound" (see for instance the plvl server). Changes to a bound state is reflected in the other states in the binding.

## General model design:

The model design is based on the model design in the nRF5 SDK for Mesh with minor modifications to make it fit the Zephyr Mesh API. It only handles model message encoding and decoding, as well as internal housekeeping for the model. Integration with drivers and other modules is left for the application.

Each model type has three interface header files:
- A common header: `include/bluetooth/mesh/<model-name>.h`
- A server model header: `include/bluetooth/mesh/<model-name>_srv.h`
- A client model header: `include/bluetooth/mesh/<model-name>_cli.h`

Every model instance requires a separate context struct for housekeeping. The memory for the states of the model are generally owned by the application, and the model interacts with this state through a set of callbacks. 

To include a model, the application must define a set of handler functions, initialize a context struct instance, and add an entry in the mesh composition data:

```C
void onoff_set();
void onoff_get();

const struct gen_onoff_srv_handlers handlers = {
	.set = onoff_set,
	.get = onoff_get,
};

static struct gen_onoff_srv srv = GEN_ONOFF_SRV(&handlers);

static struct bt_mesh_model sig_models[] = {
	BT_MESH_MODEL_GEN_ONOFF_SRV(&srv),
	// ...
};
```

Example applications will come in separate PRs.