### PR TITLE
doc: Fix style issues across documents

### DIFF
--- a/doc/nrf/gs_programming.rst
+++ b/doc/nrf/gs_programming.rst
@@ -45,30 +45,30 @@ Complete the following steps to build |NCS| projects with SES after :ref:`instal
 #. Click **OK** to import the project into SES. You can now work with the
    project in the IDE.
 
-#. Build and flash your project.
+#. Build and program your project.
    The required steps differ depending on if you build a single application or a multi-image project (such as the nRF9160 samples, which include :ref:`SPM <secure_partition_manager>`).
 
    .. important::
-      If you are working with an nRF9160 DK, make sure to select the correct controller before you flash the application to your board.
+      If you are working with an nRF9160 DK, make sure to select the correct controller before you program the application to your board.
 
       Put the **SW5** switch (marked debug/prog) in the **NRF91** position to program the main controller, or in the **NRF52** position to program the board controller.
       See the `Device programming section in the nRF9160 DK User Guide`_ for more information.
 
-   To build and flash an application:
+   To build and program an application:
 
       a. Select your project in the Project Explorer.
       #. From the menu, select **Build -> Build Solution**.
-      #. When the build completes, you can flash the sample to a connected board:
+      #. When the build completes, you can program the sample to a connected board:
 
          * For a single-image application, select **Target -> Download zephyr/zephyr.elf**.
          * For a multi-image application, select **Target -> Download zephyr/merged.hex**.
 
       .. note::
 	   Alternatively, choose the **Build and Debug** option.
-	   **Build and Debug** will build the application and flash it when
+	   **Build and Debug** will build the application and program it when
 	   the build completes.
 
-7. To inspect the details of the flashed code and the memory usage, click **Debug -> Go**.
+7. To inspect the details of the code that was programmed and the memory usage, click **Debug -> Go**.
 
    .. note::
    	In a multi-image build, this allows you to debug the source code of your application only.

--- a/doc/nrf/ug_nrf9160.rst
+++ b/doc/nrf/ug_nrf9160.rst
@@ -285,7 +285,7 @@ Samples
 Secure Partition Manager
 	The **Secure Partition Manager** sample provides a reference implementation
 	of a first-stage boot firmware.
-	It must be preflashed to the board before any other sample.
+	It must be programmed to the board before any other sample.
 	For details, see :ref:`secure_partition_manager`.
 
 Asset Tracker

--- a/samples/bluetooth/throughput/README.rst
+++ b/samples/bluetooth/throughput/README.rst
@@ -51,7 +51,7 @@ By default, the following connection parameter values are used:
 Changing connection parameter values
 ====================================
 
-You can experiment with different connection parameter values by reconfiguring the values using menuconfig and then compiling and flashing the sample again to at least one of the boards.
+You can experiment with different connection parameter values by reconfiguring the values using menuconfig and then compiling and programming the sample again to at least one of the boards.
 
 .. note::
    In a *Bluetooth* Low Energy connection, the different devices negotiate the connection parameters that are used.

--- a/samples/nrf9160/at_client/README.rst
+++ b/samples/nrf9160/at_client/README.rst
@@ -24,6 +24,7 @@ Requirements
 
   * nRF9160 DK board (PCA10090)
 
+* .. include:: /includes/spm.txt
 
 Building and running
 ********************

--- a/samples/nrf9160/secure_services/README.rst
+++ b/samples/nrf9160/secure_services/README.rst
@@ -19,19 +19,15 @@ The following development board:
 
 * nRF9160 DK board (PCA10090)
 
-The following sample must be also flashed (happens automatically with the default configuration):
-
-* :ref:`secure_partition_manager`
+* .. include:: /includes/spm.txt
 
 Building and running
 ********************
 
 .. |sample path| replace:: :file:`samples/nrf9160/secure_services`
 
-.. include:: /includes/build_and_run.txt
+.. include:: /includes/build_and_run_nrf9160.txt
 
-The sample is built as a non-secure firmware image for the nrf9160_pca10090ns board.
-:ref:`secure_partition_manager` will by default be automatically built and flashed together with this sample.
 
 
 Dependencies

--- a/samples/nrf9160/spm/README.rst
+++ b/samples/nrf9160/spm/README.rst
@@ -43,7 +43,7 @@ Automatic building of SPM
 The sample is automatically built by the non-secure applications when the nrf9160_pca10090ns board is used.
 However, it is not a part of the non-secure application.
 
-Instead of flashing SPM and the non-secure application at the same time, you might want to flash them individually.
+Instead of programming SPM and the non-secure application at the same time, you might want to program them individually.
 To do this, disable the automatic building of SPM by setting the option ``CONFIG_SPM=n`` in the ``prj.conf`` file of the application.
 
 If this results in a single-image build, the start address of the non-secure application will change.

--- a/scripts/partition_manager/partition_manager.rst
+++ b/scripts/partition_manager/partition_manager.rst
@@ -338,7 +338,7 @@ See the following example, which assigns a cryptographically signed HEX file bui
    )
 
 
-As output, Partition Manager creates a HEX file called :file:`merged.hex`, which is flashed to the board when calling ``ninja flash``.
+As output, Partition Manager creates a HEX file called :file:`merged.hex`, which is programmed to the board when calling ``ninja flash``.
 When creating :file:`merged.hex`, all assigned HEX files are included in the merge operation.
 If the HEX files overlap, the conflict is resolved as follows:
 


### PR DESCRIPTION

Fix inconsistencies across documents in the usage of terms "flash" and "program" wherever applicable to make the docs uniform style wise.

Signed-off-by: UMA PRASEEDA <uma.praseeda@nordicsemi.no>