### PR TITLE
lte_link_control: add to support unlocking PLMN

### DIFF
--- a/drivers/lte_link_control/Kconfig
+++ b/drivers/lte_link_control/Kconfig
@@ -39,7 +39,6 @@ endif # LTE_LOCK_BANDS
 
 config LTE_LOCK_PLMN
 	bool "Enable LTE PLMN lock"
-	default n
 	help
 		Enable PLMN locks for network selection.
 
@@ -51,6 +50,12 @@ config LTE_LOCK_PLMN_STRING
 		Mobile Country Code (MCC) and Mobile Network Code (MNC) values.
 		Only numeric string formats supported.
 endif # LTE_LOCK_PLMN
+
+config LTE_UNLOCK_PLMN
+	bool "Disable LTE PLMN lock"
+	depends on !LTE_LOCK_PLMN
+	help
+		Disable PLMN locks for network selection.
 
 config LTE_PSM_REQ_RPTAU
 	string "PSM setting requested periodic TAU"

--- a/drivers/lte_link_control/lte_lc.c
+++ b/drivers/lte_link_control/lte_lc.c
@@ -79,6 +79,9 @@ static const char lock_bands[] = "AT%XBANDLOCK=2,\""CONFIG_LTE_LOCK_BAND_MASK
 /* Lock PLMN */
 static const char lock_plmn[] = "AT+COPS=1,2,\""
 				 CONFIG_LTE_LOCK_PLMN_STRING"\"";
+#elif defined(CONFIG_LTE_UNLOCK_PLMN)
+/* Unlock PLMN */
+static const char unlock_plmn[] = "AT+COPS=0";
 #endif
 /* Request eDRX settings to be used */
 static const char edrx_req[] = "AT+CEDRXS=1,"CONFIG_LTE_EDRX_REQ_ACTT_TYPE
@@ -184,10 +187,16 @@ static int w_lte_lc_init(void)
 	}
 #endif
 #if defined(CONFIG_LTE_LOCK_PLMN)
-	/* Set Operator (volatile setting).
+	/* Manually select Operator (volatile setting).
 	 * Has to be done every time before activating the modem.
 	 */
 	if (at_cmd_write(lock_plmn, NULL, 0, NULL) != 0) {
+		return -EIO;
+	}
+#elif defined(CONFIG_LTE_UNLOCK_PLMN)
+	/* Automatically select Operator (volatile setting).
+	 */
+	if (at_cmd_write(unlock_plmn, NULL, 0, NULL) != 0) {
 		return -EIO;
 	}
 #endif


### PR DESCRIPTION
The volatile setting of PLMN by AT+COPS could be made persistent by AT+CFUN=0.
This could happen by API in LTE_LC driver or by commands to at_client sample.
There could be need of resetting to automatic PLMN selection (by AT+COPS=0).
Restoring of automatic PLMN selection as default could be achieved by first
configuring flag CONFIG_LTE_UNLOCK_PLMN=y then call lte_lc_power_off() after
connection, allowing some seconds after this.

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>