### PR TITLE
manifest: upgrade mcuboot revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -53,7 +53,7 @@ manifest:
       revision: c3be1b52f5e56aaba6039c423478cfaf62a91622
     - name: mcuboot
       repo-path: fw-nrfconnect-mcuboot
-      revision: 28be96b05d5adc725c939514d3d1bfd5b0fca519
+      revision: 1d7b0f2b990744295a03b29de91828e24b3c9c89
     - name: mcumgr
       repo-path: fw-nrfconnect-mcumgr
       revision: f663988d35da559a37f263d369842dbce309d1fa


### PR DESCRIPTION
In order to turn off automatic downstream test/doc jobs
for mcuboot.


Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>