### PR TITLE
codeowners: Clean up invalid entries

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -19,7 +19,7 @@
 /cmake/                                   @SebastianBoe
 /CMakeLists.txt                           @SebastianBoe
 # All Kconfig related files
-/**/Kconfig*                              @SebastianBoe
+Kconfig*                                  @SebastianBoe
 # All doc related files
 /doc/                                     @ru-fu
 /doc/CMakeLists.txt                       @carlescufi
@@ -36,7 +36,7 @@
 /include/drivers/                         @anangl
 /include/net/                             @rlubos
 /include/nfc/                             @anangl @grochu
-/include/shell/                           @nordic-krch @jarz-nordic
+/include/shell/                           @nordic-krch
 /lib/at_cmd_parser/                       @rlubos
 /lib/at_host/                             @rlubos
 /lib/at_notif/                            @pkchan
@@ -47,7 +47,7 @@
 /samples/sensor/bh1749/                   @wlgrd
 /samples/bluetooth/                       @joerchan @lemrey @carlescufi
 /samples/bootloader/                      @hakonfam @ioannisg
-subsys/debug/CMakeLists.txt               @nordic-krch
+/subsys/debug/CMakeLists.txt              @nordic-krch
 /samples/debug/ppi_trace/                 @nordic-krch
 /samples/esb/                             @lemrey
 /samples/nfc/                             @grochu
@@ -70,7 +70,7 @@ subsys/debug/CMakeLists.txt               @nordic-krch
 /subsys/partition_manager/                @hakonfam
 /subsys/profiler/                         @pdunaj
 /subsys/debug/ppi_trace/                  @nordic-krch
-/subsys/shell/                            @nordic-krch @jarz-nordic
+/subsys/shell/                            @nordic-krch
 /subsys/spm/                              @ioannisg
 /subsys/nonsecure/                        @ioannisg
 /tests/                                   @rakons


### PR DESCRIPTION
Fixes four invalid entries:
- Kconfig: To match all Kconfig entries, remove the opening /**/, as
  this didn't work (see for instance subsys/bluetooth/Kconfig).
  Pathnames that don't start with a / are matched in every directory.
- Removes user @jarz-nordic, which no longer exists from two entries.
- Makes subsys/debug/CMakeLists.txt absolute as intended.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>