### PR TITLE
subsys: spm: Bugfix for wrong define for secure services

### DIFF
--- a/subsys/spm/spm.c
+++ b/subsys/spm/spm.c
@@ -173,7 +173,7 @@ static void spm_config_flash(void)
 #if defined(CONFIG_ARM_FIRMWARE_HAS_SECURE_ENTRY_FUNCS)
 	spm_config_nsc_flash();
 
-#if defined(CONFIG_SECURE_SERVICES)
+#if defined(CONFIG_SPM_SECURE_SERVICES)
 	int err = spm_secure_services_init();
 
 	if (err != 0) {


### PR DESCRIPTION
A renaming seems to have gone wrong and one define in SPM was missed in
the renaming process. This made it impossible to turn on secure
services. Fixing the name of the define checked fixes this.

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>