### PR TITLE
bootloader: bl_crypto_client: Fixup for firmware info ABI renaming

### DIFF
--- a/subsys/bootloader/Kconfig
+++ b/subsys/bootloader/Kconfig
@@ -154,7 +154,7 @@ config SB_BPROT_IN_DEBUG
 endif # SECURE_BOOT_DEBUG
 endif # IS_SECURE_BOOTLOADER
 
-if IS_SECURE_BOOTLOADER || SECURE_BOOT
+if IS_SECURE_BOOTLOADER || SECURE_BOOT || SECURE_BOOT_CRYPTO_CLIENT
 
 rsource "bl_crypto/Kconfig"
 rsource "bl_validation/Kconfig"

--- a/subsys/bootloader/bl_crypto_client/bl_crypto_client.c
+++ b/subsys/bootloader/bl_crypto_client/bl_crypto_client.c
@@ -11,28 +11,30 @@
 
 enum abi_index {BL_ROT_VERIFY, BL_SHA256, BL_SECP256R1, LAST};
 
-const struct fw_abi_info *get_bl_crypto_abi(enum abi_index abi)
+const struct fw_info_abi *get_bl_crypto_abi(enum abi_index abi)
 {
 	__ASSERT(abi < LAST, "invalid abi argument.");
 
-	static const struct fw_abi_info *bl_crypto_abis[LAST] = {NULL};
+	static const struct fw_info_abi *bl_crypto_abis[LAST] = {NULL};
 
 	if (!bl_crypto_abis[abi]) {
 		switch(abi) {
 		case BL_ROT_VERIFY:
-			bl_crypto_abis[abi] = fw_abi_find(BL_ROT_VERIFY_ABI_ID,
+			bl_crypto_abis[abi] = fw_info_abi_find(
+					BL_ROT_VERIFY_ABI_ID,
 					CONFIG_BL_ROT_VERIFY_ABI_FLAGS,
 					CONFIG_BL_ROT_VERIFY_ABI_VER,
 					CONFIG_BL_ROT_VERIFY_ABI_MAX_VER);
 			break;
 		case BL_SHA256:
-			bl_crypto_abis[abi] = fw_abi_find(BL_SHA256_ABI_ID,
+			bl_crypto_abis[abi] = fw_info_abi_find(BL_SHA256_ABI_ID,
 					CONFIG_BL_SHA256_ABI_FLAGS,
 					CONFIG_BL_SHA256_ABI_VER,
 					CONFIG_BL_SHA256_ABI_MAX_VER);
 			break;
 		case BL_SECP256R1:
-			bl_crypto_abis[abi] = fw_abi_find(BL_SECP256R1_ABI_ID,
+			bl_crypto_abis[abi] = fw_info_abi_find(
+					BL_SECP256R1_ABI_ID,
 					CONFIG_BL_SECP256R1_ABI_FLAGS,
 					CONFIG_BL_SECP256R1_ABI_VER,
 					CONFIG_BL_SECP256R1_ABI_MAX_VER);

--- a/subsys/net/lib/fota_download/src/fota_download.c
+++ b/subsys/net/lib/fota_download/src/fota_download.c
@@ -13,7 +13,7 @@
 
 #ifdef PM_S1_ADDRESS
 /* MCUBoot support is required */
-#include <fw_metadata.h>
+#include <fw_info.h>
 #include <secure_services.h>
 #include <dfu_target_mcuboot.h>
 #endif
@@ -147,8 +147,8 @@ int fota_download_start(char *host, char *file)
 	 * space separated file is given.
 	 */
 	char *update;
-	struct fw_firmware_info s0;
-	struct fw_firmware_info s1;
+	struct fw_info s0;
+	struct fw_info s1;
 
 	err = spm_firmware_info(PM_S0_ADDRESS, &s0);
 	if (err != 0) {

--- a/tests/subsys/net/lib/fota_download/src/main.c
+++ b/tests/subsys/net/lib/fota_download/src/main.c
@@ -8,7 +8,7 @@
 #include <stdbool.h>
 #include <ztest.h>
 #include <download_client.h>
-#include <fw_metadata.h>
+#include <fw_info.h>
 #include <pm_config.h>
 #include <fota_download.h>
 
@@ -79,7 +79,7 @@ int download_client_init(struct download_client *client,
 	return 0;
 }
 
-int spm_firmware_info(u32_t fw_address, struct fw_firmware_info *info)
+int spm_firmware_info(u32_t fw_address, struct fw_info *info)
 {
 	zassert_true(info != NULL, NULL);
 

--- a/west.yml
+++ b/west.yml
@@ -53,7 +53,7 @@ manifest:
       revision: c3be1b52f5e56aaba6039c423478cfaf62a91622
     - name: mcuboot
       repo-path: fw-nrfconnect-mcuboot
-      revision: 3db81a20bc4617c435a89732ed3f3cbd122c3595
+      revision: a631263274e7220e008138e7f26c2d35bbcb2203
     - name: mcumgr
       repo-path: fw-nrfconnect-mcumgr
       revision: f663988d35da559a37f263d369842dbce309d1fa


### PR DESCRIPTION
Some parts of `bl_crypto_client` were missed in the firmware info
renaming process. This commit fixes up those files.

Fixes NCSDK-3413

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>