### PR TITLE
manifest: update nrfxlib

### DIFF
--- a/applications/asset_tracker/README.rst
+++ b/applications/asset_tracker/README.rst
@@ -76,7 +76,6 @@ LED 3 and LED 4:
     Application state indicated by LEDs
 
 All LEDs (1-4):
-    * Blinking simultaneously: Irrecoverable error in the BSD library.
     * Blinking in groups of two (LED 1 and 3, LED 2 and 4): Recoverable error in the BSD library.
     * Blinking in cross pattern (LED 1 and 4, LED 2 and 3): Communication error with the nRF Cloud.
 

--- a/applications/asset_tracker/src/main.c
+++ b/applications/asset_tracker/src/main.c
@@ -120,7 +120,6 @@ static struct k_work rsrp_work;
 enum error_type {
 	ERROR_CLOUD,
 	ERROR_BSD_RECOVERABLE,
-	ERROR_BSD_IRRECOVERABLE,
 	ERROR_LTE_LC,
 	ERROR_SYSTEM_FAULT
 };
@@ -178,13 +177,6 @@ void error_handler(enum error_type err_type, int err_code)
 		ui_led_set_pattern(UI_LED_ERROR_BSD_REC);
 		printk("Error of type ERROR_BSD_RECOVERABLE: %d\n", err_code);
 	break;
-	case ERROR_BSD_IRRECOVERABLE:
-		/* Blinking all LEDs ON/OFF if there is an
-		 * irrecoverable error.
-		 */
-		ui_led_set_pattern(UI_LED_ERROR_BSD_IRREC);
-		printk("Error of type ERROR_BSD_IRRECOVERABLE: %d\n", err_code);
-	break;
 	default:
 		/* Blinking all LEDs ON/OFF in pairs (1 and 2, 3 and 4)
 		 * undefined error.
@@ -221,12 +213,6 @@ void cloud_error_handler(int err)
 void bsd_recoverable_error_handler(uint32_t err)
 {
 	error_handler(ERROR_BSD_RECOVERABLE, (int)err);
-}
-
-/**@brief Irrecoverable BSD library error. */
-void bsd_irrecoverable_error_handler(uint32_t err)
-{
-	error_handler(ERROR_BSD_IRRECOVERABLE, (int)err);
 }
 
 static void send_gps_data_work_fn(struct k_work *work)

--- a/lib/bsdlib/nrf91_sockets.c
+++ b/lib/bsdlib/nrf91_sockets.c
@@ -266,6 +266,8 @@ static int z_to_nrf_family(sa_family_t z_family)
 		return NRF_AF_LTE;
 	case AF_LOCAL:
 		return NRF_AF_LOCAL;
+	case AF_PACKET:
+		return NRF_AF_PACKET;
 	case AF_UNSPEC:
 	/* No NRF_AF_UNSPEC defined. */
 	default:
@@ -284,6 +286,8 @@ static int nrf_to_z_family(nrf_socket_family_t nrf_family)
 		return AF_LTE;
 	case NRF_AF_LOCAL:
 		return AF_LOCAL;
+	case NRF_AF_PACKET:
+		return AF_PACKET;
 	default:
 		return -EAFNOSUPPORT;
 	}
@@ -323,6 +327,8 @@ static int z_to_nrf_socktype(int socktype)
 	switch (socktype) {
 	case SOCK_MGMT:
 		return NRF_SOCK_MGMT;
+	case SOCK_RAW:
+		return NRF_SOCK_RAW;
 	default:
 		return socktype;
 	}

--- a/samples/nrf9160/at_client/src/main.c
+++ b/samples/nrf9160/at_client/src/main.c
@@ -15,14 +15,6 @@ void bsd_recoverable_error_handler(uint32_t err)
 	printk("bsdlib recoverable error: %u\n", err);
 }
 
-/**@brief Irrecoverable BSD library error. */
-void bsd_irrecoverable_error_handler(uint32_t err)
-{
-	printk("bsdlib irrecoverable error: %u\n", err);
-
-	__ASSERT_NO_MSG(false);
-}
-
 void main(void)
 {
 	printk("The AT host sample started\n");

--- a/samples/nrf9160/aws_fota/src/main.c
+++ b/samples/nrf9160/aws_fota/src/main.c
@@ -55,14 +55,6 @@ void bsd_recoverable_error_handler(uint32_t err)
 	printk("bsdlib recoverable error: %u\n", err);
 }
 
-/**@brief Irrecoverable BSD library error. */
-void bsd_irrecoverable_error_handler(uint32_t err)
-{
-	printk("bsdlib irrecoverable error: %u\n", err);
-
-	__ASSERT_NO_MSG(false);
-}
-
 #endif /* defined(CONFIG_BSD_LIBRARY) */
 
 /**@brief Function to print strings without null-termination. */
@@ -454,7 +446,10 @@ void main(void)
 		printk("Modem firmware update failed\n");
 		printk("Fatal error.\n");
 		break;
-
+	case -1:
+		printk("Could not initialize bsdlib.\n");
+		printk("Fatal error.\n");
+		return;
 	default:
 		break;
 	}

--- a/samples/nrf9160/coap_client/src/main.c
+++ b/samples/nrf9160/coap_client/src/main.c
@@ -34,14 +34,6 @@ void bsd_recoverable_error_handler(uint32_t err)
 	printk("bsdlib recoverable error: %u\n", (unsigned int)err);
 }
 
-/**@brief Irrecoverable BSD library error. */
-void bsd_irrecoverable_error_handler(uint32_t err)
-{
-	printk("bsdlib irrecoverable error: %u\n", (unsigned int)err);
-
-	__ASSERT_NO_MSG(false);
-}
-
 #endif /* defined(CONFIG_BSD_LIBRARY) */
 
 /**@brief Resolves the configured hostname. */

--- a/samples/nrf9160/gps/src/main.c
+++ b/samples/nrf9160/gps/src/main.c
@@ -40,11 +40,6 @@ void bsd_recoverable_error_handler(uint32_t error)
 	printf("Err: %lu\n", (unsigned long)error);
 }
 
-void bsd_irrecoverable_error_handler(uint32_t error)
-{
-	printf("Irrecoverable: %lu\n", (unsigned long)error);
-}
-
 static int enable_gps(void)
 {
 	int  at_sock;

--- a/samples/nrf9160/http_application_update/src/main.c
+++ b/samples/nrf9160/http_application_update/src/main.c
@@ -27,14 +27,6 @@ void bsd_recoverable_error_handler(uint32_t err)
 	printk("bsdlib recoverable error: %u\n", err);
 }
 
-/**@brief Irrecoverable BSD library error. */
-void bsd_irrecoverable_error_handler(uint32_t err)
-{
-	printk("bsdlib irrecoverable error: %u\n", err);
-
-	__ASSERT_NO_MSG(false);
-}
-
 /**@brief Start transfer of the file. */
 static void app_dfu_transfer_start(struct k_work *unused)
 {
@@ -190,7 +182,10 @@ void main(void)
 		printk("Modem firmware update failed\n");
 		printk("Fatal error.\n");
 		break;
-
+	case -1:
+		printk("Could not initialize bsdlib.\n");
+		printk("Fatal error.\n");
+		return;
 	default:
 		break;
 	}

--- a/samples/nrf9160/lte_ble_gateway/src/main.c
+++ b/samples/nrf9160/lte_ble_gateway/src/main.c
@@ -73,7 +73,6 @@ static struct k_work connect_work;
 enum error_type {
 	ERROR_NRF_CLOUD,
 	ERROR_BSD_RECOVERABLE,
-	ERROR_BSD_IRRECOVERABLE
 };
 
 /* Forward declaration of functions */
@@ -116,13 +115,6 @@ void error_handler(enum error_type err_type, int err)
 		led_pattern = DK_LED1_MSK | DK_LED3_MSK;
 		printk("Error of type ERROR_BSD_RECOVERABLE: %d\n", err);
 		break;
-	case ERROR_BSD_IRRECOVERABLE:
-		/* Blinking all LEDs ON/OFF if there is an
-		 * irrecoverable error.
-		 */
-		led_pattern = DK_ALL_LEDS_MSK;
-		printk("Error of type ERROR_BSD_IRRECOVERABLE: %d\n", err);
-		break;
 	default:
 		/* Blinking all LEDs ON/OFF in pairs (1 and 2, 3 and 4)
 		 * undefined error.
@@ -149,12 +141,6 @@ void nrf_cloud_error_handler(int err)
 void bsd_recoverable_error_handler(uint32_t err)
 {
 	error_handler(ERROR_BSD_RECOVERABLE, (int)err);
-}
-
-/**@brief Irrecoverable BSD library error. */
-void bsd_irrecoverable_error_handler(uint32_t err)
-{
-	error_handler(ERROR_BSD_IRRECOVERABLE, (int)err);
 }
 
 /**@brief Callback for GPS trigger events */

--- a/samples/nrf9160/lwm2m_carrier/src/main.c
+++ b/samples/nrf9160/lwm2m_carrier/src/main.c
@@ -11,12 +11,6 @@ void bsd_recoverable_error_handler(uint32_t err)
 	printk("bsdlib recoverable error: %u\n", (unsigned int)err);
 }
 
-void bsd_irrecoverable_error_handler(uint32_t err)
-{
-	printk("bsdlib irrecoverable error: %u\n", (unsigned int)err);
-	__ASSERT_NO_MSG(false);
-}
-
 void lwm2m_carrier_event_handler(const lwm2m_carrier_event_t *event)
 {
 	switch (event->type) {

--- a/samples/nrf9160/mqtt_simple/src/main.c
+++ b/samples/nrf9160/mqtt_simple/src/main.c
@@ -41,14 +41,6 @@ void bsd_recoverable_error_handler(uint32_t err)
 	printk("bsdlib recoverable error: %u\n", (unsigned int)err);
 }
 
-/**@brief Irrecoverable BSD library error. */
-void bsd_irrecoverable_error_handler(uint32_t err)
-{
-	printk("bsdlib irrecoverable error: %u\n", (unsigned int)err);
-
-	__ASSERT_NO_MSG(false);
-}
-
 #endif /* defined(CONFIG_BSD_LIBRARY) */
 
 #if defined(CONFIG_LWM2M_CARRIER)


### PR DESCRIPTION
Update nrfxlib to include bsdlib 0.5.0.
The main change is the removal of `bsd_irrecoverable_error_handler()`.