### PR TITLE
tests: unity: Move mock dir include to app

### DIFF
--- a/tests/unity/CMakeLists.txt
+++ b/tests/unity/CMakeLists.txt
@@ -166,6 +166,6 @@ function(cmock_handle header_file)
 
   cmock_linker_wrap_trick(${mod_header_path})
 
-  target_include_directories(zephyr_interface BEFORE INTERFACE ${CMOCK_PRODUCTS_DIR})
+  target_include_directories(app BEFORE PRIVATE ${CMOCK_PRODUCTS_DIR})
   message(STATUS "Generating cmock for header ${header_file}")
 endfunction()


### PR DESCRIPTION
Moves the mock dir include to the beginning the app to force it in front
of other app includes.

Fixes the unity example test.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>