### PR TITLE
subsys: net: lib: aws_fota: Move device shadow out from library

### DIFF
--- a/samples/nrf9160/aws_fota/Kconfig
+++ b/samples/nrf9160/aws_fota/Kconfig
@@ -51,6 +51,10 @@ config MQTT_PAYLOAD_BUFFER_SIZE
 	int "MQTT payload buffer size"
 	default 128
 
+config DEVICE_SHADOW_PAYLOAD_SIZE
+	int "MQTT payload transmission buffer size for AWS IoT device shadow updates"
+	default 255
+
 endmenu
 
 menu "Zephyr Kernel"

--- a/samples/nrf9160/aws_fota/src/main.c
+++ b/samples/nrf9160/aws_fota/src/main.c
@@ -104,11 +104,6 @@ void mqtt_evt_handler(struct mqtt_client * const c,
 		return;
 	} else if (err < 0) {
 		printk("aws_fota_mqtt_evt_handler: Failed! %d\n", err);
-		printk("Disconnecting MQTT client...\n");
-		err = mqtt_disconnect(c);
-		if (err) {
-			printk("Could not disconnect: %d\n", err);
-		}
 	}
 
 	switch (evt->type) {
@@ -119,14 +114,6 @@ void mqtt_evt_handler(struct mqtt_client * const c,
 		}
 
 		printk("[%s:%d] MQTT client connected!\n", __func__, __LINE__);
-		if (err) {
-			printk("Unable to initialize AWS jobs upon "
-			       "connection\n");
-			err = mqtt_disconnect(c);
-			if (err) {
-				printk("Could not disconnect: %d\n", err);
-			}
-		}
 		break;
 
 	case MQTT_EVT_DISCONNECT:

--- a/subsys/net/lib/aws_fota/Kconfig
+++ b/subsys/net/lib/aws_fota/Kconfig
@@ -21,10 +21,6 @@ config AWS_FOTA_PAYLOAD_SIZE
 	int "MQTT payload reception buffer size for AWS IoT Jobs messages"
 	default 1350
 
-config DEVICE_SHADOW_PAYLOAD_SIZE
-	int "MQTT payload transmission buffer size for AWS IoT device shadow updates"
-	default 255
-
 config AWS_FOTA_HOSTNAME_MAX_LEN
 	int "Hostname buffer size"
 	default 255


### PR DESCRIPTION
Move device shadow otu from the AWS FOTA library allowing users to
configure their own device shadow in the sample and enables better
interopt with the nRF Cloud library.

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>