### PR TITLE
manifest: update fw-nrfconnect-zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -38,7 +38,7 @@ manifest:
     - name: zephyr
       repo-path: fw-nrfconnect-zephyr
       west-commands: scripts/west-commands.yml
-      revision: b41b797295af21173a5e0bde8faa5b0243cb88f4
+      revision: 98804daed7a9745302391e581073f2c29878470c
     - name: nffs
       revision: bc62a2fa9d98ddb5d633c932ea199bc68e10f194
       path: modules/fs/nffs


### PR DESCRIPTION
Upgrade downstream zephy version to one of https://github.com/NordicPlayground/fw-nrfconnect-zephyr/pull/223


Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>