### PR TITLE
manifest: update mcuboot

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -53,7 +53,7 @@ manifest:
       revision: c3be1b52f5e56aaba6039c423478cfaf62a91622
     - name: mcuboot
       repo-path: fw-nrfconnect-mcuboot
-      revision: 45e7a2404625d50dcc651d0392a93691f4eaa1cd
+      revision: 4e057a11299b61020dfc845638bb867b96d81053
     - name: mcumgr
       repo-path: fw-nrfconnect-mcumgr
       revision: f663988d35da559a37f263d369842dbce309d1fa


### PR DESCRIPTION
Updates mcuboot repo to include changes necessary to enable serial
recovery on Thingy:91.