### PR TITLE
manifest: Update to add actinius Icarus board support in MCUBoot

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -53,7 +53,7 @@ manifest:
       revision: c3be1b52f5e56aaba6039c423478cfaf62a91622
     - name: mcuboot
       repo-path: fw-nrfconnect-mcuboot
-      revision: 99d395ce554bc53b1b84128e05c6cfb60a6ca70c
+      revision: pull/69/head
     - name: mcumgr
       repo-path: fw-nrfconnect-mcumgr
       revision: f663988d35da559a37f263d369842dbce309d1fa


### PR DESCRIPTION
Update manifest to point to the Actinius Icarus board support commit in
MCUBoot.

With regards to https://github.com/NordicPlayground/fw-nrfconnect-mcuboot/pull/69
and https://github.com/NordicPlayground/fw-nrfconnect-mcuboot/pull/66#issuecomment-552015533

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>