### PR TITLE
lib: modem_info: Increase %CESQ notification parameter count

### DIFF
--- a/lib/modem_info/modem_info.c
+++ b/lib/modem_info/modem_info.c
@@ -66,7 +66,7 @@ LOG_MODULE_REGISTER(modem_info);
 #define DATE_TIME_DATA_NAME	"dateTime"
 
 #define RSRP_PARAM_INDEX	1
-#define RSRP_PARAM_COUNT	3
+#define RSRP_PARAM_COUNT	5
 #define RSRP_OFFSET_VAL		141
 
 #define BAND_PARAM_INDEX	1 /* Index of desired parameter */


### PR DESCRIPTION
The parameter count of unsolicited %CESQ notifications is now 5.
Increase the number in the lib as well to avoid -E2BIG errors.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>