### PR TITLE
net: lib: nrf_cloud: Check for correct state on disconnect

### DIFF
--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud.c
@@ -93,7 +93,7 @@ int nrf_cloud_connect(const struct nrf_cloud_connect_param *param)
 
 int nrf_cloud_disconnect(void)
 {
-	if (NOT_VALID_STATE(STATE_CONNECTED)) {
+	if (NOT_VALID_STATE(STATE_DC_CONNECTED)) {
 		return -EACCES;
 	}
 	return nct_disconnect();


### PR DESCRIPTION
When attempting to disconnect from nRF Cloud, the state was
compared to the CONNECTED state instead of the DC_CONNECTED
state, resulting in failure if the data channel was established.
This patch fixes the issue.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>