### PR TITLE
drivers: lte_lc: Ensure correct eDRX parameters are used

### DIFF
--- a/drivers/lte_link_control/Kconfig
+++ b/drivers/lte_link_control/Kconfig
@@ -80,17 +80,6 @@ config LTE_EDRX_REQ
 		Enable request for use of eDRX using AT+CEDRXS.
 		For reference, see 3GPP 27.007 Ch. 7.40.
 
-config LTE_EDRX_REQ_ACTT_TYPE
-	string "Select ActT-type."
-	default "4"
-	help
-		Select ActT-type.
-
-		 - "4" E-UTRAN (WB-S1 mode)
-		 - "5" E-UTRAN (NB-S1 mode)
-
-		For reference, see 3GPP 27.007 Ch. 7.40.
-
 config LTE_EDRX_REQ_VALUE
 	string "Requested eDRX value"
 	default "1000"

--- a/drivers/lte_link_control/Kconfig
+++ b/drivers/lte_link_control/Kconfig
@@ -82,12 +82,14 @@ config LTE_EDRX_REQ
 
 config LTE_EDRX_REQ_VALUE
 	string "Requested eDRX value"
-	default "1000"
+	default "1001"
 	help
 		Sets the eDRX value to request. Half a byte in a four-bit
 		format. The eDRX value refers to bit 4 to 1 of octet 3 of the
 		Extended DRX parameters information element.
 		See 3GPP TS 24.008, subclause 10.5.5.32.
+		The value 1001 corresponds to 163.84 seconds, and is valid for
+		both LTE-M and NB-IoT networks.
 
 config LTE_LEGACY_PCO_MODE
 	bool "Enable legacy LTE Protocol Configuration Options mode"

--- a/drivers/lte_link_control/lte_lc.c
+++ b/drivers/lte_link_control/lte_lc.c
@@ -45,6 +45,9 @@ LOG_MODULE_REGISTER(lte_lc, CONFIG_LTE_LINK_CONTROL_LOG_LEVEL);
 #define AT_XSYSTEMMODE_GPS_INDEX		2
 #define AT_XSYSTEMMODE_PARAMS_COUNT		5
 #define AT_XSYSTEMMODE_RESPONSE_MAX_LEN		30
+/* Parameter values for AT+CEDRXS command. */
+#define AT_CEDRXS_ACTT_WB			4
+#define AT_CEDRXS_ACTT_NB			5
 
 /* Forward declarations */
 static int parse_nw_reg_status(const char *at_response,
@@ -83,9 +86,6 @@ static const char lock_plmn[] = "AT+COPS=1,2,\""
 /* Unlock PLMN */
 static const char unlock_plmn[] = "AT+COPS=0";
 #endif
-/* Request eDRX settings to be used */
-static const char edrx_req[] = "AT+CEDRXS=1,"CONFIG_LTE_EDRX_REQ_ACTT_TYPE
-	",\""CONFIG_LTE_EDRX_REQ_VALUE"\"";
 /* Request eDRX to be disabled */
 static const char edrx_disable[] = "AT+CEDRXS=3";
 /* Request modem to go to power saving mode */
@@ -163,9 +163,13 @@ void at_handler(void *context, char *response)
 
 static int w_lte_lc_init(void)
 {
+	if (at_cmd_write(nw_mode_preferred, NULL, 0, NULL) != 0) {
+		return -EIO;
+	}
+
 #if defined(CONFIG_LTE_EDRX_REQ)
 	/* Request configured eDRX settings to save power */
-	if (at_cmd_write(edrx_req, NULL, 0, NULL) != 0) {
+	if (lte_lc_edrx_req(true) != 0) {
 		return -EIO;
 	}
 #endif
@@ -453,9 +457,36 @@ parse_psm_clean_exit:
 
 int lte_lc_edrx_req(bool enable)
 {
-	if (at_cmd_write(enable ? edrx_req : edrx_disable,
-			 NULL, 0, NULL) != 0) {
-		return -EIO;
+	char edrx_req[25];
+	int err, actt;
+	enum lte_lc_system_mode mode;
+
+	err = lte_lc_system_mode_get(&mode);
+	if (err) {
+		return err;
+	}
+
+	switch (mode) {
+	case LTE_LC_SYSTEM_MODE_LTEM:
+	case LTE_LC_SYSTEM_MODE_LTEM_GPS:
+		actt = AT_CEDRXS_ACTT_WB;
+		break;
+	case LTE_LC_SYSTEM_MODE_NBIOT:
+	case LTE_LC_SYSTEM_MODE_NBIOT_GPS:
+		actt = AT_CEDRXS_ACTT_NB;
+		break;
+	default:
+		LOG_ERR("Unknown system mode");
+		LOG_ERR("Cannot request eDRX for unknown system mode");
+		return -EOPNOTSUPP;
+	}
+
+	snprintf(edrx_req, sizeof(edrx_req),
+		 "AT+CEDRXS=1,%d,\""CONFIG_LTE_EDRX_REQ_VALUE"\"", actt);
+
+	err = at_cmd_write(enable ? edrx_req : edrx_disable, NULL, 0, NULL);
+	if (err) {
+		return err;
 	}
 
 	return 0;


### PR DESCRIPTION
drivers: lte_lc: Ensure correct eDRX parameters are used

Check system mode and set ActT parameter accordingly
when requesting eDRX.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>

---

drivers: lte_lc: Fix invalid eDRX default value for NB-IoT

This patch changes the default eDRX value from 1000 to 1001,
in order for it to be valid for both LTE-M and NB-IoT networks.
Ref 3GPP TS 24.008, subclause 10.5.5.32, table for S1 mode.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>