### PR TITLE
Fetch hci data and events until no more available

### DIFF
--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -246,11 +246,6 @@ static void recv_thread(void *p1, void *p2, void *p3)
 	}
 }
 
-void _signal_handler_irq(void)
-{
-	k_sem_give(&sem_recv);
-}
-
 static void signal_thread(void *p1, void *p2, void *p3)
 {
 	ARG_UNUSED(p1);

--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -209,7 +209,7 @@ static void recv_thread(void *p1, void *p2, void *p3)
 	ARG_UNUSED(p2);
 	ARG_UNUSED(p3);
 
-	static u8_t hci_buffer[256 + 4];
+	static u8_t hci_buffer[HCI_MSG_BUFFER_MAX_SIZE];
 	int errcode;
 
 	BT_DBG("Started");


### PR DESCRIPTION
Fixes the situation where the hci driver could be waiting for a host signal even though there is events or data available