### PR TITLE
tests: Unity: Force exit on native_posix platform

### DIFF
--- a/tests/unity/CMakeLists.txt
+++ b/tests/unity/CMakeLists.txt
@@ -27,6 +27,8 @@ zephyr_library_sources(
 	${CMOCK_DIR}/src/cmock.c
 )
 
+zephyr_library_sources_ifdef(CONFIG_BOARD_NATIVE_POSIX src/native_posix.c)
+
 # Generate test runner file.
 function(test_runner_generate test_file_path)
   get_property(CMOCK_DIR GLOBAL PROPERTY CMOCK_DIR)

--- a/tests/unity/src/native_posix.c
+++ b/tests/unity/src/native_posix.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/**
+ * @file
+ * @brief Additional Unity support code for the native_posix board.
+ */
+
+#include "posix_board_if.h"
+
+int suiteTearDown(int num_failures)
+{
+	/* The native posix board will loop forever after leaving the runner's
+	 * main, so we have to explicitly call exit() to terminate the test.
+	 */
+	posix_exit(num_failures > 0 ? -1 : 0);
+
+	/* Should be unreachable: */
+	return 1;
+}


### PR DESCRIPTION
The native_posix platform goes into an infinite loop after main returns.
To prevent tests from hanging, this patch adds a call to posix_exit() in
the suite teardown function for the native_posix platform, effectively
bypassing the infinite loop.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>