### PR TITLE
manifest: Update mbed TLS to point out 2.16.3.

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -84,7 +84,7 @@ manifest:
     - name: mbedtls-nrf
       path: mbedtls
       repo-path: mbedtls
-      revision: mbedtls-2.13.1
+      revision: mbedtls-2.16.3
       remote: armmbed
 
     # The projects below are included for completeness, but they are


### PR DESCRIPTION
This commit updates the manifest file, west.yml, to refer to
mbed TLS 2.16.3.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>