### PR TITLE
doc: samples: Change from firmware nRF Cloud to AWS S3 Bucket

### DIFF
--- a/doc/nrf/includes/aws_s3_bucket.txt
+++ b/doc/nrf/includes/aws_s3_bucket.txt
@@ -1,0 +1,32 @@
+Setting up an AWS S3 bucket
+===========================
+
+The firmware files for download must be stored in a bucket on an AWS S3 server.
+To do this, set up your own bucket.
+
+When setting up your own bucket, make sure to configure the permissions as shown in the following screenshot:
+
+.. figure:: /images/aws_s3_bucket_permissions.png
+   :alt: Bucket permissions in AWS S3
+
+To update the permissions for an existing bucket, select your bucket and navigate to **Permissions** > **Block public access**.
+
+In addition to the permissions, you must configure a bucket policy.
+To determine a suitable security scheme for your application, see `AWS S3 Developer Guide: Using Bucket Policies and User Policies`_ and `AWS S3 Developer Guide: Bucket Policy Examples`_.
+To configure the policy, select your bucket and navigate to **Permissions** > **Bucket Policy**.
+
+For testing purposes, you can use the following, very permissive, bucket policy (replace *bucket_name* with the name of your bucket):
+
+.. parsed-literal::
+   :class: highlight
+
+   {    "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": "*",
+                "Action": "s3:GetObject",
+                "Resource": "arn:aws:s3:::*bucket_name*/\*"
+            }
+         ]
+    }

--- a/include/net/aws_fota.rst
+++ b/include/net/aws_fota.rst
@@ -40,38 +40,7 @@ The following sequence diagram shows how a firmware over-the-air update is imple
    :alt: AWS FOTA sequence diagram for doing FOTA through AWS jobs
 
 
-AWS S3 server
-=============
-
-The firmware files for download must be stored in a bucket on an AWS S3 server.
-You can use an AWS instance that is already set up, such as `nRF Cloud`_, or set up your own bucket.
-
-When setting up your own bucket, make sure to configure the permissions as shown in the following screenshot:
-
-.. figure:: /images/aws_s3_bucket_permissions.png
-   :alt: Bucket permissions in AWS S3
-
-To update the permissions for an existing bucket, select your bucket and navigate to **Permissions** > **Block public access**.
-
-In addition to the permissions, you must configure a bucket policy.
-To determine a suitable security scheme for your application, see `AWS S3 Developer Guide: Using Bucket Policies and User Policies`_ and `AWS S3 Developer Guide: Bucket Policy Examples`_.
-To configure the policy, select your bucket and navigate to **Permissions** > **Bucket Policy**.
-
-For testing purposes, you can use the following, very permissive, bucket policy (replace *bucket_name* with the name of your bucket):
-
-.. parsed-literal::
-   :class: highlight
-
-   {    "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Effect": "Allow",
-                "Principal": "*",
-                "Action": "s3:GetObject",
-                "Resource": "arn:aws:s3:::*bucket_name*/\*"
-            }
-         ]
-    }
+.. include:: /includes/aws_s3_bucket.txt
 
 
 AWS IoT jobs

--- a/samples/nrf9160/aws_fota/README.rst
+++ b/samples/nrf9160/aws_fota/README.rst
@@ -19,9 +19,8 @@ See :ref:`lib_aws_fota` for information about the download procedure.
 The `AWS IoT Developer Guide`_ contains all required information about the Amazon Web Services IoT service.
 
 .. note::
-   For simplicity, the testing instructions for this sample use `nRF Cloud`_ as the AWS S3 server instance that hosts the new firmware image.
-   You can set up and use your own AWS S3 server bucket instead.
-   See the documentation for the :ref:`lib_aws_fota` library for more information.
+   A file server instance that hosts the new firmware image is required for this sample.
+   You can set up and use your own AWS S3 server bucket to host the firmware described in the `Setting up an AWS S3 bucket`_ section.
 
 Creating a thing in AWS IoT
 ===========================
@@ -78,8 +77,6 @@ Add the certificates to the sample code:
 
    .. warning::
       * The sample will overwrite the certificates stored with the configured :option:`security tag <CLOUD_CERT_SEC_TAG>`.
-        By default, these are the preprogrammed certificates for nRF Cloud.
-        Make sure to update the security tag to prevent overwriting the nRF Cloud certificates.
       * You should provision the certificates only once and then update the sample configuration to use the existing certificates.
         When provisioning the certificates, they are stored in the application binary and visible in the modem trace information, which is a security risk.
 
@@ -100,6 +97,7 @@ Use LTE Link Monitor to write the certificates to the board:
    #. Click **Update certificates**.
    #. Before programming the sample, make sure to configure the :option:`security tag <CLOUD_CERT_SEC_TAG>` to the one that you chose.
 
+.. include:: /includes/aws_s3_bucket.txt
 
 Requirements
 ************
@@ -109,8 +107,6 @@ Requirements
   * nRF9160 DK board (PCA10090)
 
 * An `AWS account`_ with access to Simple Storage Service (S3) and the IoT Core service
-
-* An `nRF Cloud`_ account
 
 * .. include:: /includes/spm.txt
 
@@ -198,13 +194,11 @@ After programming the sample to the board, test it by performing the following s
 #. Go to **Shadow** and confirm that the application version (``nrfcloud__dfu_v1__app_v``) is the one that you configured for the sample.
 #. In the :ref:`configuring`, change the application version.
    Then rebuild the application, but do not program it.
-#. Go to `firmware.nrfcloud.com`_ and sign in.
-   If you already have an nRF Cloud account, you can use the same credentials.
-   Otherwise, create an account and sign in.
-#. In the menu on the left-hand side, select **Firmware**.
-#. Click **Generate new** to create a URL for the firmware image.
-#. Click **Upload** for the URL that you created and select the file ``app_update.bin`` (located in the ``zephyr`` subfolder of your build directory).
-#. Create a job document (a text file) with the following content, replacing *host_url* with the server part of the URL that you created (for example, ``s3.amazonaws.com``) and *file_path* with the path and file name (for example, ``nordic-firmware-files/XXXXXXXXX``):
+#. Go to `AWS S3 console`_ and sign in.
+#. Go to the bucket you have created.
+#. Click **Upload** and select the file ``app_update.bin`` (located in the ``zephyr`` subfolder of your build directory).
+#. Click the file you uploaded in the bucket and check the **Object URL** field to find the download URL for the file.
+#. Create a job document (a text file) with the following content, replacing *host_url* with the server part of the URL that you created (for example, ``s3.amazonaws.com``) and *file_path* with the path and file name (for example, ``nordic-firmware-files/app_update.bin``):
 
    .. parsed-literal::
       :class: highlight
@@ -222,7 +216,6 @@ After programming the sample to the board, test it by performing the following s
 
    See `AWS IoT Developer Guide: Jobs`_ for more information about AWS jobs.
 #. Log on to the `AWS S3 console`_.
-#. If you do not have a bucket yet, create one with the default settings.
 #. Select the bucket, click **Upload**, and select your job document.
    Use the default settings when uploading the file.
 #. Log on to the `AWS IoT console`_, go to **Manage** > **Jobs**, and select **Create a job**.
@@ -261,8 +254,10 @@ ERROR: mqtt_connect -45:
    Certificates must be formatted correctly, without extra whitespace.
 
 Content range is not defined:
-   If you host the firmware image on a different server than nRF Cloud, this error indicates that the Content-Range field is missing in the HTTP GET header.
+   If you host the firmware image on a different server than in an S3 bucket, this error indicates that the Content-Range field is missing in the HTTP GET header.
    To fix this problem, configure the host server to provide this field.
+   If you are using an S3 bucket, make sure that you have configured it as described in `Setting up an AWS S3 bucket`_.
+   Also, confirm that your file is available from the browser without being logged into your AWS account.
 
 
 Dependencies

--- a/samples/nrf9160/http_application_update/README.rst
+++ b/samples/nrf9160/http_application_update/README.rst
@@ -47,8 +47,8 @@ Specifying the image file
 =========================
 
 Before building the sample, you must specify where the image file will be located.
-If you do not want to host it yourself, you can upload it to nRF Cloud for testing purposes.
-See `Hosting your image on nRF Cloud`_ for instructions.
+If you do not want to host it yourself, you can upload it to a public S3 bucket on Amazon Web Services (AWS).
+See `Setting up an AWS S3 bucket`_ for instructions.
 
 To specify the location in |SES|:
 
@@ -56,24 +56,17 @@ To specify the location in |SES|:
 #. Navigate to **HTTP application update sample** and specify the **Download host name** (``CONFIG_DOWNLOAD_HOST``) and **The file to download** (``CONFIG_DOWNLOAD_FILE``).
 #. Click **Configure** to save the configuration.
 
+.. include:: /includes/aws_s3_bucket.txt
 
-Hosting your image on nRF Cloud
--------------------------------
+Hosting your image on an AWS S3 Server
+--------------------------------------
 
-1. Go to `firmware.nrfcloud.com`_ and sign in.
-   If you already have an nRF Cloud account, you can use the same credentials.
-   Otherwise, create an account and sign in.
-#. In the menu on the left-hand side, select **Firmware**.
-#. Click **Generate new** to create a URL for the firmware image.
+1. Go to `AWS S3 console`_ and sign in.
+#. Go to the bucket you have created.
+#. Click **Upload** and select the file ``app_update.bin`` (located in the ``zephyr`` subfolder of your build directory).
+#. Click the file you uploaded in the bucket and check the **Object URL** field to find the download URL for the file.
 
-   .. figure:: /images/http_upload_nrfcloud.png
-      :alt: Generate URL for firmware image in nRF Cloud
-
-   Generate URL for firmware image in nRF Cloud
-
-#. Click the **Copy URL** button to copy the address.
-
-When specifying the image file, use the ``s3.amazonaws.com`` part of the URL for the download host name.
+When specifying the image file, use the ``<bucket-name>.s3.<region>.amazonaws.com`` part of the URL for the download hostname.
 Make sure to not include the ``https``.
 Specify the rest of the URL as file name.
 


### PR DESCRIPTION
Change documentation to describe how to create a public AWS S3 bucket
and add the firmware file to the bucket for downloading through HTTP
with `download_client`. Which is used by both HTTP application update
and AWS FOTA.

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>