### PR TITLE
net: download_client: fix errors in retry mechanism

### DIFF
--- a/include/net/download_client.h
+++ b/include/net/download_client.h
@@ -173,7 +173,7 @@ int download_client_connect(struct download_client *client, const char *host,
 /**
  * @brief Download a file.
  *
- * The download is carried out in fragments of @c
+ * The download is carried out in fragments of up to @c
  * CONFIG_DOWNLOAD_CLIENT_MAX_FRAGMENT_SIZE bytes,
  * which are delivered to the application
  * via @ref DOWNLOAD_CLIENT_EVT_FRAGMENT events.


### PR DESCRIPTION
Depending on when the socket error happened, a partial buffer was
sometimes left behind causing the retry to fail immediately.
If the failure happens when there is a partial fragment in the buffer,
hand it to the application first if necessary, then clear the buffer
before restarting.

Signed-off-by: Justin Brzozoski <justin.brzozoski@signal-fire.com>