### PR TITLE
bluetooth: controller: Improved configuration of connections.

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -8,14 +8,18 @@ menu "Nordic BLE controller"
 
 config BLECTRL_MASTER_COUNT
 	int "Number of concurrent master roles"
-	default 1
+	default BT_MAX_CONN if (BT_CENTRAL && (!BT_PERIPHERAL))
+	default 1 if BT_CENTRAL
+	default 0
 	help
 	  Number of concurrent master roles defines how many simultaneous
 	  connections can be created with the device working as a master.
 
 config BLECTRL_SLAVE_COUNT
 	int "Number of concurrent slave roles"
-	default 1
+	default BT_MAX_CONN if (BT_PERIPHERAL && (!BT_CENTRAL))
+	default 1 if BT_PERIPHERAL
+	default 0
 	help
 	  Number of concurrent slave roles defines how many simultaneous
 	  connections can be created with the device working as a slave.

--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -23,6 +23,11 @@
 #define BLE_CONTROLLER_IRQ_PRIO_LOW  4
 #define BLE_CONTROLLER_IRQ_PRIO_HIGH 0
 
+#if (CONFIG_BLECTRL_SLAVE_COUNT + CONFIG_BLECTRL_MASTER_COUNT) != \
+     CONFIG_BT_MAX_CONN
+	#warning Unaligned configuration between BLE Host and Controller (number of connections)
+#endif
+
 static K_SEM_DEFINE(sem_recv, 0, 1);
 static K_SEM_DEFINE(sem_signal, 0, UINT_MAX);
 


### PR DESCRIPTION
Added `#warning` when connection configurations are unaligned between the Nordic BLE Controller and BLE Host.
Needs `backport v1.1-branch` label.