### PR TITLE
nfc: Fix default IRQ priority when ZERO_LATENCY_IRQS are used

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -72,7 +72,7 @@ manifest:
       revision: 30b7efa827b04d2e47840716b0372737fe7d6c92
     - name: nrfxlib
       path: nrfxlib
-      revision: 95d09f973ff7976be777c490323e27b1629870cd
+      revision: 1bd197a386709ac6268c740cb2772b94b3b32883
     - name: cmock
       path: test/cmock
       revision: c243b9a7a7b3c471023193992b46cf1bd1910450


### PR DESCRIPTION
Include nrfxlib commit that:
Fixes NCSDK-3404 and a small documentation bug.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>