### PR TITLE
manifest: update zephyr to include zephyr_library_app_memory

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -38,7 +38,7 @@ manifest:
     - name: zephyr
       repo-path: fw-nrfconnect-zephyr
       west-commands: scripts/west-commands.yml
-      revision: 919640cdd332d64a0694fc686027d1e919f30ce1
+      revision: 9be97c63368aa5ddfb7613446794a3ec85801a49
     - name: nffs
       revision: bc62a2fa9d98ddb5d633c932ea199bc68e10f194
       path: modules/fs/nffs


### PR DESCRIPTION
Those commits updates the manifest to point to 
- 9be97c63368aa5ddfb7613446794a3ec85801a49 ~pull/230/head~ in Zephyr.
- e569efbc2b84c4a7fbd09cf4b5205c7476748366 ~pull/100/head~ in nrfxlib

https://github.com/NordicPlayground/fw-nrfconnect-zephyr/pull/230
https://github.com/NordicPlayground/nrfxlib/pull/100

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>