### PR TITLE
git: Ignore SES default build folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *~
 build
 build-*
+build_*
 cscope.*
 .dir
 


### PR DESCRIPTION
SEGGER Embedded Studio uses build_<board-name> as the default
name for its build folders. This commit ignores those, to
reduce the number of untracked files.

Signed-off-by: Didrik Rokhaug <didrik.rokhaug@gmail.com>