### PR TITLE
dfu: change dependency to dfu target mcuboot

### DIFF
--- a/subsys/dfu/src/dfu_target.c
+++ b/subsys/dfu/src/dfu_target.c
@@ -54,7 +54,7 @@ int dfu_target_init(int img_type, size_t file_size)
 {
 	const struct dfu_target *new_target = NULL;
 
-	if (IS_ENABLED(CONFIG_BOOTLOADER_MCUBOOT) &&
+	if (IS_ENABLED(CONFIG_DFU_TARGET_MCUBOOT) &&
 	    img_type == DFU_TARGET_IMAGE_TYPE_MCUBOOT) {
 		new_target = &dfu_target_mcuboot;
 	} else if (IS_ENABLED(CONFIG_DFU_TARGET_MODEM) &&


### PR DESCRIPTION
This to facilitate testing, and be aligned with modem part.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>