### PR TITLE
applications: asset_tracker: Stop sending invalid RSRP values

### DIFF
--- a/applications/asset_tracker/src/main.c
+++ b/applications/asset_tracker/src/main.c
@@ -378,6 +378,13 @@ static void modem_rsrp_handler(char rsrp_value)
 {
 	rsrp.value = rsrp_value;
 
+	/* If the RSRP value is 255, it's documented as 'not known or not
+	 * detectable'. Therefore, we should not send those values.
+	 */
+	if (rsrp.value == 255) {
+		return;
+	}
+
 	k_work_submit(&rsrp_work);
 }
 


### PR DESCRIPTION
The AT command documentation states that an RSRP value of 255
is 'not known or not detectable'. We should not send those
values, as they will be calculated as the impossible value of
+114 dBm when subtracting the static offset.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>