### PR TITLE
samples: nrf9160: gps: Add COEX0 configuration

### DIFF
--- a/samples/nrf9160/gps/src/main.c
+++ b/samples/nrf9160/gps/src/main.c
@@ -14,6 +14,7 @@
 
 #ifdef CONFIG_BOARD_NRF9160_PCA10090NS
 #define AT_MAGPIO      "AT\%XMAGPIO=1,0,0,1,1,1574,1577"
+#define AT_COEX0       "AT\%XCOEX0=1,1,1570,1580"
 #endif
 
 static const char     update_indicator[] = {'\\', '|', '/', '-'};
@@ -21,6 +22,7 @@ static const char     at_commands[][31]  = {
 				AT_XSYSTEMMODE,
 #ifdef CONFIG_BOARD_NRF9160_PCA10090NS
 				AT_MAGPIO,
+				AT_COEX0,
 #endif
 				AT_CFUN
 			};


### PR DESCRIPTION
Adds support for a COEX0 configuration, to support the newer nRF9160 DK.
The MAGPIO method is preseved for compatibility with the older DK.