### PR TITLE
subsys: dfu: support parsing paths for B1 MCUBoot upgrades

### DIFF
--- a/subsys/dfu/include/dfu_target_mcuboot.h
+++ b/subsys/dfu/include/dfu_target_mcuboot.h
@@ -20,6 +20,25 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Find correct MCUBoot update file path entry in space separated string.
+ *
+ * When supporting upgrades of the MCUBoot bootloader, two variants of the new
+ * firmware is presented, each linked against a different address.
+ * This function is told what slot is active, and sets the update pointer to
+ * point to the correct none active entry in the file path.
+ *
+ * @param[in, out] file      pointer to file path with space separator. Note
+ *                           that the space separator can be replaced by a NULL
+ *                           terminator.
+ * @param[in]      s0_active bool indicating if S0 is the currently active slot.
+ * @param[out]     update    pointer to correct file MCUBoot bootloader upgrade.
+ *                           Will be set to NULL if no space separator is found.
+ *
+ * @retval 0 If successful (note that this does not imply that a space
+ *           separator was found) negative errno otherwise.
+ */
+int dfu_ctx_mcuboot_set_b1_file(char *file, bool s0_active, char **update);
 
 /**
  * @brief See if data in buf indicates MCUBoot style upgrade.

--- a/subsys/net/lib/fota_download/CMakeLists.txt
+++ b/subsys/net/lib/fota_download/CMakeLists.txt
@@ -7,3 +7,6 @@ zephyr_library()
 zephyr_library_sources(
   src/fota_download.c
   )
+
+zephyr_include_directories_ifdef(CONFIG_SECURE_BOOT
+  ${ZEPHYR_BASE}/../nrf/subsys/dfu/include)

--- a/tests/subsys/dfu/dfu_target_mcuboot/CMakeLists.txt
+++ b/tests/subsys/dfu/dfu_target_mcuboot/CMakeLists.txt
@@ -1,0 +1,30 @@
+#
+# Copyright (c) 2019 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+cmake_minimum_required(VERSION 3.13.1)
+include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+project(json)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})
+
+target_sources(app
+  PRIVATE
+  ${ZEPHYR_BASE}/../nrf/subsys/dfu/src/dfu_target_mcuboot.c
+  )
+
+target_include_directories(app
+  PRIVATE
+  ${ZEPHYR_BASE}/../nrf/subsys/dfu/include
+  . # To get 'pm_config.h'
+  )
+
+target_compile_options(app
+  PRIVATE
+  -DCONFIG_IMG_BLOCK_BUF_SIZE=4096
+  -DCONFIG_DFU_TARGET_LOG_LEVEL=2
+  -DCONFIG_AWS_FOTA_FILE_PATH_MAX_LEN=1024
+  )

--- a/tests/subsys/dfu/dfu_target_mcuboot/pm_config.h
+++ b/tests/subsys/dfu/dfu_target_mcuboot/pm_config.h
@@ -1,0 +1,7 @@
+/* generated file copied to simplify building the test */
+#ifndef PM_CONFIG_H__
+#define PM_CONFIG_H__
+#define PM_S0_ADDRESS 0x8000
+#define PM_S1_ADDRESS 0x15000
+#define PM_MCUBOOT_SECONDARY_SIZE 0x5e000
+#endif /* PM_CONFIG_H__ */

--- a/tests/subsys/dfu/dfu_target_mcuboot/prj.conf
+++ b/tests/subsys/dfu/dfu_target_mcuboot/prj.conf
@@ -1,0 +1,6 @@
+#
+# Copyright (c) 2019 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+CONFIG_ZTEST=y

--- a/tests/subsys/dfu/dfu_target_mcuboot/src/main.c
+++ b/tests/subsys/dfu/dfu_target_mcuboot/src/main.c
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+#include <string.h>
+#include <zephyr/types.h>
+#include <stdbool.h>
+#include <ztest.h>
+#include <dfu_target_mcuboot.h>
+
+/* Create buffer which we will fill with strings to test with.
+ * This is needed since 'dfu_ctx_Mcuboot_set_b1_file` will modify its
+ * 'file' parameter, hence we can not provide it raw c strings as they
+ * are stored in read-only memory
+ */
+char buf[1024];
+
+#define S0_S1 "s0 s1"
+#define NO_SPACE "s0s1"
+
+static void test_dfu_ctx_mcuboot_set_b1_file(void)
+{
+	int err;
+	char *update;
+	bool s0_active = true;
+
+	memcpy(buf, S0_S1, sizeof(S0_S1));
+	err = dfu_ctx_mcuboot_set_b1_file(buf, s0_active, &update);
+
+	zassert_equal(err, 0, NULL);
+	zassert_true(strcmp("s1", update) == 0, NULL);
+
+	s0_active = false;
+	err = dfu_ctx_mcuboot_set_b1_file(buf, s0_active, &update);
+
+	zassert_equal(err, 0, NULL);
+	zassert_true(strcmp("s0", update) == 0, NULL);
+}
+
+static void test_dfu_ctx_mcuboot_set_b1_file__no_separator(void)
+{
+	int err;
+	char *update;
+	bool s0_active = true;
+
+	memcpy(buf, NO_SPACE, sizeof(NO_SPACE));
+	err = dfu_ctx_mcuboot_set_b1_file(buf, s0_active, &update);
+
+	zassert_equal(err, 0, "Should not get error when missing separator");
+	zassert_equal(update, NULL, "update should be NULL when no separator");
+}
+
+static void test_dfu_ctx_mcuboot_set_b1_file__null(void)
+{
+	int err;
+	char *update;
+	bool s0_active = true;
+
+	err = dfu_ctx_mcuboot_set_b1_file(NULL, s0_active, &update);
+	zassert_true(err < 0, NULL);
+
+	err = dfu_ctx_mcuboot_set_b1_file(buf, s0_active, NULL);
+	zassert_true(err < 0, NULL);
+}
+
+static void test_dfu_ctx_mcuboot_set_b1_file__not_terminated(void)
+{
+	int err;
+	char *update;
+	bool s0_active = true;
+
+	/* Remove any null terminator */
+	for (int i = 0; i < sizeof(buf); ++i) {
+		buf[i] = 'a';
+	}
+	err = dfu_ctx_mcuboot_set_b1_file(buf, s0_active, &update);
+	zassert_true(err < 0, NULL);
+}
+
+static void test_dfu_ctx_mcuboot_set_b1_file__empty(void)
+{
+	int err;
+	char *update;
+	bool s0_active = true;
+
+	err = dfu_ctx_mcuboot_set_b1_file("", s0_active, &update);
+	zassert_true(update == NULL, "update should not be set");
+}
+
+void test_main(void)
+{
+	ztest_test_suite(lib_dfu_target_mcuboot_test,
+	     ztest_unit_test(test_dfu_ctx_mcuboot_set_b1_file__no_separator),
+	     ztest_unit_test(test_dfu_ctx_mcuboot_set_b1_file__null),
+	     ztest_unit_test(test_dfu_ctx_mcuboot_set_b1_file__not_terminated),
+	     ztest_unit_test(test_dfu_ctx_mcuboot_set_b1_file__empty),
+	     ztest_unit_test(test_dfu_ctx_mcuboot_set_b1_file)
+	 );
+
+	ztest_run_test_suite(lib_dfu_target_mcuboot_test);
+}

--- a/tests/subsys/dfu/dfu_target_mcuboot/testcase.yaml
+++ b/tests/subsys/dfu/dfu_target_mcuboot/testcase.yaml
@@ -1,0 +1,5 @@
+tests:
+  testing.dfu_target.mcuboot:
+    platform_whitelist: qemu_cortex_m3
+    build_only: false
+    tags: dfu_target_mcuboot

--- a/tests/subsys/net/lib/fota_download/CMakeLists.txt
+++ b/tests/subsys/net/lib/fota_download/CMakeLists.txt
@@ -1,0 +1,35 @@
+#
+# Copyright (c) 2019 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+cmake_minimum_required(VERSION 3.13.1)
+include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
+project(fota_download)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})
+
+target_sources(app
+  PRIVATE
+  ${ZEPHYR_BASE}/../nrf/subsys/net/lib/fota_download/src/fota_download.c
+  )
+
+target_include_directories(app
+  PRIVATE
+  ${ZEPHYR_BASE}/../nrf/include/net/
+  ${ZEPHYR_BASE}/../nrf/subsys/dfu/include
+  . # To get 'pm_config.h'
+  )
+
+target_compile_options(app
+  PRIVATE
+  -DCONFIG_DOWNLOAD_CLIENT_MAX_RESPONSE_SIZE=500
+  -DCONFIG_DOWNLOAD_CLIENT_STACK_SIZE=500
+  -DCONFIG_FW_MAGIC_LEN=32
+  -DFIRMWARE_INFO_MAGIC=0xbabababa
+  -DABI_INFO_MAGIC=0xdededede
+  -DCONFIG_FW_FIRMWARE_INFO_OFFSET=0x200
+  -DCONFIG_FOTA_DOWNLOAD_LOG_LEVEL=2
+  )

--- a/tests/subsys/net/lib/fota_download/pm_config.h
+++ b/tests/subsys/net/lib/fota_download/pm_config.h
@@ -1,0 +1,6 @@
+/* generated file copied to simplify building the test */
+#ifndef PM_CONFIG_H__
+#define PM_CONFIG_H__
+#define PM_S0_ADDRESS 0x8000
+#define PM_S1_ADDRESS 0x15000
+#endif /* PM_CONFIG_H__ */

--- a/tests/subsys/net/lib/fota_download/prj.conf
+++ b/tests/subsys/net/lib/fota_download/prj.conf
@@ -1,0 +1,6 @@
+#
+# Copyright (c) 2019 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+CONFIG_ZTEST=y

--- a/tests/subsys/net/lib/fota_download/src/main.c
+++ b/tests/subsys/net/lib/fota_download/src/main.c
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+#include <string.h>
+#include <zephyr/types.h>
+#include <stdbool.h>
+#include <ztest.h>
+#include <download_client.h>
+#include <fw_metadata.h>
+#include <pm_config.h>
+#include <fota_download.h>
+
+/* Create buffer which we will fill with strings to test with.
+ * This is needed since 'dfu_ctx_Mcuboot_set_b1_file` will modify its
+ * 'file' parameter, hence we can not provide it raw c strings as they
+ * are stored in read-only memory
+ */
+char buf[1024];
+
+#define S0_S1 "s0 s1"
+#define S0 "s0"
+#define S1 "s1"
+#define NO_SPACE "s0s1"
+
+/* Stubs and mocks */
+bool dfu_ctx_mcuboot_set_b1_file__s0_active;
+static u32_t s0_version;
+static u32_t s1_version;
+const char *download_client_start_file;
+char *dfu_ctx_mcuboot_set_b1_file__update;
+
+int dfu_target_init(int img_type, size_t file_size)
+{
+	return 0;
+}
+
+int dfu_target_img_type(const void *const buf, size_t len)
+{
+	return 0;
+}
+
+int dfu_target_offset_get(size_t *offset)
+{
+	return 0;
+}
+
+int dfu_target_write(const void *const buf, size_t len)
+{
+	return 0;
+}
+
+int dfu_target_done(bool successful)
+{
+	return 0;
+}
+
+int download_client_disconnect(struct download_client *client)
+{
+	return 0;
+}
+
+int download_client_start(struct download_client *client, const char *file,
+			  size_t from)
+{
+	download_client_start_file = file;
+	return 0;
+}
+
+int download_client_file_size_get(struct download_client *client, size_t *size)
+{
+	return 0;
+}
+
+int download_client_init(struct download_client *client,
+			 download_client_callback_t callback)
+{
+	return 0;
+}
+
+int spm_firmware_info(u32_t fw_address, struct fw_firmware_info *info)
+{
+	zassert_true(info != NULL, NULL);
+
+	if (fw_address == PM_S0_ADDRESS) {
+		info->firmware_version = s0_version;
+	} else if (fw_address == PM_S1_ADDRESS) {
+		info->firmware_version = s1_version;
+	} else {
+		zassert_true(false, "Unexpected address");
+	}
+
+	return 0;
+}
+
+int download_client_connect(struct download_client *client, const char *host,
+			    const struct download_client_cfg *config)
+{
+	return 0;
+}
+
+int dfu_ctx_mcuboot_set_b1_file(char *file, bool s0_active, char **update)
+{
+	dfu_ctx_mcuboot_set_b1_file__s0_active = s0_active;
+	*update = dfu_ctx_mcuboot_set_b1_file__update;
+	return 0;
+}
+
+/* END stubs and mocks */
+
+void client_callback(enum fota_download_evt_id evt_id) { }
+
+static void init(void)
+{
+	int err;
+
+	err = fota_download_init(client_callback);
+	zassert_equal(err, 0, NULL);
+}
+
+static void test_fota_download_start(void)
+{
+	int err;
+	bool expect_s0_active = false;
+
+	init();
+
+	/* Verify that correct argument for s0_active is given */
+	s0_version = 0;
+	s1_version = 1;
+	expect_s0_active = false;
+	strcpy(buf, S0_S1);
+	err = fota_download_start("something.com", buf);
+	zassert_equal(err, 0, NULL);
+	zassert_equal(dfu_ctx_mcuboot_set_b1_file__s0_active, expect_s0_active,
+		      "Incorrect param for s0_active");
+
+	s0_version = 2;
+	s1_version = 1;
+	expect_s0_active = true;
+	err = fota_download_start("something.com", buf);
+	zassert_equal(err, 0, NULL);
+	zassert_equal(dfu_ctx_mcuboot_set_b1_file__s0_active, expect_s0_active,
+		      "Incorrect param for s0_active");
+
+
+	/* Next, verify that the update path given by mcuboot_set_b1_file
+	 * is used correctly.
+	 */
+
+	/* update set to null indicates to use original file param */
+	dfu_ctx_mcuboot_set_b1_file__update = NULL;
+	strcpy(buf, S0_S1);
+	err = fota_download_start("something.com", buf);
+	zassert_equal(err, 0, NULL);
+	zassert_true(strcmp(download_client_start_file, S0_S1) == 0, NULL);
+
+	/* update set to not null indicates to use update for file param */
+	dfu_ctx_mcuboot_set_b1_file__update = S1;
+	strcpy(buf, S0_S1);
+	err = fota_download_start("something.com", buf);
+	zassert_equal(err, 0, NULL);
+	zassert_true(strcmp(download_client_start_file, S1) == 0, NULL);
+}
+
+void test_main(void)
+{
+	ztest_test_suite(lib_fota_download_test,
+	     ztest_unit_test(test_fota_download_start)
+	 );
+
+	ztest_run_test_suite(lib_fota_download_test);
+}

--- a/tests/subsys/net/lib/fota_download/testcase.yaml
+++ b/tests/subsys/net/lib/fota_download/testcase.yaml
@@ -1,0 +1,5 @@
+tests:
+  testing.net.lib.fota_download
+    platform_whitelist: qemu_cortex_m3
+    build_only: false
+    tags: fota_download


### PR DESCRIPTION
When updating the second stage bootloader, B1, (MCUBoot in this case),
two variants of the new firmware is required. One for each possible
flash placement (slot), S0 and S1. To present the two variants,
the path will contain two entries, separated by a space. The entry
before the space contains the path to the S0 candidate, while the
entry after the space contains the path to the S1 candidate.

This commit adds a function which parses a space separated path,
and given a flag indicating which candidate should be used (S0 or S1)
it returns a pointer to the correct part of the path.

In addition, this commit updates fota_download.c to find the active
slot, and indicate to the path parsing function which variant it
should point to.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>