### PR TITLE
drivers: at_cmd: fix size_t header dependency

### DIFF
--- a/include/at_cmd.h
+++ b/include/at_cmd.h
@@ -22,6 +22,7 @@ extern "C" {
 #endif
 
 #include <zephyr/types.h>
+#include <stddef.h>
 
 /**
  * @brief AT command return codes


### PR DESCRIPTION
If reordering at_cmd.h in the application, you will get
a compile error on size_t. By adding stddef.h, you can
now freely reorder your includes in the application

Signed-off-by: Håkon Alseth <haal@nordicsemi.no>