### PR TITLE
[Backport v1.1-branch] entropy: cc310 driver depends on !BT_LLL_VENDOR_NORDIC

### DIFF
--- a/drivers/entropy/Kconfig
+++ b/drivers/entropy/Kconfig
@@ -10,6 +10,7 @@ config ENTROPY_CC310
 	depends on HW_CC310 || (SOC_NRF9160 && SPM)
 	depends on ENTROPY_GENERATOR
 	depends on !BT_LL_SW_LEGACY
+	depends on !BT_LLL_VENDOR_NORDIC
 	select ENTROPY_HAS_DRIVER
 	select ENTROPY_NRF_FORCE_ALT
 	default y


### PR DESCRIPTION
backport of: https://github.com/NordicPlayground/fw-nrfconnect-nrf/pull/1375
