### PR TITLE
drivers: at_cmd: Clarify buffer use in at_cmd_write documentation

### DIFF
--- a/include/at_cmd.h
+++ b/include/at_cmd.h
@@ -108,6 +108,10 @@ int at_cmd_write_with_callback(const char *const cmd,
  *                the function return code as a positive value. NULL pointer is
  *                allowed.
  *
+ * @note It is allowed to use the same buffer for both, @ref cmd and @ref buf
+ *       parameters in order to save RAM. The function will not modify @ref buf
+ *       contents until the entire @ref cmd is sent.
+ *
  * @retval 0 If command execution was successful (same as OK returned from
  *           modem). Error codes returned from the driver or by the socket are
  *           returned as negative values, CMS and CME errors are returned as


### PR DESCRIPTION
Make it explicit in API documentation that it is allowed to use the same
buffer for both, command and response in `at_cmd_write` function.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>