### PR TITLE
gps: Copy DOP and fix ms type

### DIFF
--- a/drivers/nrf9160_gps/nrf9160_gps.c
+++ b/drivers/nrf9160_gps/nrf9160_gps.c
@@ -74,6 +74,10 @@ static void copy_pvt(struct gps_pvt *dest, nrf_gnss_pvt_data_frame_t *src)
 	dest->datetime.minute = src->datetime.minute;
 	dest->datetime.seconds = src->datetime.seconds;
 	dest->datetime.ms = src->datetime.ms;
+	dest->pdop = src->pdop;
+	dest->hdop = src->hdop;
+	dest->vdop = src->vdop;
+	dest->tdop = src->tdop;
 
 	for (size_t i = 0;
 	     i < MIN(NRF_GNSS_MAX_SATELLITES, GPS_MAX_SATELLITES); i++) {

--- a/include/gps.h
+++ b/include/gps.h
@@ -40,7 +40,7 @@ struct gps_datetime {
 	u8_t hour;
 	u8_t minute;
 	u8_t seconds;
-	u8_t ms;
+	u16_t ms;
 };
 
 struct gps_sv {


### PR DESCRIPTION
Two commits, one to fix the type of member "ms".
Other to copy the dilution of precision so that the application can filter based on it.
See wiki for more info: https://en.wikipedia.org/wiki/Dilution_of_precision_(navigation)
