### PR TITLE
Bugfix for AWS FOTA and HTTP application update samples

### DIFF
--- a/samples/nrf9160/aws_fota/src/main.c
+++ b/samples/nrf9160/aws_fota/src/main.c
@@ -5,16 +5,15 @@
  */
 
 #include <zephyr.h>
-#include <uart.h>
 #include <stdio.h>
-#include <at_cmd.h>
 #include <bsd.h>
 #include <lte_lc.h>
+#include <at_cmd.h>
+#include <at_notif.h>
 #include <net/mqtt.h>
 #include <net/socket.h>
 #include <net/bsdlib.h>
 #include <net/aws_fota.h>
-
 #include <dfu/mcuboot.h>
 #include <misc/reboot.h>
 
@@ -441,6 +440,8 @@ static void modem_configure(void)
 			"This sample does not support auto init and connect");
 	int err;
 
+	err = at_notif_init();
+	__ASSERT(err == 0, "AT Notify could not be initialized.");
 	err = at_cmd_init();
 	__ASSERT(err == 0, "AT CMD could not be established.");
 	printk("LTE Link Connecting ...\n");

--- a/samples/nrf9160/http_application_update/src/main.c
+++ b/samples/nrf9160/http_application_update/src/main.c
@@ -9,7 +9,7 @@
 #include <bsd.h>
 #include <lte_lc.h>
 #include <at_cmd.h>
-#include <logging/log.h>
+#include <at_notif.h>
 #include <net/bsdlib.h>
 #include <net/fota_download.h>
 #include <dfu/mcuboot.h>
@@ -128,6 +128,8 @@ static void modem_configure(void)
 			"This sample does not support auto init and connect");
 	int err;
 
+	err = at_notif_init();
+	__ASSERT(err == 0, "AT Notify could not be initialized.");
 	err = at_cmd_init();
 	__ASSERT(err == 0, "AT CMD could not be established.");
 	printk("LTE Link Connecting ...\n");


### PR DESCRIPTION
After 16ae282 was added the samples were not updated resulting in both sample being unable to use `lte_lc_init_and_connect()` to get an LTE Link.

This also contains some minor fixup for the includes in the samples.