### PR TITLE
manifest: Update manifest to latest zephyr

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -38,7 +38,7 @@ manifest:
     - name: zephyr
       repo-path: fw-nrfconnect-zephyr
       west-commands: scripts/west-commands.yml
-      revision: 98804daed7a9745302391e581073f2c29878470c
+      revision: 9c3f95834f5c021a5c36db6f382a2cfdaff25c06
     - name: nffs
       revision: bc62a2fa9d98ddb5d633c932ea199bc68e10f194
       path: modules/fs/nffs


### PR DESCRIPTION
This commit updates the manifest to use
9c3f95834f5c021a5c36db6f382a2cfdaff25c06 in zephyr repo.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>