### PR TITLE
entropy: cc310 driver depends on !BT_LLL_VENDOR_NORDIC

### DIFF
--- a/drivers/entropy/Kconfig
+++ b/drivers/entropy/Kconfig
@@ -10,6 +10,7 @@ config ENTROPY_CC310
 	depends on HW_CC310 || (SOC_NRF9160 && SPM)
 	depends on ENTROPY_GENERATOR
 	depends on !BT_LL_SW_LEGACY
+	depends on !BT_LLL_VENDOR_NORDIC
 	select ENTROPY_HAS_DRIVER
 	select ENTROPY_NRF_FORCE_ALT
 	default y


### PR DESCRIPTION
The selection of BB_LLL_VENDOR_NORDIC results in inclusion of
drivers/entropy/entropy_nrf5.c which then conflicts with the cc310
entropy driver.
Although the entropy_nrf5.c driver requires that ENTROPY_NRF_FORCE_ALT
is not set, then the forced selection of entropy nrf5 rng by
BB_LLL_VENDOR_NORDIC, results in this dependency not working as
expected.

Thus, BB_LLL_VENDOR_NORDIC, is added as a dependency to ENTROPY_CC310.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>