### PR TITLE
nrf_cc310: Added description for cc310 drivers

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -157,6 +157,7 @@ set(NRF_EXTRACT_CONTENT_COMMAND
   "*.rst:boards:${NRF_RST_OUT}/doc/nrf"
   "release-notes*.rst:doc:${NRF_RST_OUT}/doc/nrf"
   "changelog.rst:doc:${NRF_RST_OUT}/doc/nrf"
+  "*.rst:doc/nrf/drivers:${NRF_RST_OUT}"
   "*.rst:include:${NRF_RST_OUT}/doc/nrf"
   "*.rst:lib:${NRF_RST_OUT}/doc/nrf"
   "*.rst:scripts:${NRF_RST_OUT}/doc/nrf"

--- a/doc/nrf/drivers.rst
+++ b/doc/nrf/drivers.rst
@@ -13,3 +13,4 @@ Here you can find documentation for these drivers, including API documentation.
    :glob:
 
    ../../include/drivers/*
+   drivers/*

--- a/doc/nrf/drivers/entropy_cc310.rst
+++ b/doc/nrf/drivers/entropy_cc310.rst
@@ -1,0 +1,23 @@
+.. _lib_entropy_cc310:
+
+CC310 entropy driver
+####################
+
+You can use the CC310 entropy driver (entropy_cc310) to generate random data using the Arm CryptoCell CC310 hardware.
+This hardware is available on the nRF52840 and nRF9160 devices.
+
+When used on nRF52840, the entropy_cc310 driver gathers entropy by using the CC310 hardware through the :ref:`nrf_cc310_platform_readme`.
+
+When used on nRF9160, the driver behavior depends on whether it is used in a secure or non-secure application:
+
+  * When used :ref:`in a secure application <ug_nrf9160>`, or when the :ref:`lib_spm` is not used, the entropy_cc310 driver gathers entropy by using the CC310 hardware through the :ref:`nrf_cc310_platform_readme`.
+
+  * When used :ref:`in a non-secure application <ug_nrf9160>`, the driver gathers entropy through the :ref:`lib_secure_services` library.
+
+API documentation
+*****************
+
+| Header file: :file:`<NCS>/zephyr/include/drivers/entropy.h`
+| Source file: :file:`drivers/entropy_cc310/entropy_cc310.c`
+
+The entropy_cc310 driver implements the Zephyr :ref:`zephyr:entropy_interface` API.

--- a/doc/nrf/drivers/hw_cc310.rst
+++ b/doc/nrf/drivers/hw_cc310.rst
@@ -1,0 +1,21 @@
+.. _lib_hw_cc310:
+
+CC310 hardware driver
+#####################
+
+The CC310 hardware driver (hw_cc310) ensures correct initialization of the :ref:`nrf_cc310_platform_readme`.
+
+It initializes the following elements of the library:
+
+* CC310 abort functions,
+* hardware mutex and mutex API,
+* platform with or without RNG.
+
+You can initialize the hw_cc310 driver using the :option:`CONFIG_HW_CC310` Kconfig option.
+
+API documentation
+*****************
+
+| Source file: :file:`drivers/hw_cc310/hw_cc310.c`
+
+After the hw_cc310 driver has been initialized, you can use the APIs from the :ref:`crypto_api_nrf_cc310_platform` and the :ref:`nrf_cc310_mbedcrypto_readme`.


### PR DESCRIPTION
Doc commit from: https://github.com/NordicPlayground/fw-nrfconnect-nrf/pull/1268

nrf_cc310: Added description for cc310 drivers
    
Added description for:
- cc310 entropy driver
- cc310 hw initialization
    
Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>
