### PR TITLE
tests: unity: Use yaml file for configuring cmock

### DIFF
--- a/tests/unity/CMakeLists.txt
+++ b/tests/unity/CMakeLists.txt
@@ -8,6 +8,7 @@ zephyr_library()
 
 set_property(GLOBAL PROPERTY CMOCK_DIR ${ZEPHYR_BASE}/../test/cmock)
 get_property(CMOCK_DIR GLOBAL PROPERTY CMOCK_DIR)
+set(UNITY_CONFIG_FILE ${CMAKE_CURRENT_LIST_DIR}/unity_cfg.yaml CACHE STRING "")
 
 find_program(
   RUBY_EXECUTABLE
@@ -53,27 +54,23 @@ function(cmock_generate header_path dst_path)
   get_property(CMOCK_DIR GLOBAL PROPERTY CMOCK_DIR)
   set(MOCK_PREFIX mock_)
 
+  get_filename_component(file_name "${header_path}" NAME_WE)
+  set(MOCK_FILE ${dst_path}/${MOCK_PREFIX}${file_name}.c)
+
   file(MAKE_DIRECTORY "${dst_path}")
 
-  execute_process(
+  add_custom_command(OUTPUT ${MOCK_FILE}
     COMMAND ${RUBY_EXECUTABLE}
     ${CMOCK_DIR}/lib/cmock.rb
     --mock_prefix=${MOCK_PREFIX}
-    --plugins=return_thru_ptr\;ignore_arg\;ignore\;callback\;array
     --mock_path=${dst_path}
+    -o${UNITY_CONFIG_FILE}
     ${header_path}
+    DEPENDS ${header_path} ${UNITY_CONFIG_FILE}
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-    RESULT_VARIABLE op_result
-    OUTPUT_VARIABLE output_result
   )
 
-  if (NOT ${op_result} EQUAL 0)
-    message(SEND_ERROR "${output_result}")
-    message(FATAL_ERROR "Failed to generate runner ${output_file}")
-  endif()
-
-  get_filename_component(file_name "${header_path}" NAME_WE)
-  target_sources(app PRIVATE ${dst_path}/${MOCK_PREFIX}${file_name}.c)
+  target_sources(app PRIVATE ${MOCK_FILE})
 endfunction()
 
 # Add --wrap linker option for each function listed in the input file.

--- a/tests/unity/unity_cfg.yaml
+++ b/tests/unity/unity_cfg.yaml
@@ -1,0 +1,31 @@
+#
+# Copyright (c) 2019 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+# Configuration for Unity and CMock
+#
+# See https://github.com/ThrowTheSwitch/CMock/blob/master/docs/CMock_Summary.md#config-options
+# and https://github.com/ThrowTheSwitch/Unity/blob/master/docs/UnityHelperScriptsGuide.md#options-accepted-by-generate_test_runnerrb
+#
+# Some additional options are passed to cmock on the command line, see CMakeLists.txt.
+:cmock:
+    :plugins:
+        - :ignore
+        - :ignore_arg
+        - :array
+        - :callback
+        - :return_thru_ptr
+        - :expect_any_args
+    :treat_externs: :include
+    :callback_after_arg_check: true
+    :treat_as:
+        's8_t': 'INT8'
+        'u8_t': 'HEX8'
+        's16_t': 'INT16'
+        'u16_t': 'HEX16'
+        's32_t': 'INT32'
+        'u32_t': 'HEX32'
+        's64_t': 'INT64'
+        'u64_t': 'HEX64'


### PR DESCRIPTION
Moves CMock configuration out into a dedicated config file, to improve
maintainability and add "treat_as" entries.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>