### PR TITLE
net: lib: fota_download: Retry on download socket errors

### DIFF
--- a/subsys/net/lib/fota_download/Kconfig
+++ b/subsys/net/lib/fota_download/Kconfig
@@ -11,6 +11,10 @@ menuconfig FOTA_DOWNLOAD
 
 if (FOTA_DOWNLOAD)
 
+menuconfig FOTA_SOCKET_RETRIES
+	int "Number of retries for socket-related download issues"
+	default 2
+
 module=FOTA_DOWNLOAD
 module-dep=LOG
 module-str=Firmware Over the Air Download


### PR DESCRIPTION
Change the implementation to use the retry functionality now provided by
download_client on socket errors.  Retry based on a simple count which
the developer can set via Kconfig.

Signed-off-by: Justin Brzozoski <justin.brzozoski@signal-fire.com>