### PR TITLE
LTE link controller extensions

### DIFF
--- a/include/lte_lc.h
+++ b/include/lte_lc.h
@@ -12,6 +12,20 @@
 #ifndef ZEPHYR_INCLUDE_LTE_LINK_CONTROL_H_
 #define ZEPHYR_INCLUDE_LTE_LINK_CONTROL_H_
 
+/* NOTE: enum lte_lc_nw_reg_status maps directly to the registration status
+ *	 as returned by the AT command "AT+CEREG?".
+ */
+enum lte_lc_nw_reg_status {
+	LTE_LC_NW_REG_NOT_REGISTERED		= 0,
+	LTE_LC_NW_REG_REGISTERED_HOME		= 1,
+	LTE_LC_NW_REG_SEARCHING			= 2,
+	LTE_LC_NW_REG_REGISTRATION_DENIED	= 3,
+	LTE_LC_NW_REG_UNKNOWN			= 4,
+	LTE_LC_NW_REG_REGISTERED_ROAMING	= 5,
+	LTE_LC_NW_REG_REGISTERED_EMERGENCY	= 8,
+	LTE_LC_NW_REG_UICC_FAIL			= 90
+};
+
 /** @brief Function for initializing
  * the modem.  NOTE: a follow-up call to lte_lc_connect()
  * must be made.
@@ -61,7 +75,7 @@ int lte_lc_normal(void);
  */
 int lte_lc_psm_req(bool enable);
 
-/* @brief Function for getting the current PSM (Power Saving Mode)
+/**@brief Function for getting the current PSM (Power Saving Mode)
  *	  configurations for periodic TAU (Tracking Area Update) and
  *	  active time, both in units of seconds.
  *
@@ -81,5 +95,13 @@ int lte_lc_psm_get(int *tau, int *active_time);
  * @return Zero on success or (negative) error code otherwise.
  */
 int lte_lc_edrx_req(bool enable);
+
+/**@brief Get the current network registration status.
+ *
+ * @param status Pointer for network registation status.
+ *
+ * @return Zero on success or (negative) error code otherwise.
+ */
+int lte_lc_nw_reg_status_get(enum lte_lc_nw_reg_status *status);
 
 #endif /* ZEPHYR_INCLUDE_LTE_LINK_CONTROL_H_ */

--- a/include/lte_lc.h
+++ b/include/lte_lc.h
@@ -26,6 +26,15 @@ enum lte_lc_nw_reg_status {
 	LTE_LC_NW_REG_UICC_FAIL			= 90
 };
 
+enum lte_lc_system_mode {
+	LTE_LC_SYSTEM_MODE_NONE,
+	LTE_LC_SYSTEM_MODE_LTEM,
+	LTE_LC_SYSTEM_MODE_NBIOT,
+	LTE_LC_SYSTEM_MODE_GPS,
+	LTE_LC_SYSTEM_MODE_LTEM_GPS,
+	LTE_LC_SYSTEM_MODE_NBIOT_GPS
+};
+
 /** @brief Function for initializing
  * the modem.  NOTE: a follow-up call to lte_lc_connect()
  * must be made.
@@ -103,5 +112,21 @@ int lte_lc_edrx_req(bool enable);
  * @return Zero on success or (negative) error code otherwise.
  */
 int lte_lc_nw_reg_status_get(enum lte_lc_nw_reg_status *status);
+
+/**@brief Set the modem's system mode.
+ *
+ * @param mode System mode to set.
+ *
+ * @return Zero on success or (negative) error code otherwise.
+ */
+int lte_lc_system_mode_set(enum lte_lc_system_mode mode);
+
+/**@brief Get the modem's system mode.
+ *
+ * @param mode Pointer to system mode variable.
+ *
+ * @return Zero on success or (negative) error code otherwise.
+ */
+int lte_lc_system_mode_get(enum lte_lc_system_mode *mode);
 
 #endif /* ZEPHYR_INCLUDE_LTE_LINK_CONTROL_H_ */

--- a/include/lte_lc.h
+++ b/include/lte_lc.h
@@ -35,6 +35,16 @@ enum lte_lc_system_mode {
 	LTE_LC_SYSTEM_MODE_NBIOT_GPS
 };
 
+/* NOTE: enum lte_lc_func_mode maps directly to the functional mode
+ *	 as returned by the AT command "AT+CFUN?".
+ */
+enum lte_lc_func_mode {
+	LTE_LC_FUNC_MODE_POWER_OFF		= 0,
+	LTE_LC_FUNC_MODE_NORMAL			= 1,
+	LTE_LC_FUNC_MODE_OFFLINE		= 4,
+	LTE_LC_FUNC_MODE_OFFLINE_UICC_ON	= 44
+};
+
 /** @brief Function for initializing
  * the modem.  NOTE: a follow-up call to lte_lc_connect()
  * must be made.
@@ -128,5 +138,13 @@ int lte_lc_system_mode_set(enum lte_lc_system_mode mode);
  * @return Zero on success or (negative) error code otherwise.
  */
 int lte_lc_system_mode_get(enum lte_lc_system_mode *mode);
+
+/**@brief Get the modem's functional mode.
+ *
+ * @param mode Pointer to functional mode variable.
+ *
+ * @return Zero on success or (negative) error code otherwise.
+ */
+int lte_lc_func_mode_get(enum lte_lc_func_mode *mode);
 
 #endif /* ZEPHYR_INCLUDE_LTE_LINK_CONTROL_H_ */


### PR DESCRIPTION
### drivers: lte_lc: Add API to get network registration status

This patch adds an API to get the current network registration
status.
The LTE link controller is changed to use the new parsing
function for registration status internally as well.

---

### drivers: lte_lc: Add API for setting and getting system mode

Adds APIs for getting and setting system mode.
Also adds utility function for checking if a returned AT
response is the same as expected.

---

### drivers: lte_lc: Add API for getting functional mode

Adds API for getting the modem's current functional mode.