### PR TITLE
[v1.1-branch] scripts: requirements: Gate pygit2 and editdistance

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -3,5 +3,7 @@ sphinxcontrib-mscgen>=0.5
 ecdsa
 intelhex
 nrfutil
-pygit2>=0.26.0
-editdistance>=0.5.0
+# The following packages have not yet been rebuilt and published for
+# Python 3.8
+pygit2>=0.26.0;python_version<"3.8"
+editdistance>=0.5.0;python_version<"3.8"


### PR DESCRIPTION
    The current releases of pygit2 and editdistance do not support Python
    3.8, and so make the default installation instructions fail, since
    chocolatey now pulls Python 3.8 by default. Remove these dependencies
    for 3.8 until pygit2 has released 1.0.0, and edidistance whatever the
    new version is which will add compatibility for Python 3.8.

    This will cause the ncs-loot and ncs-compare west extensions not to work
    on Python 3.8, but that can be easily fixed by the user later by
    installing pygit2 and editdistance manually if they indeed wish to.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>