### PR TITLE
tests: unity: Cleanup header parsing regexes

### DIFF
--- a/scripts/unity/func_name_list.py
+++ b/scripts/unity/func_name_list.py
@@ -14,10 +14,10 @@ def func_names_from_header(in_file, out_file):
 
     with open(out_file, 'w') as f_out:
         # Regex match all function names in the header file
-        x = re.findall(r"(struct\s|\s?)(\w+\s)(\*?)(\w+?)(\(.*?\))(;)",
+        x = re.findall(r"^\s*(?:\w+[*\s]+)+(\w+?)\(.*?\);",
                        content, re.M | re.S)
         for item in x:
-            f_out.write(item[3] + "\n")
+            f_out.write(item + "\n")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Simplifies the regexes in header_prepare.py and func_name_list.py by
removing all superflous groups. Fixes parsing of static inline
functions that return structs, which would previously duplicate the
struct keyword in the generated code. Prevents the addition of macros to
the function list.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>