### PR TITLE
doc: Make the Kconfig reference a separate documentation set

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -67,6 +67,9 @@ set(NRF_BINARY_DIR ${CMAKE_BINARY_DIR}/nrf)
 set(MCUBOOT_BINARY_DIR ${CMAKE_BINARY_DIR}/mcuboot)
 set(NRFXLIB_BINARY_DIR ${CMAKE_BINARY_DIR}/nrfxlib)
 
+# Output directory for the shared Kconfig documentation
+set(KCONFIG_BINARY_DIR ${CMAKE_BINARY_DIR}/kconfig)
+
 # HTML output directory
 set(HTML_DIR ${CMAKE_BINARY_DIR}/html)
 file(MAKE_DIRECTORY ${HTML_DIR})
@@ -78,9 +81,12 @@ file(MAKE_DIRECTORY ${HTML_DIR})
 # common Sphinx HTML output folder.
 #
 
-# Parameters to doc/CMakeLists.txt in Zephyr
+# Parameters to doc/CMakeLists.txt in Zephyr. KCONFIG_OUTPUT is used to find
+# objects.inv from the Kconfig docs, to link the Zephyr docs to the Kconfig
+# docs.
 set(SPHINXOPTS -c ${NRF_BASE}/doc/zephyr)
 set(SPHINX_OUTPUT_DIR ${HTML_DIR}/zephyr)
+set(KCONFIG_OUTPUT ${HTML_DIR}/kconfig)
 
 # Get access to the 'html' target from doc/CMakeLists.txt in Zephyr
 add_subdirectory(${ZEPHYR_BASE}/doc ${ZEPHYR_BINARY_DIR})
@@ -94,7 +100,7 @@ add_dependencies(zephyr html)
 # Add 'clean-zephyr', 'clean-nrf', etc., targets
 #
 
-foreach(target zephyr nrf mcuboot nrfxlib)
+foreach(target zephyr nrf mcuboot nrfxlib kconfig)
   set(TARGET_BINARY_DIR ${CMAKE_BINARY_DIR}/${target})
   # Cleanup build output
   add_custom_target(
@@ -176,18 +182,6 @@ else()
   set(SEP :)
 endif()
 
-add_custom_target(
-  nrf-kconfig
-  COMMAND ${CMAKE_COMMAND} -E make_directory ${NRF_RST_OUT}/doc/nrf/reference/kconfig
-  COMMAND ${CMAKE_COMMAND} -E env
-  PYTHONPATH="${ZEPHYR_BASE}/scripts/kconfig${SEP}$ENV{PYTHONPATH}"
-  srctree=${NRF_BASE}
-  KCONFIG_TURBO_MODE=${KCONFIG_TURBO_MODE}
-  KCONFIG_DOC_MODE=1
-  ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/doc/scripts/genrest.py --kconfig ${NRF_BASE}/Kconfig.nrf ${NRF_RST_OUT}/doc/nrf/reference/kconfig/
-  WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-)
-
 set(NRF_SPHINX_BUILD_HTML_COMMAND
   ${CMAKE_COMMAND} -E env
   ZEPHYR_BUILD=${ZEPHYR_BINARY_DIR}
@@ -195,6 +189,7 @@ set(NRF_SPHINX_BUILD_HTML_COMMAND
   NRF_BASE=${NRF_BASE}
   NRF_BUILD=${NRF_BINARY_DIR}
   NRF_OUTPUT=${HTML_DIR}/nrf
+  KCONFIG_OUTPUT=${HTML_DIR}/kconfig
   NRF_RST_SRC=${NRF_RST_OUT}/doc/nrf
   MCUBOOT_OUTPUT=${HTML_DIR}/mcuboot
   NRFXLIB_OUTPUT=${HTML_DIR}/nrfxlib
@@ -210,7 +205,7 @@ add_custom_target(
   COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_LIST_DIR}/static/html/index.html ${HTML_DIR}
   WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
 )
-add_dependencies(nrf-html nrf-doxy nrf-content nrf-kconfig)
+add_dependencies(nrf-html nrf-doxy nrf-content)
 
 add_custom_target(nrf)
 add_dependencies(nrf nrf-html)
@@ -261,6 +256,9 @@ add_custom_target(
   ZEPHYR_OUTPUT=${HTML_DIR}/zephyr
   NRF_OUTPUT=${HTML_DIR}/nrf
   NRF_RST_SRC=${NRF_RST_OUT}/doc/nrf
+  MCUBOOT_OUTPUT=${HTML_DIR}/mcuboot
+  MCUBOOT_RST_SRC=${MCUBOOT_RST_OUT}/doc/mcuboot
+  KCONFIG_OUTPUT=${HTML_DIR}/kconfig
   ${SPHINXBUILD} -w ${MCUBOOT_SPHINX_LOG} -N -b html ${MCUBOOT_SPHINXOPTS} ${MCUBOOT_RST_OUT}/doc/mcuboot ${HTML_DIR}/mcuboot
 
   WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
@@ -309,18 +307,6 @@ add_custom_target(
 )
 
 
-add_custom_target(
-  nrfxlib-kconfig
-  COMMAND ${CMAKE_COMMAND} -E make_directory ${NRFXLIB_RST_OUT}/kconfig
-  COMMAND ${CMAKE_COMMAND} -E env
-  PYTHONPATH="${ZEPHYR_BASE}/scripts/kconfig${SEP}$ENV{PYTHONPATH}"
-  srctree=${NRFXLIB_BASE}
-  KCONFIG_TURBO_MODE=${KCONFIG_TURBO_MODE}
-  KCONFIG_DOC_MODE=1
-  ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/doc/scripts/genrest.py --kconfig ${NRFXLIB_BASE}/Kconfig.nrfxlib ${NRFXLIB_RST_OUT}/kconfig
-  WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-)
-
 set(NRFXLIB_EXTRACT_CONTENT_COMMAND
  ${CMAKE_COMMAND} -E env
   ZEPHYR_BASE=${NRFXLIB_BASE}
@@ -346,11 +332,76 @@ add_custom_target(
   COMMAND ${CMAKE_COMMAND} -E env
   NRF_BASE=${NRF_BASE}
   NRFXLIB_BUILD=${NRFXLIB_BINARY_DIR}
+  NRFXLIB_OUTPUT=${HTML_DIR}/nrfxlib
+  NRFXLIB_RST_SRC=${NRFXLIB_RST_OUT}
+  KCONFIG_OUTPUT=${HTML_DIR}/kconfig
   ${SPHINXBUILD} -w ${NRFXLIB_SPHINX_LOG} -N -b html ${NRFXLIB_SPHINXOPTS} ${NRFXLIB_RST_OUT} ${HTML_DIR}/nrfxlib
 
   WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
 )
-add_dependencies(nrfxlib-html nrfxlib-content nrfxlib-doxy nrfxlib-kconfig)
+add_dependencies(nrfxlib-html nrfxlib-content nrfxlib-doxy)
 
 add_custom_target(nrfxlib)
 add_dependencies(nrfxlib nrfxlib-html)
+
+#
+# Add targets for building the shared Kconfig documentation
+#
+
+# The Kconfig documentation is a separate documentation set that's shared
+# between all modules (nRF, Zephyr, etc.). This makes it possible to link to
+# Kconfig symbols regardless of where they are defined.
+#
+# We rely on the Zephyr Kconfig files pulling in the other Kconfig files, and
+# use the --modules option to genrest.py to split the documentation into a
+# separate page for each module.
+
+set(KCONFIG_RST_OUT ${KCONFIG_BINARY_DIR}/rst)
+
+# The 'kconfig-content' target uses genrest.py to generate .rst files for all
+# Kconfig symbols, as well as index pages that point to them
+add_custom_target(
+  kconfig-content
+  COMMAND ${CMAKE_COMMAND} -E make_directory ${KCONFIG_RST_OUT}
+  COMMAND ${CMAKE_COMMAND} -E env
+    PYTHONPATH=${ZEPHYR_BASE}/scripts/kconfig${SEP}$ENV{PYTHONPATH}
+    ZEPHYR_BASE=${ZEPHYR_BASE}
+    srctree=${ZEPHYR_BASE}
+    BOARD_DIR=boards/*/*/
+    ARCH=*
+    ARCH_DIR=arch/
+    SOC_DIR=soc/
+    CMAKE_BINARY_DIR=${CMAKE_BINARY_DIR}
+    KCONFIG_WARN_UNDEF=y
+    KCONFIG_TURBO_MODE=${KCONFIG_TURBO_MODE}
+    KCONFIG_DOC_MODE=1
+      ${PYTHON_EXECUTABLE} ${ZEPHYR_BASE}/doc/scripts/genrest.py ${KCONFIG_RST_OUT}
+        --separate-all-index
+        --modules Zephyr,zephyr,${ZEPHYR_BASE}
+                  nRF,nrf,${NRF_BASE}
+                  nrfxlib,nrfxlib,${NRFXLIB_BASE}
+
+  VERBATIM
+)
+
+# No 'kconfig' target exists, because it clashes with the imported 'kconfig'
+# target from the Zephyr repository
+
+add_custom_target(
+  kconfig-html
+  COMMAND ${CMAKE_COMMAND} -E env
+    ZEPHYR_BASE=${ZEPHYR_BASE}
+    ZEPHYR_BUILD=${CMAKE_CURRENT_BINARY_DIR}
+      ${SPHINXBUILD}
+        -b html
+        -c ${NRF_BASE}/doc/kconfig
+        -d ${KCONFIG_BINARY_DIR}/doctrees
+        -N
+        -w ${KCONFIG_BINARY_DIR}/sphinx.log
+        # The Kconfig reference build doesn't use Breathe, so we can safely
+        # parallelize it
+        -j auto
+        ${KCONFIG_RST_OUT}
+        ${HTML_DIR}/kconfig
+)
+add_dependencies(kconfig-html kconfig-content)

--- a/doc/kconfig/conf.py
+++ b/doc/kconfig/conf.py
@@ -1,0 +1,64 @@
+# Kconfig documentation build configuration file
+
+import os
+
+NRF_BASE = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+# -- General configuration ------------------------------------------------
+
+# Sphinx 2.0 changes the default from 'index' to 'contents'
+master_doc = 'index'
+
+# General information about the project.
+project = 'Kconfig reference'
+copyright = '2019, Nordic Semiconductor'
+author = 'Nordic Semiconductor'
+
+# Get rid of version number while keeping the spacing the same as for other
+# docsets
+version = '&nbsp;'
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+exclude_patterns = ['_build']
+
+# -- Options for HTML output ----------------------------------------------
+
+html_theme = "kconfig"
+html_theme_path = ['{}/doc/themes'.format(NRF_BASE)]
+html_favicon = '{}/doc/static/images/favicon.ico'.format(NRF_BASE)
+
+# The name for this set of Sphinx documents.  If None, it defaults to
+# "<project> v<release> documentation".
+html_title = "Kconfig reference"
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['{}/doc/static'.format(NRF_BASE)]
+
+# If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
+# using the given strftime format.
+html_last_updated_fmt = '%b %d, %Y'
+
+# If false, no module index is generated.
+html_domain_indices = False
+
+# If false, no index is generated.
+html_use_index = True
+
+# If true, the index is split into individual pages for each letter.
+html_split_index = True
+
+# If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
+html_show_sphinx = False
+
+# If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
+html_show_copyright = True
+
+# If true, license is shown in the HTML footer. Default is True.
+html_show_license = True
+
+def setup(app):
+    app.add_stylesheet("css/common.css")
+    app.add_stylesheet("css/kconfig.css")

--- a/doc/mcuboot/conf.py
+++ b/doc/mcuboot/conf.py
@@ -40,6 +40,17 @@ if "NRF_RST_SRC" not in os.environ:
     sys.exit("$NRF_RST_SRC environment variable undefined.")
 NRF_RST_SRC = os.path.abspath(os.environ["NRF_RST_SRC"])
 
+if "MCUBOOT_OUTPUT" not in os.environ:
+    sys.exit("$MCUBOOT_OUTPUT environment variable undefined.")
+MCUBOOT_OUTPUT = os.path.abspath(os.environ["MCUBOOT_OUTPUT"])
+
+if "MCUBOOT_RST_SRC" not in os.environ:
+    sys.exit("$MCUBOOT_RST_SRC environment variable undefined.")
+MCUBOOT_RST_SRC = os.path.abspath(os.environ["MCUBOOT_RST_SRC"])
+
+if "KCONFIG_OUTPUT" not in os.environ:
+    sys.exit("$KCONFIG_OUTPUT environment variable undefined.")
+KCONFIG_OUTPUT = os.path.abspath(os.environ["KCONFIG_OUTPUT"])
 
 # -- General configuration ------------------------------------------------
 
@@ -147,9 +158,15 @@ html_show_copyright = True
 # If true, license is shown in the HTML footer. Default is True.
 html_show_license = True
 
-
 intersphinx_mapping = {
-    'zephyr': ('{}'.format(os.path.relpath(ZEPHYR_OUTPUT, NRF_OUTPUT)), os.path.join('{}'.format(os.path.relpath(ZEPHYR_OUTPUT, NRF_RST_SRC)), 'objects.inv'))
+    # Link the Kconfig docs with Intersphinx so that references to Kconfig
+    # symbols (via :option:`CONFIG_FOO`) turn into links
+    'kconfig': (os.path.relpath(KCONFIG_OUTPUT, MCUBOOT_OUTPUT),
+                os.path.join(os.path.relpath(KCONFIG_OUTPUT, MCUBOOT_RST_SRC),
+                             'objects.inv')),
+    'zephyr': (os.path.relpath(ZEPHYR_OUTPUT, NRF_OUTPUT),
+               os.path.join(os.path.relpath(ZEPHYR_OUTPUT, NRF_RST_SRC),
+                            'objects.inv'))
 }
 
 def setup(app):

--- a/doc/mcuboot/readme-ncs.rst
+++ b/doc/mcuboot/readme-ncs.rst
@@ -8,7 +8,7 @@ See :doc:`readme-zephyr` for general information on how to integrate MCUboot wit
 nRF Connect SDK's `fork of MCUboot <https://github.com/NordicPlayground/fw-nrfconnect-mcuboot>`_ provides additional functionality that is available when MCUboot is included.
 This functionality is implemented in the files in the ``zephyr`` subfolder.
 
-To include MCUboot in your nRF Connect SDK application, enable :option:`zephyr:CONFIG_BOOTLOADER_MCUBOOT`.
+To include MCUboot in your nRF Connect SDK application, enable :option:`CONFIG_BOOTLOADER_MCUBOOT`.
 
 When you build your application with this option set, the following files that can be used for firmware over-the-air (FOTA) upgrades are automatically generated:
 

--- a/doc/nrf/conf.py
+++ b/doc/nrf/conf.py
@@ -60,6 +60,10 @@ if "NRFXLIB_OUTPUT" not in os.environ:
     sys.exit("$NRFXLIB_OUTPUT environment variable undefined.")
 NRFXLIB_OUTPUT = os.path.abspath(os.environ["NRFXLIB_OUTPUT"])
 
+if "KCONFIG_OUTPUT" not in os.environ:
+    sys.exit("$KCONFIG_OUTPUT environment variable undefined.")
+KCONFIG_OUTPUT = os.path.abspath(os.environ["KCONFIG_OUTPUT"])
+
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
@@ -175,7 +179,10 @@ html_show_license = True
 intersphinx_mapping = {
     'zephyr': ('{}'.format(os.path.relpath(ZEPHYR_OUTPUT, NRF_OUTPUT)), os.path.join('{}'.format(os.path.relpath(ZEPHYR_OUTPUT, NRF_RST_SRC)), 'objects.inv')),
     'mcuboot': ('{}'.format(os.path.relpath(MCUBOOT_OUTPUT, NRF_OUTPUT)), os.path.join('{}'.format(os.path.relpath(MCUBOOT_OUTPUT, NRF_RST_SRC)), 'objects.inv')),
-    'nrfxlib': ('{}'.format(os.path.relpath(NRFXLIB_OUTPUT, NRF_OUTPUT)), os.path.join('{}'.format(os.path.relpath(NRFXLIB_OUTPUT, NRF_RST_SRC)), 'objects.inv'))
+    'nrfxlib': ('{}'.format(os.path.relpath(NRFXLIB_OUTPUT, NRF_OUTPUT)), os.path.join('{}'.format(os.path.relpath(NRFXLIB_OUTPUT, NRF_RST_SRC)), 'objects.inv')),
+    'kconfig': (os.path.relpath(KCONFIG_OUTPUT, NRF_OUTPUT),
+                os.path.join(os.path.relpath(KCONFIG_OUTPUT, NRF_RST_SRC),
+                             'objects.inv'))
 }
 
 breathe_projects = {

--- a/doc/nrf/doc_build.rst
+++ b/doc/nrf/doc_build.rst
@@ -87,6 +87,12 @@ Complete the following steps to build the documentation output:
 
            cmake -GNinja ..
 
+#. Run ninja to build the Kconfig documentation:
+
+        .. code-block:: console
+
+           ninja kconfig-html
+
 #. Run ninja to build the Zephyr documentation:
 
         .. code-block:: console

--- a/doc/nrf/index.rst
+++ b/doc/nrf/index.rst
@@ -32,6 +32,5 @@ Documentation for different versions of the |NCS| is available at the following 
    drivers
    libraries
    scripts
-   reference/kconfig/index
 
 ..   cheat_sheet

--- a/doc/nrf/ug_nrf5340.rst
+++ b/doc/nrf/ug_nrf5340.rst
@@ -94,7 +94,7 @@ The |NCS| provides the following samples for the nRF53 network core:
   You might need to adjust the Kconfig configuration of this sample to make it compatible with the peer application.
   For example:
 
-  * :option:`zephyr:CONFIG_BT_MAX_CONN` must be equal to the maximum number of connections supported by the application sample.
+  * :option:`CONFIG_BT_MAX_CONN` must be equal to the maximum number of connections supported by the application sample.
   * If the application sample uses a specific Bluetooth LE functionality, this functionality must be enabled in the network sample as well.
     For example, you must modify the configuration of the network sample to make it compatible with the :ref:`ble_throughput` sample::
 

--- a/doc/nrfxlib/conf.py
+++ b/doc/nrfxlib/conf.py
@@ -32,6 +32,18 @@ if "NRFXLIB_BUILD" not in os.environ:
     sys.exit("$NRFXLIB_BUILD environment variable undefined.")
 NRFXLIB_BUILD = os.path.abspath(os.environ["NRFXLIB_BUILD"])
 
+if "NRFXLIB_OUTPUT" not in os.environ:
+    sys.exit("$NRFXLIB_OUTPUT environment variable undefined.")
+NRFXLIB_OUTPUT = os.path.abspath(os.environ["NRFXLIB_OUTPUT"])
+
+if "NRFXLIB_RST_SRC" not in os.environ:
+    sys.exit("$NRFXLIB_RST_SRC environment variable undefined.")
+NRFXLIB_RST_SRC = os.path.abspath(os.environ["NRFXLIB_RST_SRC"])
+
+if "KCONFIG_OUTPUT" not in os.environ:
+    sys.exit("$KCONFIG_OUTPUT environment variable undefined.")
+KCONFIG_OUTPUT = os.path.abspath(os.environ["KCONFIG_OUTPUT"])
+
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
@@ -136,6 +148,13 @@ html_show_copyright = True
 # If true, license is shown in the HTML footer. Default is True.
 html_show_license = True
 
+# Link the Kconfig docs with Intersphinx so that references to Kconfig symbols
+# (via :option:`CONFIG_FOO`) turn into links
+intersphinx_mapping = {
+    'kconfig': (os.path.relpath(KCONFIG_OUTPUT, NRFXLIB_OUTPUT),
+                os.path.join(os.path.relpath(KCONFIG_OUTPUT, NRFXLIB_RST_SRC),
+                             'objects.inv'))
+}
 
 breathe_projects = {
     "nrfxlib": "{}/doxygen/xml".format(NRFXLIB_BUILD),

--- a/doc/static/css/common.css
+++ b/doc/static/css/common.css
@@ -67,6 +67,9 @@ div.figure {
 .nrfxlib {
  background-color: #ff9933;
 }
+.kconfig {
+ background-color: #e82424
+}
 
 
 /* dbk tweak for doxygen-generated API headings (for RTD theme) */

--- a/doc/static/css/kconfig.css
+++ b/doc/static/css/kconfig.css
@@ -1,0 +1,24 @@
+/* background color top and bottom left */
+
+.wy-side-nav-search {
+ background-color: #e82424
+}
+
+.rst-versions .rst-current-version {
+ background-color: #e82424;
+}
+
+/* text color navigation menu */
+
+/* l1 not selected */
+.wy-menu-vertical a {
+ color: #e82424;
+}
+/* expanded container nodes */
+.wy-menu-vertical li.on a, .wy-menu-vertical li.current > a {
+ color: #e82424;
+}
+/* expanded nodes, not selected */
+.wy-menu-vertical li.current a {
+ color: #e82424;
+}

--- a/doc/themes/kconfig/theme.conf
+++ b/doc/themes/kconfig/theme.conf
@@ -1,0 +1,18 @@
+[theme]
+inherit = nrf
+stylesheet = css/theme.css
+pygments_style = default
+
+[options]
+canonical_url =
+analytics_id =
+collapse_navigation = True
+sticky_navigation = True
+navigation_depth = 4
+includehidden = True
+titles_only =
+logo_only =
+display_version = True
+prev_next_buttons_location = bottom
+style_external_links = False
+vcs_pageview_mode =

--- a/doc/themes/kconfig/versions.html
+++ b/doc/themes/kconfig/versions.html
@@ -1,21 +1,21 @@
 {# Add rst-badge after rst-versions for small badge style. #}
   <div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
     <span class="rst-current-version" data-toggle="rst-current-version">
-      <span class="fa fa-book"> nrfxlib</span>
+      <span class="fa fa-book"> Kconfig reference</span>
        <span class="fa fa-caret-down"></span>
     </span>
     <div class="rst-other-versions">
       <div class="rst-other-version ncs">
         <a href="{{ pathto('',1) }}../nrf/index.html">nRF Connect SDK</a>
       </div>
+      <div class="rst-other-version nrfxlib">
+        <a href="{{ pathto('',1) }}../nrfxlib/README.html">nrfxlib</a>
+      </div>
       <div class="rst-other-version zephyr">
-        <a href="{{ pathto('',1) }}../zephyr/index.html">Zephyr</a><br/>
+        <a href="{{ pathto('',1) }}../zephyr/index.html">Zephyr</a>
       </div>
       <div class="rst-other-version mcuboot">
         <a href="{{ pathto('',1) }}../mcuboot/wrapper.html">MCUboot</a>
-      </div>
-      <div class="rst-other-version kconfig">
-        <a href="{{ pathto('',1) }}../kconfig/index.html">Kconfig Reference</a>
       </div>
     </div>
   </div>

--- a/doc/themes/mcuboot/versions.html
+++ b/doc/themes/mcuboot/versions.html
@@ -14,5 +14,8 @@
       <div class="rst-other-version zephyr">
         <a href="{{ pathto('',1) }}../zephyr/index.html">Zephyr</a><br/>
       </div>
+      <div class="rst-other-version kconfig">
+        <a href="{{ pathto('',1) }}../kconfig/index.html">Kconfig Reference</a>
+      </div>
     </div>
   </div>

--- a/doc/themes/nrf/versions.html
+++ b/doc/themes/nrf/versions.html
@@ -14,5 +14,8 @@
       <div class="rst-other-version mcuboot">
         <a href="{{ pathto('',1) }}../mcuboot/wrapper.html">MCUboot</a>
       </div>
+      <div class="rst-other-version kconfig">
+        <a href="{{ pathto('',1) }}../kconfig/index.html">Kconfig Reference</a>
+      </div>
     </div>
   </div>

--- a/doc/themes/zephyr/versions.html
+++ b/doc/themes/zephyr/versions.html
@@ -14,5 +14,8 @@
       <div class="rst-other-version mcuboot">
         <a href="{{ pathto('',1) }}../mcuboot/wrapper.html">MCUboot</a>
       </div>
+      <div class="rst-other-version kconfig">
+        <a href="{{ pathto('',1) }}../kconfig/index.html">Kconfig Reference</a>
+      </div>
     </div>
   </div>

--- a/doc/zephyr/conf.py
+++ b/doc/zephyr/conf.py
@@ -17,13 +17,24 @@ import os
 from subprocess import CalledProcessError, check_output, DEVNULL
 
 if "ZEPHYR_BASE" not in os.environ:
-    print("$ZEPHYR_BASE environment variable undefined.")
     sys.exit("$ZEPHYR_BASE environment variable undefined.")
 ZEPHYR_BASE = os.path.abspath(os.environ["ZEPHYR_BASE"])
 
 if "ZEPHYR_BUILD" not in os.environ:
     sys.exit("$ZEPHYR_BUILD environment variable undefined.")
 ZEPHYR_BUILD = os.path.abspath(os.environ["ZEPHYR_BUILD"])
+
+if "ZEPHYR_OUTPUT" not in os.environ:
+    sys.exit("$ZEPHYR_OUTPUT environment variable undefined.")
+ZEPHYR_OUTPUT = os.path.abspath(os.environ["ZEPHYR_OUTPUT"])
+
+if "ZEPHYR_RST_SRC" not in os.environ:
+    sys.exit("$ZEPHYR_RST_SRC environment variable undefined.")
+ZEPHYR_RST_SRC = os.path.abspath(os.environ["ZEPHYR_RST_SRC"])
+
+if "KCONFIG_OUTPUT" not in os.environ:
+    sys.exit("$KCONFIG_OUTPUT environment variable undefined.")
+KCONFIG_OUTPUT = os.path.abspath(os.environ["KCONFIG_OUTPUT"])
 
 NRF_BASE = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 
@@ -61,6 +72,7 @@ except CalledProcessError as e:
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'sphinx.ext.intersphinx',
     'breathe', 'sphinx.ext.todo',
     'sphinx.ext.extlinks',
     'sphinx.ext.autodoc',
@@ -257,6 +269,14 @@ html_show_copyright = True
 
 # If true, license is shown in the HTML footer. Default is True.
 html_show_license = True
+
+# Link the Kconfig docs with Intersphinx so that references to Kconfig symbols
+# (via :option:`CONFIG_FOO`) turn into links
+intersphinx_mapping = {
+    'kconfig': (os.path.relpath(KCONFIG_OUTPUT, ZEPHYR_OUTPUT),
+                os.path.join(os.path.relpath(KCONFIG_OUTPUT, ZEPHYR_RST_SRC),
+                             'objects.inv'))
+}
 
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the

--- a/samples/bluetooth/peripheral_uart/README.rst
+++ b/samples/bluetooth/peripheral_uart/README.rst
@@ -59,7 +59,7 @@ After programming the sample to your board, test it by performing the following 
 1. Connect the board to the computer using a USB cable. The board is assigned a COM port (Windows) or ttyACM device (Linux), which is visible in the Device Manager.
 #. |connect_terminal|
 #. Reset the board.
-#. Observe that LED 1 is blinking and that the device is advertising with the device name that is configured in :option:`CONFIG_BT_DEVICE_NAME <zephyr:CONFIG_BT_DEVICE_NAME>`.
+#. Observe that LED 1 is blinking and that the device is advertising with the device name that is configured in :option:`CONFIG_BT_DEVICE_NAME`.
 #. Observe that the text "Starting Nordic UART service example" is printed on the COM listener running on the computer.
 #. Connect to the device using nRF Connect for Mobile.
    Observe that LED 2 is on.

--- a/west.yml
+++ b/west.yml
@@ -46,7 +46,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: fw-nrfconnect-zephyr
-      revision: 9e7299a38e1256fee8a12155a43a6455f19bf0ae
+      revision: e23d8ac48dd0e5890559d618c048132dd4b0a697
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above
@@ -94,7 +94,7 @@ manifest:
       path: modules/lib/mcumgr
     - name: nrfxlib
       path: nrfxlib
-      revision: 7f72d296488975ee45a420a00f9e48b85ec5e20b
+      revision: 3c3702f5395c030593545ce0139f7cf7c129a657
     # Other third-party repositories.
     - name: cmock
       path: test/cmock


### PR DESCRIPTION
Instead of having a separate Kconfig reference page in each
documentation set (nRF, nrfxlib, MCUBoot, and Zephyr), have a single
shared Kconfig documentation set, which can be selected in the
documentation switcher on the bottom left.

All Kconfig symbols now get pulled in via the main Zephyr repo, which
includes nrf, nrfxlib, and mcuboot as modules. This makes it possible to
click through to symbols defined in other repositories. Previously,
symbols defined in other repositories became dead links.

The new --modules flag to genrest.py is used to generate separate index
pages for each repository.

Intersphinx is used to link :option:`CONFIG_FOO` references in all
documentation sets to the new Kconfig documentation set.

Also update the Zephyr repository to get the fw-nrfconnect-zephyr
documentation build change in
NordicPlayground/fw-nrfconnect-zephyr#213 in,
which is required by this PR.