### PR TITLE
cmake: partition_manager: support subsys defined pm.yml

### DIFF
--- a/cmake/partition_manager.cmake
+++ b/cmake/partition_manager.cmake
@@ -15,6 +15,7 @@ set(${IMAGE}logical_target ${logical_target_for_zephyr_elf} CACHE STRING "" FORC
 
 if(FIRST_BOILERPLATE_EXECUTION)
   get_property(PM_IMAGES GLOBAL PROPERTY PM_IMAGES)
+  get_property(PM_SUBSYS_PREPROCESSED GLOBAL PROPERTY PM_SUBSYS_PREPROCESSED)
 
   set(static_configuration_file ${APPLICATION_SOURCE_DIR}/pm_static.yml)
 
@@ -41,6 +42,9 @@ if(FIRST_BOILERPLATE_EXECUTION)
       list(APPEND input_files ${${IMAGE}PROJECT_BINARY_DIR}/${generated_path}/pm.yml)
       list(APPEND header_files ${${IMAGE}PROJECT_BINARY_DIR}/${generated_path}/pm_config.h)
     endforeach()
+
+    # Add subsys defined pm.yml to the input_files
+    list(APPEND input_files ${PM_SUBSYS_PREPROCESSED})
 
     math(EXPR flash_size "${CONFIG_FLASH_SIZE} * 1024")
 

--- a/scripts/partition_manager.py
+++ b/scripts/partition_manager.py
@@ -409,7 +409,12 @@ def load_reqs(reqs, input_config):
     for ymlpath in input_config:
         if path.exists(ymlpath):
             with open(ymlpath, 'r') as f:
-                reqs.update(yaml.safe_load(f))
+                loaded_reqs = yaml.safe_load(f)
+                for key in loaded_reqs.keys():
+                    if key in reqs.keys() and loaded_reqs[key] != reqs[key]:
+                        raise RuntimeError("Conflicting configuration found for '{}' value for key '{}' differs."
+                                           "val1: {} val2: {} ".format(f.name, key, loaded_reqs[key], reqs[key]))
+                reqs.update(loaded_reqs)
 
     reqs['app'] = dict()
 

--- a/scripts/partition_manager/partition_manager.rst
+++ b/scripts/partition_manager/partition_manager.rst
@@ -49,6 +49,21 @@ This file must be stored in the same folder as the main :file:`CMakeLists.txt` f
    The root application does not need to define a :file:`pm.yml` file, because its partition size and placement is implied by the size and placement of the sub-image partitions.
    If a root application defines a :file:`pm.yml` file, it is silently ignored.
 
+Partition Manager configuration can be also provided by a subsystem.
+Subsystem Partition Manager configurations cannot define image partitions.
+
+There are some limitations when multiple images include the same subsystem which defines a Partition Manager configuration.
+All partitions are global, and will only be included once, even if multiple configurations define them.
+When multiple configurations define the same partition, the configuration of that partition must be identical in all definitions.
+An exception is raised if the configuration differs.
+
+The listing below shows how to properly define the Partition Manager configuration for a subsystem.
+This must be placed in the :file:`CMakeLists.txt` that defines the subsystem.
+
+.. code-block:: cmake
+
+  add_partition_manager_config(pm.yml)
+
 .. _pm_yaml_format:
 
 Configuration file format

--- a/subsys/partition_manager/CMakeLists.txt
+++ b/subsys/partition_manager/CMakeLists.txt
@@ -45,3 +45,21 @@ if((EXISTS ${APPLICATION_SOURCE_DIR}/pm.yml) AND IMAGE)
     ${IMAGE}
     )
 endif()
+
+get_property(img_pm_subsys GLOBAL PROPERTY ${IMAGE}PM_SUBSYS)
+if (img_pm_subsys)
+  foreach (subsys_pm_yml ${img_pm_subsys})
+    file(RELATIVE_PATH rel_path_to_yml ${ZEPHYR_BASE} ${subsys_pm_yml})
+    set(subsys_pm_preprocessed
+      ${PROJECT_BINARY_DIR}/${rel_path_to_yml})
+    preprocess_pm_yml(
+      ${subsys_pm_yml}
+      ${subsys_pm_preprocessed}
+      )
+  set_property(
+    GLOBAL APPEND PROPERTY
+    PM_SUBSYS_PREPROCESSED
+      ${subsys_pm_preprocessed}
+    )
+  endforeach()
+endif()

--- a/west.yml
+++ b/west.yml
@@ -38,7 +38,7 @@ manifest:
     - name: zephyr
       repo-path: fw-nrfconnect-zephyr
       west-commands: scripts/west-commands.yml
-      revision: fc95403819ca26d7db05496ea4142a5d0ccaddd3
+      revision: 919640cdd332d64a0694fc686027d1e919f30ce1
     - name: nffs
       revision: bc62a2fa9d98ddb5d633c932ea199bc68e10f194
       path: modules/fs/nffs


### PR DESCRIPTION
Allow subsystems to define pm.yml files for defining partitions.

tested with: ncs/zephyr/tests/subsys/settings/nffs/raw/build on pca10090ns

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>