### PR TITLE
drivers/at_cmd: Correct detection of CME / CMS errors

### DIFF
--- a/drivers/at_cmd/at_cmd.c
+++ b/drivers/at_cmd/at_cmd.c
@@ -19,8 +19,8 @@ LOG_MODULE_REGISTER(at_cmd, CONFIG_AT_CMD_LOG_LEVEL);
 
 #define AT_CMD_OK_STR    "OK"
 #define AT_CMD_ERROR_STR "ERROR"
-#define AT_CMD_CMS_STR   "+CMS:"
-#define AT_CMD_CME_STR   "+CME:"
+#define AT_CMD_CMS_STR   "+CMS ERROR:"
+#define AT_CMD_CME_STR   "+CME ERROR:"
 
 static K_THREAD_STACK_DEFINE(socket_thread_stack, \
 				CONFIG_AT_CMD_THREAD_STACK_SIZE);
@@ -77,13 +77,6 @@ static int get_return_code(char *buf, struct return_state_object *ret)
 			break;
 		}
 
-		tmpstr = strstr(buf, AT_CMD_ERROR_STR);
-		if (tmpstr) {
-			ret->state = AT_CMD_ERROR;
-			ret->code  = -ENOEXEC;
-			break;
-		}
-
 		tmpstr = strstr(buf, AT_CMD_CMS_STR);
 		if (tmpstr) {
 			ret->state = AT_CMD_ERROR_CMS;
@@ -95,6 +88,13 @@ static int get_return_code(char *buf, struct return_state_object *ret)
 		if (tmpstr) {
 			ret->state = AT_CMD_ERROR_CME;
 			ret->code = atoi(&buf[ARRAY_SIZE(AT_CMD_CMS_STR) - 1]);
+			break;
+		}
+
+		tmpstr = strstr(buf, AT_CMD_ERROR_STR);
+		if (tmpstr) {
+			ret->state = AT_CMD_ERROR;
+			ret->code  = -ENOEXEC;
 			break;
 		}
 	} while (0);

--- a/lib/at_host/at_host.c
+++ b/lib/at_host/at_host.c
@@ -101,11 +101,11 @@ static void cmd_send(struct k_work *work)
 		write_uart_string(ERROR_STR);
 		break;
 	case AT_CMD_ERROR_CMS:
-		sprintf(str, "+CMS: %d\r\n", err);
+		sprintf(str, "+CMS ERROR: %d\r\n", err);
 		write_uart_string(str);
 		break;
 	case AT_CMD_ERROR_CME:
-		sprintf(str, "+CME: %d\r\n", err);
+		sprintf(str, "+CME ERROR: %d\r\n", err);
 		write_uart_string(str);
 		break;
 	default:


### PR DESCRIPTION
Reorder presedence of error detection and correct
pattern to match.

Signed-off-by: Glenn Ruben Bakke <glenn.ruben.bakke@nordicsemi.no>