### PR TITLE
drivers: lte_lc: Add missing stdbool include

### DIFF
--- a/include/lte_lc.h
+++ b/include/lte_lc.h
@@ -12,6 +12,8 @@
 #ifndef ZEPHYR_INCLUDE_LTE_LINK_CONTROL_H_
 #define ZEPHYR_INCLUDE_LTE_LINK_CONTROL_H_
 
+#include <stdbool.h>
+
 /* NOTE: enum lte_lc_nw_reg_status maps directly to the registration status
  *	 as returned by the AT command "AT+CEREG?".
  */


### PR DESCRIPTION
Several functions in lte_lc.h takes a bool prarameter, but does
not include stdbool.h. Unless saved by the order of includes,
this leads to an error when compiling.

Signed-off-by: Didrik Rokhaug <didrik.rokhaug@gmail.com>