### PR TITLE
net: aws_jobs: Fix aws_jobs_cmp matching empty string

### DIFF
--- a/subsys/net/lib/aws_jobs/src/aws_jobs.c
+++ b/subsys/net/lib/aws_jobs/src/aws_jobs.c
@@ -257,7 +257,8 @@ bool aws_jobs_cmp(const char *sub, const char *pub, size_t pub_len,
 {
 	int ret;
 
-	if (sub == NULL || pub == NULL || suffix == NULL) {
+	if (sub == NULL || pub == NULL || suffix == NULL ||
+	    sub[0] == '\0' || pub[0] == '\0') {
 		return false;
 	}
 

--- a/tests/aws_jobs/src/main.c
+++ b/tests/aws_jobs/src/main.c
@@ -38,6 +38,19 @@ static void test_aws_jobs_cmp__null(void)
 	zassert_false(ret, "");
 }
 
+static void test_aws_jobs_cmp__empty(void)
+{
+	const char *published = "$aws/things/nrf-id/jobs/notify-next";
+	const char *subscribed = "$aws/things/nrf-id/jobs/notify-next";
+	int ret;
+
+	ret = aws_jobs_cmp("", published, strlen(published), "");
+	zassert_false(ret, "Should not be equal, blank subscribed matched");
+
+	ret = aws_jobs_cmp(subscribed, "", strlen(published), "");
+	zassert_false(ret, "Should not be equal, blank published matched");
+}
+
 static void test_aws_jobs_cmp__no_suffix(void)
 {
 	const char *published = "$aws/things/nrf-id/jobs/notify-next";
@@ -99,6 +112,7 @@ void test_main(void)
 {
 	ztest_test_suite(aws_jobs_test,
 			 ztest_unit_test(test_aws_jobs_cmp__null),
+			 ztest_unit_test(test_aws_jobs_cmp__empty),
 			 ztest_unit_test(test_aws_jobs_cmp__no_suffix),
 			 ztest_unit_test(test_aws_jobs_cmp__suffix),
 			 ztest_unit_test(test_aws_jobs_subscribe_topic_update),


### PR DESCRIPTION
Adds a check making sure that an empty string will not match any other
string. Also updates test to reflect this.