### PR TITLE
S0/S1 firmware info offset

### DIFF
--- a/samples/bootloader/src/main.c
+++ b/samples/bootloader/src/main.c
@@ -68,10 +68,10 @@ static bool verify_firmware(u32_t address)
 			break;
 		}
 		retval = bl_root_of_trust_verify(fw_ver_info->public_key,
-					      (u8_t *)key_data,
-					      fw_ver_info->signature,
-					      (u8_t *)address,
-					      fw_info->firmware_size);
+					(u8_t *)key_data,
+					fw_ver_info->signature,
+					(u8_t *)fw_ver_info->firmware_address,
+					fw_info->firmware_size);
 		if (retval != -ESIGINV) {
 			break;
 		}

--- a/subsys/bootloader/image/CMakeLists.txt
+++ b/subsys/bootloader/image/CMakeLists.txt
@@ -13,7 +13,7 @@ if (CONFIG_BOOTLOADER_MCUBOOT)
   set(image_to_boot mcuboot_)
 
   # Partition S1 is only enabled when MCUBoot is enabled.
-  set(s1_addr $<TARGET_PROPERTY:partition_manager,PM_S1_IMAGE_ADDRESS>)
+  set(s1_addr $<TARGET_PROPERTY:partition_manager,PM_S1_ADDRESS>)
 
 else()
 
@@ -38,7 +38,7 @@ if (${found} EQUAL -1)
 endif()
 
 # Partition S0 will always contain the image to be booted by B0.
-set(s0_addr $<TARGET_PROPERTY:partition_manager,PM_S0_IMAGE_ADDRESS>)
+set(s0_addr $<TARGET_PROPERTY:partition_manager,PM_S0_ADDRESS>)
 if (s1_addr)
   set(s1_arg --s1-addr ${s1_addr})
 endif()


### PR DESCRIPTION
This makes B0 agnostic to the MCUboot image header at the start of the S0/S1 images.

- The firmware info offset is calculated from the start of s0/s1, not from s0_image/s1_image.
- The firmware address in firmware_info is still sX_image, meaning that's where B0 will boot it from.
- The firmware address in validation_info is also still sX_image, meaning that's where B0 will calculate the signature from.