### PR TITLE
Revert "entropy: cc310: Use cc310 with MPU"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -174,7 +174,7 @@ pipeline {
       when { expression { CI_STATE.NRF.RUN_DOWNSTREAM } }
       steps { script {
           CI_STATE.NRF.WAITING = true
-          def DOWNSTREAM_JOBS = lib_Main.getDownStreamJobs(JOB_NAME)
+          def DOWNSTREAM_JOBS = lib_Main.getDownStreamJobs(JOB_NAME, CI_STATE)
           if (DOWNSTREAM_JOBS.size() == 1){
             DOWNSTREAM_JOBS.add("thst/test-ci-nrfconnect-cfg-null/lib")
           }

--- a/drivers/entropy/Kconfig
+++ b/drivers/entropy/Kconfig
@@ -11,6 +11,7 @@ config ENTROPY_CC310
 	depends on ENTROPY_GENERATOR
 	depends on !BT_LL_SW_LEGACY
 	depends on !BT_LLL_VENDOR_NORDIC
+	depends on !MPU_STACK_GUARD
 	select ENTROPY_HAS_DRIVER
 	select ENTROPY_NRF_FORCE_ALT
 	default y


### PR DESCRIPTION
- fix desktop dfu test failure
This reverts commit 44a52c1e10463eb6069ff7077e7005e96e89bd68.