### PR TITLE
bluetooth: controller: Update west to ble_controller_0.3.0-3.prealpha

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -72,7 +72,7 @@ manifest:
       revision: 30b7efa827b04d2e47840716b0372737fe7d6c92
     - name: nrfxlib
       path: nrfxlib
-      revision: 9f9bd638a5a7cce77ee47e195e6458822ffc5e75
+      revision: 0c4b1e210bb95f6d84ccd5db05df52fab684aeec
     - name: cmock
       path: test/cmock
       revision: c243b9a7a7b3c471023193992b46cf1bd1910450


### PR DESCRIPTION
This controller adds support for nRF52833 and fixes hci_data_get()
when multiple devices are connected.

Signed-off-by: Rubin Gerritsen <Rubin.Gerritsen@nordicsemi.no>