### PR TITLE
manifest: Update manifest to latest zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -38,7 +38,7 @@ manifest:
     - name: zephyr
       repo-path: fw-nrfconnect-zephyr
       west-commands: scripts/west-commands.yml
-      revision: 98804daed7a9745302391e581073f2c29878470c
+      revision: 0adfea4acb72d151237e2d65f89537a598119c25
     - name: nffs
       revision: bc62a2fa9d98ddb5d633c932ea199bc68e10f194
       path: modules/fs/nffs


### PR DESCRIPTION
This commit updates the manifest to use https://github.com/NordicPlayground/fw-nrfconnect-zephyr/commit/0adfea4acb72d151237e2d65f89537a598119c25 in zephyr repo.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>