### PR TITLE
doc: Adding documentation for AT Client sample

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -50,6 +50,8 @@
 
 .. _`Device programming section in the nRF9160 DK User Guide`: https://infocenter.nordicsemi.com/topic/ug_nrf91_dk/UG/nrf91_DK/mcu_device_programming.html
 
+.. _`AT Commands Reference Guide`: https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/intro.html
+
 .. _`system mode section in the AT Commands reference document`: https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/mob_termination_ctrl_status/xsystemmode.html
 
 .. _`AT Commands reference`: https://infocenter.nordicsemi.com/topic/ref_at_commands/REF/at_commands/intro.html

--- a/samples/nrf9160/at_client/README.rst
+++ b/samples/nrf9160/at_client/README.rst
@@ -1,0 +1,134 @@
+.. _at_client_sample:
+
+nRF9160: AT Client
+##################
+
+The AT Client sample demonstrates the asynchronous serial communication taking place over UART to the nRF9160 modem.
+The sample enables you to use an external computer or MCU to send AT commands to the LTE-M/NB-IoT modem of your nRF9160 device.
+
+Overview
+********
+
+The AT Client sample acts as a proxy for sending directives to the nRF9160 modem via AT commands.
+This facilitates the reading of responses or analyzing of events related to the nRF9160 modem.
+The commands can be initiated from a terminal or the `LTE Link Monitor`_, which is an application implemented as part of `nRF Connect for Desktop`_.
+
+For more information on the AT commands, see the `AT Commands Reference Guide`_.
+
+
+
+Requirements
+************
+
+* The following development board:
+
+  * nRF9160 DK board (PCA10090)
+
+
+Building and running
+********************
+
+.. |sample path| replace:: :file:`samples/nrf9160/at_client`
+
+.. include:: /includes/build_and_run_nrf9160.txt
+
+
+Connecting to the nRF9160 DK board with LTE Link Monitor
+========================================================
+
+To connect to the nRF9160 DK board with LTE Link Monitor, perform the following steps:
+
+#. Launch the LTE Link Monitor after programming the AT Client sample onto the nRF9160 DK board.
+#. Make sure that **Automatic requests** is enabled in LTE Link Monitor.
+#. Connect the nRF9160 DK board to the PC with a USB cable.
+#. Power on the nRF9160 DK board.
+#. Click **Select Device** and select the particular board device entry from the drop-down list in the LTE Link Monitor.
+#. Observe that initially the command :command:`AT+CFUN?` is automatically sent to the modem, which returns a value 4, indicating that the modem is in the offline mode.
+#. Observe that the LTE Link Monitor terminal display also shows :command:`AT+CFUN=1` indicating that the modem has changed to the normal mode.
+#. Press the reset button on the nRF9160 DK to reboot the board and start the AT Client sample.
+
+
+Testing
+=======
+
+After programming the sample to your board, test the sample by performing the following steps:
+
+1. `Connect to the nRF9160 DK board with LTE Link Monitor <Connecting to the nRF9160 DK board with LTE Link Monitor_>`_.
+#. Run the following commands from the LTE Link Monitor terminal:
+
+   a. Enter the command: :command:`AT+CFUN?`
+
+      This command reads the current functional mode of the modem and triggers the command :command:`AT+CFUN=1` which sets the functional mode of the modem to normal.
+
+   #. Enter the command :command:`AT+CFUN?` into the LTE Link Monitor terminal again.
+
+      The UART/Modem/UICC/LTE/PDN indicators in the LTE Link Monitor side panel turn green.
+      This command also automatically launches a series of commands like:
+
+     * :command:`AT+CGSN=1` which displays the product serial identification number (IMEI).
+     * :command:`AT+CGMI`   which displays the manufacturer name.
+     * :command:`AT+CGMM`   which displays the model identification name.
+     * :command:`AT+CGMR`   which displays the revision identification.
+     * :command:`AT+CEMODE` which displays the current mode of operation.
+
+   c. Enter the command: :command:`AT%XOPERID`
+
+      This command returns the network operator ID.
+
+
+   #. Enter the command: :command:`AT%XMONITOR`
+
+      This command returns the modem parameters.
+
+
+   #. Enter the command: :command:`AT%XTEMP?`
+
+      This command displays the current modem temperature.
+
+
+   #. Enter the command: :command:`AT%CMNG=1`
+
+      This command displays a list of all certificates that are stored on your device.
+      If the device has been added to nRF Cloud, a CA certificate, a client certificate, and a private key with security tag 16842753 (which is the security tag for nRF Cloud credentials) are displayed.
+
+
+
+Sample output
+=============
+
+The following is a sample output of the command: :command:`AT%XMONITOR`
+
+.. code-block:: console
+
+   AT%XMONITOR
+   %XMONITOR: 5,"","","24201","76C1",7,20,"0102DA03",105,6400,53,24,"","11100000","11100000"
+   OK
+
+
+Dependencies
+************
+
+This sample uses the following libraries:
+
+From |NCS|
+  * ``lib/at_host`` which includes:
+      * :ref:`at_cmd_readme`
+      * :ref:`at_notif_readme`
+
+From nrfxlib
+  * :ref:`nrfxlib:bsdlib`
+
+In addition, it uses the following samples:
+
+From |NCS|
+  * :ref:`secure_partition_manager`
+
+
+
+
+
+
+References
+**********
+
+`AT Commands Reference Guide`_


### PR DESCRIPTION
Adding missing documentation for AT Client sample
[nRF9160_ AT Client — nRF Connect SDK 1.0.99 documentation.pdf](https://github.com/NordicPlayground/fw-nrfconnect-nrf/files/3778248/nRF9160_.AT.Client.nRF.Connect.SDK.1.0.99.documentation.pdf)


Signed-off-by: UMA PRASEEDA <uma.praseeda@nordicsemi.no>