### PR TITLE
lib: modem_info: Library extension

### DIFF
--- a/include/modem_info.h
+++ b/include/modem_info.h
@@ -56,6 +56,7 @@ enum modem_info {
 	MODEM_INFO_GPS_MODE,	/**< GPS support mode. */
 	MODEM_INFO_IMSI,	/**< Mobile subscriber identity. */
 	MODEM_INFO_IMEI,	/**< Modem serial number. */
+	MODEM_INFO_DATE_TIME,	/**< Mobile network time and date */
 	MODEM_INFO_COUNT,	/**< Number of legal elements in the enum. */
 };
 
@@ -81,6 +82,7 @@ struct network_param {
 	struct lte_param lte_mode; /**< LTE-M support mode. */
 	struct lte_param nbiot_mode; /**< NB-IoT support mode. */
 	struct lte_param gps_mode; /**< GPS support mode. */
+	struct lte_param date_time; /**< Mobile network time and date */
 
 	double cellid_dec; /**< Cell ID of the device (in decimal format). */
 	char network_mode[MODEM_INFO_NETWORK_MODE_MAX_SIZE];

--- a/include/modem_info.rst
+++ b/include/modem_info.rst
@@ -16,6 +16,7 @@ It issues AT commands to retrieve the following data:
 * The modem firmware version
 * The modem serial number
 * The LTE-M, NB-IoT, and GPS support mode
+* Mobile network time and date
 
 The modem information library uses the :ref:`at_cmd_parser_readme`.
 

--- a/lib/modem_info/modem_info.c
+++ b/lib/modem_info/modem_info.c
@@ -40,6 +40,7 @@ LOG_MODULE_REGISTER(modem_info);
 #define AT_CMD_SYSTEMMODE	"AT%XSYSTEMMODE?"
 #define AT_CMD_IMSI		"AT+CIMI"
 #define AT_CMD_IMEI		"AT+CGSN"
+#define AT_CMD_DATE_TIME	"AT+CCLK?"
 #define AT_CMD_SUCCESS_SIZE	5
 
 #define RSRP_DATA_NAME		"rsrp"
@@ -62,6 +63,7 @@ LOG_MODULE_REGISTER(modem_info);
 #define GPS_MODE_DATA_NAME	"gpsMode"
 #define IMSI_DATA_NAME		"imsi"
 #define MODEM_IMEI_DATA_NAME	"imei"
+#define DATE_TIME_DATA_NAME	"dateTime"
 
 #define RSRP_PARAM_INDEX	1
 #define RSRP_PARAM_COUNT	3
@@ -105,11 +107,14 @@ LOG_MODULE_REGISTER(modem_info);
 #define GPS_MODE_PARAM_INDEX	3
 #define SYSTEMMODE_PARAM_COUNT	5
 
-#define IMSI_PARAM_INDEX    0
-#define IMSI_PARAM_COUNT    1
+#define IMSI_PARAM_INDEX	0
+#define IMSI_PARAM_COUNT	1
 
 #define MODEM_IMEI_PARAM_INDEX	0
 #define MODEM_IMEI_PARAM_COUNT  1
+
+#define DATE_TIME_PARAM_INDEX	1
+#define DATE_TIME_PARAM_COUNT	2
 
 struct modem_info_data {
 	const char *cmd;
@@ -279,6 +284,14 @@ static const struct modem_info_data imei_data = {
 	.data_type	= AT_PARAM_TYPE_STRING,
 };
 
+static const struct modem_info_data date_time_data = {
+	.cmd		= AT_CMD_DATE_TIME,
+	.data_name	= DATE_TIME_DATA_NAME,
+	.param_index	= DATE_TIME_PARAM_INDEX,
+	.param_count	= DATE_TIME_PARAM_COUNT,
+	.data_type	= AT_PARAM_TYPE_STRING,
+};
+
 static const struct modem_info_data *const modem_data[] = {
 	[MODEM_INFO_RSRP]	= &rsrp_data,
 	[MODEM_INFO_CUR_BAND]	= &band_data,
@@ -300,6 +313,7 @@ static const struct modem_info_data *const modem_data[] = {
 	[MODEM_INFO_GPS_MODE]   = &gps_mode_data,
 	[MODEM_INFO_IMSI]	= &imsi_data,
 	[MODEM_INFO_IMEI]	= &imei_data,
+	[MODEM_INFO_DATE_TIME]	= &date_time_data,
 };
 
 static rsrp_cb_t modem_info_rsrp_cb;

--- a/lib/modem_info/modem_info_params.c
+++ b/lib/modem_info/modem_info_params.c
@@ -31,6 +31,7 @@ int modem_info_params_init(struct modem_param_info *modem)
 	modem->network.lte_mode.type		= MODEM_INFO_LTE_MODE;
 	modem->network.nbiot_mode.type		= MODEM_INFO_NBIOT_MODE;
 	modem->network.gps_mode.type		= MODEM_INFO_GPS_MODE;
+	modem->network.date_time.type		= MODEM_INFO_DATE_TIME;
 
 	modem->sim.uicc.type			= MODEM_INFO_UICC;
 	modem->sim.iccid.type			= MODEM_INFO_ICCID;
@@ -143,6 +144,7 @@ int modem_info_params_get(struct modem_param_info *modem)
 		ret += modem_data_get(&modem->network.lte_mode);
 		ret += modem_data_get(&modem->network.nbiot_mode);
 		ret += modem_data_get(&modem->network.gps_mode);
+		ret += modem_data_get(&modem->network.date_time);
 
 		ret += mcc_mnc_parse(&modem->network.current_operator,
 				&modem->network.mcc,


### PR DESCRIPTION
Extended library to support getting mobile network time and date
from modem