### PR TITLE
fw_info: rename to avoid duplicate kconfig name

### DIFF
--- a/subsys/fw_info/Kconfig
+++ b/subsys/fw_info/Kconfig
@@ -26,7 +26,7 @@ config FW_INFO_OFFSET
 	  of firmware information should search all possible offsets. Note
 	  that all space between the vector table and this address is unused.
 
-config FW_INFO_VERSION
+config FW_INFO_FIRMWARE_VERSION
 	int "Version number of the firmware."
 	default 1
 

--- a/subsys/fw_info/fw_info.c
+++ b/subsys/fw_info/fw_info.c
@@ -43,7 +43,7 @@ __fw_info struct fw_info m_firmware_info =
 {
 	.magic = {FIRMWARE_INFO_MAGIC},
 	.firmware_size = (u32_t)&_flash_used,
-	.firmware_version = CONFIG_FW_INFO_VERSION,
+	.firmware_version = CONFIG_FW_INFO_FIRMWARE_VERSION,
 	.firmware_address = (u32_t)&_image_rom_start,
 	.abi_in = &abi_getter_in,
 	.abi_out = &abi_getter,


### PR DESCRIPTION
The 'CONFIG_FW_INFO_VERSION' kconfig option was a duplicate, this
will cause issues as they are treated as the same value.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>