### PR TITLE
at_cmd_parser: parse AT commands

### DIFF
--- a/lib/at_cmd_parser/at_cmd_parser.c
+++ b/lib/at_cmd_parser/at_cmd_parser.c
@@ -24,6 +24,7 @@ enum at_parser_state {
 	NUMBER,
 	SMS_PDU,
 	NOTIFICATION,
+	COMMAND,
 	OPTIONAL,
 };
 
@@ -49,6 +50,9 @@ static int at_parse_detect_type(const char **str, int index)
 		 * notification ID, (eg +CEREG:)
 		 */
 		set_new_state(NOTIFICATION);
+	} else if ((index == 0) && is_command(tmpstr)) {
+		/* Next, check if we deal with command (eg AT+CCLK) */
+		set_new_state(COMMAND);
 	} else if (index == 0) {
 		/* If the string start without an notification
 		 * ID, we treat the whole string as one string
@@ -124,7 +128,17 @@ static int at_parse_process_element(const char **str,
 		at_params_string_put(list,
 				     index, start_ptr,
 				     tmpstr - start_ptr);
+	} else if (state == COMMAND) {
+		const char *start_ptr = tmpstr;
 
+		tmpstr += sizeof("AT+") - 1;
+
+		while (is_valid_notification_char(*tmpstr)) {
+			tmpstr++;
+		}
+
+		at_params_string_put(list, index, start_ptr,
+				     tmpstr - start_ptr);
 	} else if (state == OPTIONAL) {
 		at_params_empty_put(list, index);
 

--- a/lib/at_cmd_parser/at_utils.h
+++ b/lib/at_cmd_parser/at_utils.h
@@ -20,11 +20,13 @@
 #include <ctype.h>
 
 #define AT_PARAM_SEPARATOR              ','
-#define AT_CMD_SEPARATOR                ':'
+#define AT_RSP_SEPARATOR                ':'
+#define AT_CMD_SEPARATOR                '='
 #define AT_CMD_BUFFER_TERMINATOR        0
 #define AT_CMD_STRING_IDENTIFIER        '\"'
 #define AT_STANDARD_NOTIFICATION_PREFIX '+'
 #define AT_PROP_NOTIFICATION_PREFX      '%'
+#define AT_CUSTOM_COMMAND_PREFX         '#'
 
 /**
  * @brief Check if character is a notification start character
@@ -41,6 +43,33 @@ static inline bool is_notification(char chr)
 {
 	if ((chr == AT_STANDARD_NOTIFICATION_PREFIX) ||
 	    (chr == AT_PROP_NOTIFICATION_PREFX)) {
+		return true;
+	}
+
+	return false;
+}
+
+/**
+ * @brief Check if a string is a beginning of an AT command
+ *
+ * This function will check if the character is a "AT+" or "AT%" which
+ * identifies an AT command.
+ *
+ * @param[in] str String to examine
+ *
+ * @retval true  If the string is an AT command
+ * @retval false Otherwise
+ */
+static inline bool is_command(const char *str)
+{
+	if (strlen(str) < 3) {
+		return false;
+	}
+
+	if ((toupper(str[0]) == 'A') && (toupper(str[1]) == 'T') &&
+	    ((str[2] == AT_STANDARD_NOTIFICATION_PREFIX) ||
+	     (str[2] == AT_PROP_NOTIFICATION_PREFX) ||
+	     (str[2] == AT_CUSTOM_COMMAND_PREFX))) {
 		return true;
 	}
 
@@ -102,6 +131,7 @@ static inline bool is_terminated(char chr)
 static inline bool is_separator(char chr)
 {
 	if ((chr == AT_PARAM_SEPARATOR) ||
+	    (chr == AT_RSP_SEPARATOR) ||
 	    (chr == AT_CMD_SEPARATOR)) {
 		return true;
 	}

--- a/tests/lib/at_cmd_parser/at_cmd_parser/src/main.c
+++ b/tests/lib/at_cmd_parser/at_cmd_parser/src/main.c
@@ -522,6 +522,90 @@ static void test_testcases_teardown(void)
 	at_params_list_free(&test_list2);
 }
 
+static void test_at_cmd_setup(void)
+{
+	at_params_list_init(&test_list2, TEST_PARAMS2);
+}
+
+static void test_at_cmd(void)
+{
+	int ret;
+	char tmpbuf[32];
+	u32_t tmpbuf_len;
+	u16_t tmpshrt;
+
+	static const char at_cmd_cclk[] = "AT+CCLK=\"18/12/06,22:10:00+08\"";
+
+	ret = at_parser_params_from_str(at_cmd_cclk, NULL, &test_list2);
+	zassert_true(ret == 0, "at_parser_params_from_str should return 0");
+
+	ret = at_params_valid_count_get(&test_list2);
+	zassert_true(ret == 2,
+		     "at_params_valid_count_get returns wrong valid count");
+
+	zassert_true(at_params_type_get(&test_list2, 0) == AT_PARAM_TYPE_STRING,
+		     "Param type at index 0 should be a string");
+	zassert_true(at_params_type_get(&test_list2, 1) == AT_PARAM_TYPE_STRING,
+		     "Param type at index 1 should be a string");
+
+	tmpbuf_len = sizeof(tmpbuf);
+	zassert_equal(0, at_params_string_get(&test_list2, 0,
+					      tmpbuf, &tmpbuf_len),
+		      "Get string should not fail");
+	zassert_equal(0, memcmp("AT+CCLK", tmpbuf, tmpbuf_len),
+		      "The string in tmpbuf should equal to AT+CCLK");
+
+	tmpbuf_len = sizeof(tmpbuf);
+	zassert_equal(0, at_params_string_get(&test_list2, 1,
+					      tmpbuf, &tmpbuf_len),
+		      "Get string should not fail");
+	zassert_equal(0, memcmp("18/12/06,22:10:00+08", tmpbuf, tmpbuf_len),
+		      "The string in tmpbuf should equal to "
+		      "18/12/06,22:10:00+08");
+
+	static const char at_cmd_xsystemmode[] = "AT%XSYSTEMMODE=1,2,3,4";
+
+	ret = at_parser_params_from_str(at_cmd_xsystemmode, NULL, &test_list2);
+	zassert_true(ret == 0, "at_parser_params_from_str should return 0");
+
+	ret = at_params_valid_count_get(&test_list2);
+	zassert_true(ret == 5,
+		     "at_params_valid_count_get returns wrong valid count");
+
+	zassert_true(at_params_type_get(&test_list2, 0) == AT_PARAM_TYPE_STRING,
+		     "Param type at index 0 should be a string");
+	zassert_true(at_params_type_get(&test_list2, 1) ==
+							AT_PARAM_TYPE_NUM_SHORT,
+		     "Param type at index 1 should be a string");
+	zassert_true(at_params_type_get(&test_list2, 2) ==
+							AT_PARAM_TYPE_NUM_SHORT,
+		     "Param type at index 2 should be a string");
+	zassert_true(at_params_type_get(&test_list2, 3) ==
+							AT_PARAM_TYPE_NUM_SHORT,
+		     "Param type at index 3 should be a string");
+	zassert_true(at_params_type_get(&test_list2, 4) ==
+							AT_PARAM_TYPE_NUM_SHORT,
+		     "Param type at index 4 should be a string");
+
+	zassert_equal(0, at_params_short_get(&test_list2, 1, &tmpshrt),
+		      "Get short should not fail");
+	zassert_equal(1, tmpshrt, "Short should be 1");
+	zassert_equal(0, at_params_short_get(&test_list2, 2, &tmpshrt),
+		      "Get short should not fail");
+	zassert_equal(2, tmpshrt, "Short should be 2");
+	zassert_equal(0, at_params_short_get(&test_list2, 3, &tmpshrt),
+		      "Get short should not fail");
+	zassert_equal(3, tmpshrt, "Short should be 3");
+	zassert_equal(0, at_params_short_get(&test_list2, 4, &tmpshrt),
+		      "Get short should not fail");
+	zassert_equal(4, tmpshrt, "Short should be 4");
+}
+
+static void test_at_cmd_teardown(void)
+{
+	at_params_list_free(&test_list2);
+}
+
 void test_main(void)
 {
 	ztest_test_suite(at_cmd_parser,
@@ -540,7 +624,11 @@ void test_main(void)
 			 ztest_unit_test_setup_teardown(
 				test_testcases,
 				test_testcases_setup,
-				test_testcases_teardown)
+				test_testcases_teardown),
+			 ztest_unit_test_setup_teardown(
+				test_at_cmd,
+				test_at_cmd_setup,
+				test_at_cmd_teardown)
 			);
 
 	ztest_run_test_suite(at_cmd_parser);

--- a/tests/lib/at_cmd_parser/at_utils/src/main.c
+++ b/tests/lib/at_cmd_parser/at_utils/src/main.c
@@ -13,7 +13,7 @@ char *string_return     = "mfw_nrf9160_0.7.0-23.prealpha";
 
 static void test_notification_detection(void)
 {
-	for (char c = 0; c < sizeof(c); ++c) {
+	for (char c = 0; c < 127; ++c) {
 		if ((c == '%') || (c == '+')) {
 			continue;
 		}
@@ -28,9 +28,23 @@ static void test_notification_detection(void)
 		     "Notification char was not detected");
 }
 
+static void test_command_detection(void)
+{
+	zassert_true(is_command("AT+"), "Command was not detected");
+	zassert_true(is_command("AT%"), "Command was not detected");
+	zassert_true(is_command("AT#"), "Command was not detected");
+	zassert_true(is_command("at+"), "Command was not detected");
+	zassert_true(is_command("at%"), "Command was not detected");
+	zassert_true(is_command("at#"), "Command was not detected");
+	zassert_false(is_command("AT"), "Should fail, command too short");
+	zassert_false(is_command("BT+"), "Should fail, invalid string");
+	zassert_false(is_command("AB+"), "Should fail, invalid string");
+	zassert_false(is_command("AT$"), "Should fail, invalid string");
+}
+
 static void test_valid_notification_char_detection(void)
 {
-	for (char c = 0; c < sizeof(c); ++c) {
+	for (char c = 0; c < 127; ++c) {
 		if ((c >= 'A') && (c <= 'Z')) {
 			continue;
 		}
@@ -56,7 +70,7 @@ static void test_valid_notification_char_detection(void)
 
 static void test_string_termination(void)
 {
-	for (char c = 1; c < sizeof(c); ++c) {
+	for (char c = 1; c < 127; ++c) {
 		zassert_false(is_terminated(c), "String termination detected");
 	}
 
@@ -66,21 +80,22 @@ static void test_string_termination(void)
 
 static void test_string_separator(void)
 {
-	for (char c = 0; c < sizeof(c); ++c) {
-		if ((c == ':') || (c == ',')) {
+	for (char c = 0; c < 127; ++c) {
+		if ((c == ':') || (c == ',') || (c == '=')) {
 			continue;
 		}
 
 		zassert_false(is_separator(c), "Separator detected");
 	}
 
+	zassert_true(is_separator('='), "Separator not detected");
 	zassert_true(is_separator(':'), "Separator not detected");
 	zassert_true(is_separator(','), "Separator not detected");
 }
 
 static void test_lfcr(void)
 {
-	for (char c = 0; c < sizeof(c); ++c) {
+	for (char c = 0; c < 127; ++c) {
 		if ((c == '\r') || (c == '\n')) {
 			continue;
 		}
@@ -94,7 +109,7 @@ static void test_lfcr(void)
 
 static void test_dblquote(void)
 {
-	for (char c = 0; c < sizeof(c); ++c) {
+	for (char c = 0; c < 127; ++c) {
 		if (c == '"') {
 			continue;
 		}
@@ -107,7 +122,7 @@ static void test_dblquote(void)
 
 static void test_array_detection(void)
 {
-	for (char c = 0; c < sizeof(c); ++c) {
+	for (char c = 0; c < 127; ++c) {
 		if ((c == '(') || (c == ')')) {
 			continue;
 		}
@@ -122,8 +137,8 @@ static void test_array_detection(void)
 
 static void test_number_detection(void)
 {
-	for (char c = 0; c < sizeof(c); ++c) {
-		if ((c <= 0) && (c >= 9)) {
+	for (char c = 0; c < 127; ++c) {
+		if ((c >= '0') && (c <= '9')) {
 			continue;
 		}
 
@@ -146,6 +161,7 @@ void test_main(void)
 {
 	ztest_test_suite(at_cmd_parser,
 			ztest_unit_test(test_notification_detection),
+			ztest_unit_test(test_command_detection),
 			ztest_unit_test(test_valid_notification_char_detection),
 			ztest_unit_test(test_string_termination),
 			ztest_unit_test(test_string_separator),


### PR DESCRIPTION
`at_cmd_parser` is good for parsing AT responses and notifications, but could not parse AT commands. Fix this by adding extra state in the parser.

This showed up in #1099, where the sample wanted to parse custom commands.