### PR TITLE
doc: update doc wrapper for incoming mcuboot file

### DIFF
--- a/doc/mcuboot/wrapper.rst
+++ b/doc/mcuboot/wrapper.rst
@@ -20,3 +20,4 @@ MCUboot documentation
    testplan-mynewt.md
    release.md
    PORTING.md
+   SECURITY.md


### PR DESCRIPTION
Update to the documentation wrapper file in
order to include new file into mcuboot doc scope.
This have to be done before the doc file introduction in
the child repository(https://github.com/NordicPlayground/fw-nrfconnect-mcuboot/pull/61) as otherwise CI will fail.



Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>