### PR TITLE
lib: at_host: Rework AT command buffer behaviour

### DIFF
--- a/lib/at_host/Kconfig
+++ b/lib/at_host/Kconfig
@@ -67,6 +67,21 @@ config AT_HOST_TERMINATION
 	default 2 if LF_TERMINATION
 	default 3 if CR_LF_TERMINATION
 
+config AT_HOST_CMD_MAX_LEN
+	int "Maximum AT command length"
+	help
+		The maximum allowed length of an AT command passed through the
+		AT host. The space is allocated statically.
+		This limit is in turn limited by bsdlib's BSD_AT_MAX_CMD_SIZE.
+	range 0 4096
+	default 4096
+
+config AT_HOST_THREAD_PRIO
+	int "AT host workqueue thread priority level"
+	range 0 NUM_PREEMPT_PRIORITIES
+	default 0 if !MULTITHREADING
+	default 10
+
 module = AT_HOST
 module-str = AT host
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"

--- a/lib/at_host/at_host.c
+++ b/lib/at_host/at_host.c
@@ -15,6 +15,10 @@
 
 LOG_MODULE_REGISTER(at_host, CONFIG_AT_HOST_LOG_LEVEL);
 
+/* Stack definition for AT host workqueue */
+#define AT_HOST_STACK_SIZE 512
+K_THREAD_STACK_DEFINE(at_host_stack_area, AT_HOST_STACK_SIZE);
+
 #define CONFIG_UART_0_NAME      "UART_0"
 #define CONFIG_UART_1_NAME      "UART_1"
 #define CONFIG_UART_2_NAME      "UART_2"
@@ -24,7 +28,11 @@ LOG_MODULE_REGISTER(at_host, CONFIG_AT_HOST_LOG_LEVEL);
 #define OK_STR    "OK\r\n"
 #define ERROR_STR "ERROR\r\n"
 
-#define AT_MAX_CMD_LEN		CONFIG_AT_CMD_RESPONSE_MAX_LEN
+#if CONFIG_AT_HOST_CMD_MAX_LEN > CONFIG_AT_CMD_RESPONSE_MAX_LEN
+#define AT_BUF_SIZE CONFIG_AT_HOST_CMD_MAX_LEN
+#else
+#define AT_BUF_SIZE CONFIG_AT_CMD_RESPONSE_MAX_LEN
+#endif
 
 /** @brief Termination Modes. */
 enum term_modes {
@@ -45,63 +53,57 @@ enum select_uart {
 
 static enum term_modes term_mode;
 static struct device *uart_dev;
-static u8_t at_buf[AT_MAX_CMD_LEN];
-static size_t at_buf_len;
+static char at_buf[AT_BUF_SIZE]; /* AT command and modem response buffer */
+static struct k_work_q at_host_work_q;
 static struct k_work cmd_send_work;
-static const char termination[3] = { '\0', '\r', '\n' };
 
 
 
-static inline void write_uart_string(char *str, size_t len)
+static inline void write_uart_string(char *str)
 {
-	for (size_t i = 0; i < len; i++) {
+	/* Send characters until, but not including, null */
+	for (size_t i = 0; str[i]; i++) {
 		uart_poll_out(uart_dev, str[i]);
 	}
 }
 
 static void response_handler(char *response)
 {
-	int len = strlen(response) + 1;
 	/* Forward the data over UART */
-	if (len > 1) {
-		write_uart_string(response, len);
-	}
+	write_uart_string(response);
 }
 
 static void cmd_send(struct k_work *work)
 {
-	size_t            chars;
-	char              str[15];
-	static char       buf[AT_MAX_CMD_LEN];
+	char              str[19];
 	enum at_cmd_state state;
 	int               err;
 
 	ARG_UNUSED(work);
 
-	/* Make sure the string is 0-terminated */
-	at_buf[MIN(at_buf_len, AT_MAX_CMD_LEN - 1)] = 0;
-
-	err = at_cmd_write(at_buf, buf, AT_MAX_CMD_LEN, &state);
+	err = at_cmd_write(at_buf, at_buf,
+			   sizeof(at_buf), &state);
 	if (err < 0) {
-		LOG_ERR("Could not send AT command to modem: %d", err);
+		LOG_ERR("Error while processing AT command: %d", err);
 		state = AT_CMD_ERROR;
 	}
 
+	/* Handle the various error responses from modem */
 	switch (state) {
 	case AT_CMD_OK:
-		write_uart_string(buf, strlen(buf));
-		write_uart_string(OK_STR, sizeof(OK_STR));
+		write_uart_string(at_buf);
+		write_uart_string(OK_STR);
 		break;
 	case AT_CMD_ERROR:
-		write_uart_string(ERROR_STR, sizeof(ERROR_STR));
+		write_uart_string(ERROR_STR);
 		break;
 	case AT_CMD_ERROR_CMS:
-		chars = sprintf(str, "+CMS: %d\r\n", err);
-		write_uart_string(str, ++chars);
+		sprintf(str, "+CMS: %d\r\n", err);
+		write_uart_string(str);
 		break;
 	case AT_CMD_ERROR_CME:
-		chars = sprintf(str, "+CME: %d\r\n", err);
-		write_uart_string(str, ++chars);
+		sprintf(str, "+CME: %d\r\n", err);
+		write_uart_string(str);
 		break;
 	default:
 		break;
@@ -112,76 +114,81 @@ static void cmd_send(struct k_work *work)
 
 static void uart_rx_handler(u8_t character)
 {
+	static bool cr_state; /* Whether last character received was a <CR> */
 	static bool inside_quotes;
-	static size_t cmd_len;
-	size_t pos;
+	static size_t at_cmd_len;
 
-	cmd_len += 1;
-	pos = cmd_len - 1;
-
-	/* Handle special characters. */
+	/* Handle control characters */
 	switch (character) {
 	case 0x08: /* Backspace. */
 		/* Fall through. */
 	case 0x7F: /* DEL character */
-		pos = pos ? pos - 1 : 0;
-		at_buf[pos] = 0;
-		cmd_len = cmd_len <= 1 ? 0 : cmd_len - 2;
-		break;
-	case '"':
-		inside_quotes = !inside_quotes;
-		 /* Fall through. */
-	default:
-		/* Detect AT command buffer overflow or zero length */
-		if (cmd_len > AT_MAX_CMD_LEN) {
-			LOG_ERR("Buffer overflow, dropping '%c'\n", character);
-			cmd_len = AT_MAX_CMD_LEN;
-			return;
-		} else if (cmd_len < 1) {
-			LOG_ERR("Invalid AT command length: %d", cmd_len);
-			cmd_len = 0;
-			return;
+		if (at_cmd_len > 0) {
+			at_cmd_len--;
 		}
-
-		at_buf[pos] = character;
-		break;
-	}
-
-	if (inside_quotes) {
 		return;
 	}
 
-	/* Check if the character marks line termination. */
-	switch (term_mode) {
-	case MODE_NULL_TERM:
-		/* Fall through. */
-	case MODE_CR:
-		if (character == termination[term_mode]) {
-			goto send;
+	/*
+	 * Handle termination characters, if outside quotes.
+	 * The characters are never written to buffer unless inside quotes.
+	 */
+	if (!inside_quotes) {
+		switch (character) {
+		case '\0':
+			if (term_mode == MODE_NULL_TERM) {
+				goto send;
+			}
+			return;
+		case '\r':
+			if (term_mode == MODE_CR) {
+				goto send;
+			}
+			if (term_mode == MODE_CR_LF) {
+				cr_state = true;
+			}
+			return;
+		case '\n':
+			if (term_mode == MODE_LF) {
+				goto send;
+			}
+			if (term_mode == MODE_CR_LF && cr_state) {
+				goto send;
+			}
+			return;
 		}
-		break;
-	case MODE_LF:
-		if ((at_buf[pos - 1]) &&
-			character == termination[term_mode]) {
-			goto send;
-		}
-		break;
-	case MODE_CR_LF:
-		if ((at_buf[pos - 1] == '\r') && (character == '\n')) {
-			goto send;
-		}
-		break;
-	default:
-		LOG_ERR("Invalid termination mode: %d", term_mode);
-		break;
+		cr_state = false;
+	}
+
+	/* Detect AT command buffer overflow, leaving space for null */
+	if (at_cmd_len + 1 > sizeof(at_buf) - 1) {
+		LOG_ERR("Buffer overflow, dropping '%c'\n", character);
+		return;
+	}
+
+	/* Write character to AT buffer */
+	at_buf[at_cmd_len] = character;
+	at_cmd_len++;
+
+	/* Handle special written character */
+	if (character == '"') {
+		inside_quotes = !inside_quotes;
 	}
 
 	return;
 send:
-	uart_irq_rx_disable(uart_dev);
-	k_work_submit(&cmd_send_work);
-	at_buf_len = cmd_len;
-	cmd_len = 0;
+	at_buf[at_cmd_len] = '\0'; /* Terminate the command string */
+
+	/* Reset UART handler state */
+	cr_state = false;
+	inside_quotes = false;
+	at_cmd_len = 0;
+
+	/* Send the command, if there is one to send */
+	if (at_buf[0]) {
+		uart_irq_rx_disable(uart_dev); /* Stop UART to protect at_buf */
+		k_work_submit_to_queue(&at_host_work_q, &cmd_send_work);
+	}
 }
 
 static void isr(struct device *dev)
@@ -194,7 +201,12 @@ static void isr(struct device *dev)
 		return;
 	}
 
-	while (uart_fifo_read(dev, &character, 1)) {
+	/*
+	 * Check that we are not sending data (buffer must be preserved then),
+	 * and that a new character is available before handling each character
+	 */
+	while ((!k_work_pending(&cmd_send_work)) &&
+	       (uart_fifo_read(dev, &character, 1))) {
 		uart_rx_handler(character);
 	}
 }
@@ -277,6 +289,9 @@ static int at_host_init(struct device *arg)
 	}
 
 	k_work_init(&cmd_send_work, cmd_send);
+	k_work_q_start(&at_host_work_q, at_host_stack_area,
+		       K_THREAD_STACK_SIZEOF(at_host_stack_area),
+		       CONFIG_AT_HOST_THREAD_PRIO);
 	uart_irq_rx_enable(uart_dev);
 
 	return err;


### PR DESCRIPTION
Improves the AT host's forwarding of commands by:

* Using a single static buffer for both transmission and reception
* Using a dedicated workqueue, rather than blocking the system workqueue
* Adding a Kconfig for maximum command length
* Correcting the usage of maximum length macros
* Correcting the error message on at_cmd_write to be more generic
* Simplifying UART character input handling
* Removing redundant string length tracking variables at_buf_len and pos
* Changing length arguments to write_uart_string to avoid sending nulls

Signed-off-by: Bernt Johan Damslora <bernt.johan.damslora@nordicsemi.no>