### PR TITLE
net: download_client: retry on errors when callback returns zero

### DIFF
--- a/include/net/download_client.h
+++ b/include/net/download_client.h
@@ -31,25 +31,33 @@ extern "C" {
  * @brief Download client event IDs.
  */
 enum download_client_evt_id {
-	/** Event contains a fragment. */
+	/**
+	 * Event contains a fragment.
+	 * The application may return any non-zero value to stop the download.
+	 */
 	DOWNLOAD_CLIENT_EVT_FRAGMENT,
-	/** Download complete. */
-	DOWNLOAD_CLIENT_EVT_DONE,
 	/**
 	 * An error has occurred during download and
 	 * the connection to the server has been lost.
-	 * - ENOTCONN: error reading from socket
-	 * - ECONNRESET: peer closed connection
-	 * - EBADMSG: HTTP response header not
-	 *            as expected
 	 *
-	 * In both cases, the application should
-	 * disconnect (@ref download_client_disconnect)
-	 * and connect (@ref download_client_connect)
-	 * before reattempting the download, to
-	 * reinitialize the network socket.
+	 * Error reason may be one of the following:
+	 * - ENOTCONN: socket error during send() or recv()
+	 * - ECONNRESET: peer closed connection
+	 * - EBADMSG: HTTP response header not as expected
+	 *
+	 * In case of network-related errors (ENOTCONN or ECONNRESET),
+	 * returning zero from the callback will let the library attempt
+	 * to reconnect to the server and download the last fragment again.
+	 * Otherwise, the application may return any non-zero value
+	 * to stop the download.
+	 *
+	 * In case the download is stopped, the application should manually
+	 * disconnect (@ref download_client_disconnect) to clean up the
+	 * network socket as necessary before re-attempting the download.
 	 */
 	DOWNLOAD_CLIENT_EVT_ERROR,
+	/** Download complete. */
+	DOWNLOAD_CLIENT_EVT_DONE,
 };
 
 /**

--- a/subsys/net/lib/download_client/src/download_client.c
+++ b/subsys/net/lib/download_client/src/download_client.c
@@ -367,7 +367,7 @@ static int fragment_evt_send(const struct download_client *client)
 	return client->callback(&evt);
 }
 
-static void error_evt_send(const struct download_client *dl, int error)
+static int error_evt_send(const struct download_client *dl, int error)
 {
 	/* Error will be sent as negative. */
 	__ASSERT_NO_MSG(error > 0);
@@ -377,7 +377,25 @@ static void error_evt_send(const struct download_client *dl, int error)
 		.error = -error
 	};
 
-	dl->callback(&evt);
+	return dl->callback(&evt);
+}
+
+static int reconnect(struct download_client *dl)
+{
+	int err;
+
+	LOG_INF("Reconnecting..");
+	err = download_client_disconnect(dl);
+	if (err) {
+		return err;
+	}
+
+	err = download_client_connect(dl, dl->host, &dl->config);
+	if (err) {
+		return err;
+	}
+
+	return 0;
 }
 
 void download_thread(void *client, void *a, void *b)
@@ -398,16 +416,24 @@ restart_and_suspend:
 
 		if (len == -1) {
 			LOG_ERR("Error reading from socket, errno %d", errno);
-			error_evt_send(dl, ENOTCONN);
-			/* Restart and suspend */
-			break;
+			rc = error_evt_send(dl, ENOTCONN);
+			if (rc) {
+				/* Restart and suspend */
+				break;
+			}
+			reconnect(dl);
+			goto send_again;
 		}
 
 		if (len == 0) {
 			LOG_WRN("Peer closed connection!");
-			error_evt_send(dl, ECONNRESET);
-			/* Restart and suspend */
-			break;
+			rc = error_evt_send(dl, ECONNRESET);
+			if (rc) {
+				/* Restart and suspend */
+				break;
+			}
+			reconnect(dl);
+			goto send_again;
 		}
 
 		LOG_DBG("Read %d bytes from socket", len);
@@ -422,9 +448,10 @@ restart_and_suspend:
 				continue;
 			}
 			if (rc < 0) {
-				/* Something was wrong with the header */
+				/* Something was wrong with the header.
+				 * Restart and suspend, no point in retrying.
+				 */
 				error_evt_send(dl, EBADMSG);
-				/* Restart and suspend */
 				break;
 			}
 
@@ -481,15 +508,20 @@ restart_and_suspend:
 		/* Attempt to reconnect if the connection was closed */
 		if (dl->connection_close) {
 			dl->connection_close = false;
-			download_client_disconnect(dl);
-			download_client_connect(dl, dl->host, &dl->config);
+			reconnect(dl);
 		}
 
+		/* Send a GET request for the next bytes */
+send_again:
 		rc = get_request_send(dl);
 		if (rc) {
-			error_evt_send(dl, ECONNRESET);
-			/* Restart and suspend */
-			break;
+			rc = error_evt_send(dl, ECONNRESET);
+			if (rc) {
+				/* Restart and suspend */
+				break;
+			}
+			reconnect(dl);
+			goto send_again;
 		}
 	}
 


### PR DESCRIPTION
Returning zero from the handler when receiving DOWNLOAD_CLIENT_EVT_ERROR will reconnect the network socket and attempt to continue the download from the last fragment.

This should address the requirements of: https://github.com/NordicPlayground/fw-nrfconnect-nrf/pull/1134 by @jbrzozoski.

I haven't tested that we have enough stack size (`2048`) to `_connect()` from the thread, but perhaps somebody else could check that? :)

FYI: @hakonfam, @sigvartmh.