### PR TITLE
manifest: update nrfxlib for Oberon 3.0.2

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -72,7 +72,7 @@ manifest:
       revision: 30b7efa827b04d2e47840716b0372737fe7d6c92
     - name: nrfxlib
       path: nrfxlib
-      revision: 0c4b1e210bb95f6d84ccd5db05df52fab684aeec
+      revision: a806f5fcac3bde98c4c7324a0c4d547b4ba89f75
     - name: cmock
       path: test/cmock
       revision: c243b9a7a7b3c471023193992b46cf1bd1910450


### PR DESCRIPTION
Update nrfxlib to get oberon 3.0.2

Depends on https://github.com/NordicPlayground/nrfxlib/pull/89 being merged.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>