### PR TITLE
lib: bsdlib: Set offloaded flag on nRF91 interface

### DIFF
--- a/lib/bsdlib/nrf91_sockets.c
+++ b/lib/bsdlib/nrf91_sockets.c
@@ -934,18 +934,13 @@ static int nrf91_bsdlib_socket_offload_init(struct device *arg)
 
 static struct nrf91_socket_iface_data {
 	struct net_if *iface;
-	u8_t dummy_link_addr;
 } nrf91_socket_iface_data;
 
 static void nrf91_socket_iface_init(struct net_if *iface)
 {
 	nrf91_socket_iface_data.iface = iface;
 
-	/* FIXME Zephyr's interface initialization function checks for link
-	 *       address presence, set dummy placeholder for now.
-	 */
-	net_if_set_link_addr(iface, &nrf91_socket_iface_data.dummy_link_addr, 1,
-			     NET_LINK_UNKNOWN);
+	iface->if_dev->offloaded = true;
 
 	socket_offload_register(&nrf91_socket_offload_ops);
 }


### PR DESCRIPTION
Setting `offloaded` flag on nRF91 network interface will prevent calling
functions specific to native network stack during interface
initialization.

This prevents a system crash during initialization, when native network
stack and IPv6 remained enabled.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>