### PR TITLE
samples: nrf9160: aws_fota: Add warning with regards to provisioning

### DIFF
--- a/samples/nrf9160/aws_fota/CMakeLists.txt
+++ b/samples/nrf9160/aws_fota/CMakeLists.txt
@@ -8,6 +8,19 @@ cmake_minimum_required(VERSION 3.8.2)
 
 include(../../../cmake/boilerplate.cmake NO_POLICY_SCOPE)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+if(CONFIG_PROVISION_CERTIFICATES)
+  message(WARNING "
+      ------------------------------------------------------------
+      --- WARNING: Provisioning certificates is ENABLED. Do    ---
+      --- not use this binary in production or share it with   ---
+      --- anyone. It has certificates stored in readable flash,---
+      --- the binary, and the modem traces. Only use this      ---
+      --- binary once to provision certificates for development---
+      --- to reduce flash tear. After the certificates are     ---
+      --- provisioned, disable this option and rebuild the     ---
+      --- sample.                                              ---
+      ------------------------------------------------------------")
+endif()
 project(mqtt-aws-jobs-fota)
 
 # NORDIC SDK APP START

--- a/samples/nrf9160/aws_fota/Kconfig
+++ b/samples/nrf9160/aws_fota/Kconfig
@@ -10,38 +10,60 @@ config APP_VERSION
 	string "Application version"
 	default "v1.0.0"
 
+config USE_NRF_CLOUD
+	bool "Use nRF Cloud"
+	default n
+
+if !USE_NRF_CLOUD
 config CLOUD_CERT_SEC_TAG
-	int "Secure tag fo TLS credentials"
-	default 16842753
+	int "Security tag for TLS credentials"
+	default 12345678
 
-config MQTT_BROKER_HOSTNAME
-	string "AWS IoT MQTT broker hostname"
-	default "a2n7tk1kp18wix-ats.iot.us-east-1.amazonaws.com"
+config PROVISION_CERTIFICATES
+	bool "Provision certificates from the certificates.h file"
+	default n
 	help
-	  Default is set to be the NRF Cloud MQTT broker
-
-config MQTT_BROKER_PORT
-	int "AWS IoT MQTT broker port"
-	default 8883
+	  If enabled, the sample provisions server certificates into
+	  the modem by storing the certificates defined in the
+	  certificates.h file in the modem under the given security tag.
+	  Use this option only once to provision the device.
+	  The certificates are stored in the application binary and are
+	  therefore shown in the modem trace information. This is a
+	  security risk. After provisioning the certificates, turn off
+	  this option and compile and program the sample again.
+	  Also, do not share the binary that includes the compiled
+	  certificates with anyone.
 
 config USE_CLOUD_CLIENT_ID
-	bool "Custom MQTT Client Id"
+	bool "Custom MQTT client ID"
+	default y
 if USE_CLOUD_CLIENT_ID
-
 config CLOUD_CLIENT_ID
 	string "Client ID"
 	default "your_client_id"
 endif
 
-config USE_PROVISIONED_CERTIFICATES
-	bool "Use provisioned certificates"
-	default y
+config MQTT_BROKER_HOSTNAME
+	string "AWS IoT MQTT broker hostname"
+	default "your_aws_mqtt_broker_hostname.amazonaws.com"
 	help
-	  If enabled, the application will not provide server certificates into
-	  the modem and use whatever certificates that are stored in the modem
-	  under the default secure tag (e. g. certificates provisioned by
-	  another sample, for instance, `asset_tracker`). Otherwise, a user
-	  should provide a valid server certificate in `certificates.h` file.
+	  Default is set to be the nRF Cloud MQTT broker.
+config MQTT_BROKER_PORT
+	int "AWS IoT MQTT broker port"
+	default 8883
+endif #!USE_NRF_CLOUD
+
+if USE_NRF_CLOUD
+config MQTT_BROKER_HOSTNAME
+	string
+	default "a2n7tk1kp18wix-ats.iot.us-east-1.amazonaws.com"
+	help
+	  Default is set to be the nRF Cloud MQTT broker.
+
+config MQTT_BROKER_PORT
+	int
+	default 8883
+endif #USE_NRF_CLOUD
 
 config MQTT_MESSAGE_BUFFER_SIZE
 	int "MQTT message buffer size"

--- a/samples/nrf9160/aws_fota/README.rst
+++ b/samples/nrf9160/aws_fota/README.rst
@@ -61,9 +61,15 @@ Also, make sure to download one of the `root CA certificates <https://docs.aws.a
 
 Then, attach the policy you created earlier to the certificates. You must also add the information from the Root CA, Public Certificate, and Private Key into :file:`certificates.h`.
 
-When these steps are done, deselect ``CONFIG_USE_PROVISIONED_CERTIFICATES`` in menuconfig.
-This will write your new certificates to the secure tag :c:type:`sec_tag_t` defined in menuconfig ``CONFIG_CLOUD_CERT_SEC_TAG`` into the modem.
+When these steps are done, select ``CONFIG_PROVISION_CERTIFICATES`` in Kconfig.
+This will write your new certificates into the modem, to the security tag :c:type:`sec_tag_t` defined in the Kconfig variable ``CONFIG_CLOUD_CERT_SEC_TAG``.
 
+.. warning::
+
+   After provisioning the certificates once, make sure to deselect this option and compile and program the sample again.
+   Otherwise, the certificates are stored in the area of readable flash on the device, and they are visible in the compiled binary and on a modem trace.
+   This is a security risk for your private key and certificate if the binary is published or leaked, or if the device flash is dumped.
+   In production, never store certificates in readable flash on the device or write them to the modem, because these writes are visible on a modem trace.
 
 Usage
 *****

--- a/samples/nrf9160/aws_fota/src/main.c
+++ b/samples/nrf9160/aws_fota/src/main.c
@@ -18,11 +18,15 @@
 #include <dfu/mcuboot.h>
 #include <misc/reboot.h>
 
+#if defined(CONFIG_USE_NRF_CLOUD)
+#define NRF_CLOUD_SECURITY_TAG 16842753
+#endif
+
 #if defined(CONFIG_BSD_LIBRARY)
 #include "nrf_inbuilt_key.h"
 #endif
 
-#if !defined(CONFIG_USE_PROVISIONED_CERTIFICATES)
+#if defined(CONFIG_PROVISION_CERTIFICATES)
 #include "certificates.h"
 #endif
 
@@ -238,7 +242,8 @@ static void broker_init(const char *hostname)
 			broker->sin_family = AF_INET;
 			broker->sin_port = htons(CONFIG_MQTT_BROKER_PORT);
 
-			printk("IPv4 Address 0x%08x\n", broker->sin_addr.s_addr);
+			printk("IPv4 Address 0x%08x\n",
+				broker->sin_addr.s_addr);
 			break;
 		} else if (addr->ai_addrlen == sizeof(struct sockaddr_in6)) {
 			/* IPv6 Address. */
@@ -268,57 +273,48 @@ static void broker_init(const char *hostname)
 	/* Free the address. */
 	freeaddrinfo(result);
 }
-
-#if !defined(CONFIG_USE_PROVISIONED_CERTIFICATES)
+#if defined(CONFIG_PROVISION_CERTIFICATES)
+#warning Not for prodcution use. This should only be used once to provisioning the certificates please deselect the provision certificates configuration and compile again.
+#define MAX_OF_2 MAX(sizeof(CLOUD_CA_CERTIFICATE),\
+		     sizeof(CLOUD_CLIENT_PRIVATE_KEY))
+#define MAX_LEN MAX(MAX_OF_2, sizeof(CLOUD_CLIENT_PUBLIC_CERTIFICATE))
+static u8_t certificates[][MAX_LEN] = {{CLOUD_CA_CERTIFICATE},
+				       {CLOUD_CLIENT_PRIVATE_KEY},
+				       {CLOUD_CLIENT_PUBLIC_CERTIFICATE} };
+static const size_t cert_len[] = {
+	sizeof(CLOUD_CA_CERTIFICATE) - 1, sizeof(CLOUD_CLIENT_PRIVATE_KEY) - 1,
+	sizeof(CLOUD_CLIENT_PUBLIC_CERTIFICATE) - 1
+};
 static int provision_certificates(void)
 {
-	{
-		int err;
+	int err;
 
-		/* Delete certificates */
-		nrf_sec_tag_t sec_tag = CONFIG_CLOUD_CERT_SEC_TAG;
+	printk("************************* WARNING *************************\n");
+	printk("%s called do not use this in production!\n", __func__);
+	printk("This will store the certificates in readable flash and leave\n");
+	printk("them exposed on modem_traces. Only use this once for\n");
+	printk("provisioning certificates for development to reduce flash tear."
+		"\n");
+	printk("************************* WARNING *************************\n");
+	nrf_sec_tag_t sec_tag = CONFIG_CLOUD_CERT_SEC_TAG;
+	nrf_key_mgnt_cred_type_t cred[] = {
+		NRF_KEY_MGMT_CRED_TYPE_CA_CHAIN,
+		NRF_KEY_MGMT_CRED_TYPE_PRIVATE_CERT,
+		NRF_KEY_MGMT_CRED_TYPE_PUBLIC_CERT,
+	};
 
-		for (nrf_key_mgnt_cred_type_t type = 0; type < 3; type++) {
-			err = nrf_inbuilt_key_delete(sec_tag, type);
-			printk("nrf_inbuilt_key_delete(%u, %d) => result=%d\n",
+	/* Delete certificates */
+	for (nrf_key_mgnt_cred_type_t type = 0; type < 3; type++) {
+		err = nrf_inbuilt_key_delete(sec_tag, type);
+		printk("nrf_inbuilt_key_delete(%u, %d) => result=%d\n",
 				sec_tag, type, err);
-		}
+	}
 
-		/* Provision CA Certificate. */
-		err = nrf_inbuilt_key_write(CONFIG_CLOUD_CERT_SEC_TAG,
-					NRF_KEY_MGMT_CRED_TYPE_CA_CHAIN,
-					CLOUD_CA_CERTIFICATE,
-					strlen(CLOUD_CA_CERTIFICATE));
+	/* Write certificates */
+	for (nrf_key_mgnt_cred_type_t type = 0; type < 3; type++) {
+		err = nrf_inbuilt_key_write(sec_tag, cred[type],
+				certificates[type], cert_len[type]);
 		printk("nrf_inbuilt_key_write => result=%d\n", err);
-		if (err) {
-			printk("CLOUD_CA_CERTIFICATE err: %d", err);
-			return err;
-		}
-
-		/* Provision Private Certificate. */
-		err = nrf_inbuilt_key_write(
-			CONFIG_CLOUD_CERT_SEC_TAG,
-			NRF_KEY_MGMT_CRED_TYPE_PRIVATE_CERT,
-			CLOUD_CLIENT_PRIVATE_KEY,
-			strlen(CLOUD_CLIENT_PRIVATE_KEY));
-		printk("nrf_inbuilt_key_write => result=%d\n", err);
-		if (err) {
-			printk("NRF_CLOUD_CLIENT_PRIVATE_KEY err: %d", err);
-			return err;
-		}
-
-		/* Provision Public Certificate. */
-		err = nrf_inbuilt_key_write(
-			CONFIG_CLOUD_CERT_SEC_TAG,
-			NRF_KEY_MGMT_CRED_TYPE_PUBLIC_CERT,
-				 CLOUD_CLIENT_PUBLIC_CERTIFICATE,
-				 strlen(CLOUD_CLIENT_PUBLIC_CERTIFICATE));
-		printk("nrf_inbuilt_key_write => result=%d\n", err);
-		if (err) {
-			printk("CLOUD_CLIENT_PUBLIC_CERTIFICATE err: %d",
-				err);
-			return err;
-		}
 	}
 	return 0;
 }
@@ -329,10 +325,11 @@ static int client_id_get(char *id_buf)
 #if !defined(CONFIG_CLOUD_CLIENT_ID)
 	enum at_cmd_state at_state;
 	char imei_buf[IMEI_LEN + 5];
-
 	int err = at_cmd_write("AT+CGSN", imei_buf, (IMEI_LEN + 5), &at_state);
+
 	if (err) {
-		printk("Error when trying to do at_cmd_write: %d, at_state: %d", err, at_state);
+		printk("Error when trying to do at_cmd_write: %d, at_state: %d",
+			err, at_state);
 	}
 
 	snprintf(id_buf, CLIENT_ID_LEN + 1, "nrf-%s", imei_buf);
@@ -347,10 +344,9 @@ static int client_init(struct mqtt_client *client, char *hostname)
 {
 	mqtt_client_init(client);
 	broker_init(hostname);
-
 	int ret = client_id_get(client_id_buf);
-	printk("client_id: %s\n", client_id_buf);
 
+	printk("client_id: %s\n", client_id_buf);
 	if (ret != 0) {
 		return ret;
 	}
@@ -373,7 +369,13 @@ static int client_init(struct mqtt_client *client, char *hostname)
 	/* MQTT transport configuration */
 	client->transport.type = MQTT_TRANSPORT_SECURE;
 
-	static sec_tag_t sec_tag_list[] = {CONFIG_CLOUD_CERT_SEC_TAG};
+	static sec_tag_t sec_tag_list[] = {
+#ifdef CONFIG_USE_NRF_CLOUD
+		NRF_CLOUD_SECURITY_TAG
+#else
+		CONFIG_CLOUD_CERT_SEC_TAG
+#endif
+	};
 	struct mqtt_sec_config *tls_config = &(client->transport).tls.config;
 
 	tls_config->peer_verify = 2;
@@ -460,9 +462,9 @@ void main(void)
 	}
 	printk("Initialized bsdlib\n");
 
-#if !defined(CONFIG_USE_PROVISIONED_CERTIFICATES)
+#if defined(CONFIG_PROVISION_CERTIFICATES)
 	provision_certificates();
-#endif /* CONFIG_USE_PROVISIONED_CERTIFICATES  */
+#endif /* CONFIG_PROVISION_CERTIFICATES */
 	modem_configure();
 
 	client_init(&client, CONFIG_MQTT_BROKER_HOSTNAME);
@@ -486,7 +488,8 @@ void main(void)
 	}
 
 	/* All initializations were successful mark image as working so that we
-	 * will not revert upon reboot. */
+	 * will not revert upon reboot.
+	 */
 	boot_write_img_confirmed();
 
 	while (1) {


### PR DESCRIPTION
Add warnings in Cmake, help text in Kconfig, uart print and compiler
warning. To ensure that users do not expose their private keys or
certificates accidentaly.

Fixes NCSDK-3234

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>