### PR TITLE
lib: bsdlib: imply socket offloading instead of selecting it

### DIFF
--- a/lib/bsdlib/Kconfig
+++ b/lib/bsdlib/Kconfig
@@ -10,7 +10,7 @@ config BSD_LIBRARY
 	prompt "Use BSD Socket library for IP/TLS/DTLS"
 	select FLOAT
 	select FP_SHARING
-	select NET_SOCKETS_OFFLOAD
+	imply NET_SOCKETS_OFFLOAD
 	depends on TRUSTED_EXECUTION_NONSECURE
 	help
 	  Use Nordic BSD Socket library.


### PR DESCRIPTION
Use `imply` instead of `select` for NET_SOCKETS_OFFLOAD.

Switching to `imply` lets us turn on socket offloading only
if all its dependencies are satisfied, and avoid warnings
in case they aren't. This is useful for projects that use
bsdlib socket APIs (nrf_*) directly without going through
offloading, and might not want to satisfy all the dependencies
of NET_SOCKETS_OFFLOAD to avoid warnings.