### PR TITLE
drivers: at_cmd: corrected warning in set_notification_handler().

### DIFF
--- a/drivers/at_cmd/at_cmd.c
+++ b/drivers/at_cmd/at_cmd.c
@@ -292,7 +292,7 @@ int at_cmd_write(const char *const cmd,
 void at_cmd_set_notification_handler(at_cmd_handler_t handler)
 {
 	LOG_DBG("Setting notification handler to %p", handler);
-	if ((notification_handler != NULL) && (handler != NULL)) {
+	if (notification_handler != NULL && handler != notification_handler) {
 		LOG_WRN("Forgetting prior notification handler %p",
 			notification_handler);
 	}


### PR DESCRIPTION
Before: (handler != NULL) is wrong. Even if hander is NULL, it is
        also forgetting prior notification handler.

After: (handler != notification_handler) should be right.
Signed-off-by: PK Chan <pak.kee.chan@nordicsemi.no>

--------------

I learned about such change from @junqingzou this morning (ref: PR #1099).

I have tested with use case `at_cmd_set_notification_handler(NULL)`. In such case, the previous handler has been forgotten, but the desired message has not been printed.
