### PR TITLE
bluetooth: gatt_dm: Avoid crash in DM on disconnection

### DIFF
--- a/subsys/bluetooth/gatt_dm.c
+++ b/subsys/bluetooth/gatt_dm.c
@@ -487,7 +487,11 @@ const struct bt_gatt_attr *bt_gatt_dm_char_by_uuid(
 	while ((curr = bt_gatt_dm_char_next(dm, curr)) != NULL) {
 		struct bt_gatt_chrc *chrc = bt_gatt_dm_attr_chrc_val(curr);
 
-		__ASSERT_NO_MSG(chrc != NULL);
+		if (chrc == NULL) {
+			LOG_ERR("No characteristic - device disconnected");
+			break;
+		}
+
 		if (!bt_uuid_cmp(uuid, chrc->uuid)) {
 			return curr;
 		}


### PR DESCRIPTION
It seems that discovery manager is not handling well the case
when device gets disconnected while performing discovery procedure.
This small patch fixes one of possible failing paths.

Jira:DESK-740

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>