### PR TITLE
lib: modem_info: Fix area code string termination

### DIFF
--- a/lib/modem_info/modem_info_params.c
+++ b/lib/modem_info/modem_info_params.c
@@ -53,10 +53,10 @@ static int area_code_parse(struct lte_param *area_code)
 		return -EINVAL;
 	}
 
-	area_code->value_string[2] = '\0';
+	area_code->value_string[4] = '\0';
 	/* Parses the string, interpreting its content as an 	*/
 	/* integral number with base 16. (Hexadecimal)		*/
-	area_code->value = (double)strtol(area_code->value_string, NULL, 16);
+	area_code->value = strtol(area_code->value_string, NULL, 16);
 
 	return 0;
 }


### PR DESCRIPTION
This patch fixes an issue where the are code string was null
terminated too early. The area code is 'a two-byte Tracking Area
Code (TAC) in hexadecimal format', which is represented in a
four-byte ASCII string. Null-termination is therefore moved from
byte 2 to 4. Also a cast to double is removed.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>