### PR TITLE
applications: asset_tracker: Increase default MQTT keep-alive

### DIFF
--- a/applications/asset_tracker/Kconfig
+++ b/applications/asset_tracker/Kconfig
@@ -187,9 +187,7 @@ menu "Cloud"
 
 config MQTT_KEEPALIVE
 	int
-	default 1000 if POWER_OPTIMIZATION_ENABLE
-	default GPS_CONTROL_FIX_TRY_TIME if GPS_USE_EXTERNAL
-	default 120
+	default 1200
 
 config CLOUD_BUTTON
 	bool "Enable button sensor"

--- a/applications/asset_tracker/src/main.c
+++ b/applications/asset_tracker/src/main.c
@@ -1164,8 +1164,14 @@ connect:
 	};
 
 	while (true) {
+		/* The timeout is set to (keepalive / 3), so that the worst case
+		 * time between two messages from device to broker is
+		 * ((4 / 3) * keepalive + connection overhead), which is within
+		 * MQTT specification of (1.5 * keepalive) before the broker
+		 * must close the connection.
+		 */
 		ret = poll(fds, ARRAY_SIZE(fds),
-			K_SECONDS(CONFIG_MQTT_KEEPALIVE));
+			K_SECONDS(CONFIG_MQTT_KEEPALIVE / 3));
 
 		if (ret < 0) {
 			printk("poll() returned an error: %d\n", ret);


### PR DESCRIPTION
Increasing deafult MQTT keep-alive time to 1200 seconds,
because short keep-alive times may be too short when using power
saving modes, such as PSM and eDRX, in combination with
low-bandwidth NB-IoT networks.

In addition, the poll() timeout is set to 1/3 of the MQTT
keep-alive value. This will ensure that we check the need for
sending a ping and maintaining connection to cloud solution in
time for setting up slow connections and send the ping in time.
The underlying mqtt_live() checks time since last activity,
and only sends ping if it's been a period equal to the keep-
alive value since last data was sent. This means we risked to
send ping close 2 * CONFIG_MQTT_KEEPALIVE, and even more
delayed on NB-IoT. With this patch, we  will not go past
4/3 * CONFIG_MQTT_KEEPALIVE, which is usually accpeted by
the cloud service.

Fixes NCSDK-3608

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>