### PR TITLE
[DNM] drivers: entropy: Adjust Kconfig ENTROPY_FORCE_ALT flag

### DIFF
--- a/drivers/bt_ll_nrfxlib/entropy/Kconfig
+++ b/drivers/bt_ll_nrfxlib/entropy/Kconfig
@@ -9,7 +9,7 @@ if ENTROPY_GENERATOR
 config ENTROPY_NRF_LL_NRFXLIB
 	bool "nRF BLE Controller entropy driver"
 	default y
-	select ENTROPY_NRF_FORCE_ALT
+	select ENTROPY_FORCE_ALT
 	select ENTROPY_HAS_DRIVER
 	help
 	  This option enables the RNG peripheral, which is a random number

--- a/west.yml
+++ b/west.yml
@@ -38,7 +38,7 @@ manifest:
     - name: zephyr
       repo-path: fw-nrfconnect-zephyr
       west-commands: scripts/west-commands.yml
-      revision: d6e67554cfeb28df5525e53c073f61a00836f283
+      revision: pull/219/head
     - name: nffs
       revision: bc62a2fa9d98ddb5d633c932ea199bc68e10f194
       path: modules/fs/nffs


### PR DESCRIPTION
This PR follows a fix needed when https://github.com/NordicPlayground/fw-nrfconnect-zephyr/pull/219
is merged.

Until then, do not merge this PR.

This renames ENTROPY_NRF_FORCE_ALT into ENTROPY_FORCE_ALT

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>