### PR TITLE
applications: asset_tracker: send GPS data regardless of Switch 2

### DIFF
--- a/applications/asset_tracker/src/main.c
+++ b/applications/asset_tracker/src/main.c
@@ -247,8 +247,7 @@ static void gps_trigger_handler(struct device *dev, struct gps_trigger *trigger)
 
 	ARG_UNUSED(trigger);
 
-	if (ui_button_is_active(UI_SWITCH_2)
-	   || !atomic_get(&send_data_enable)) {
+	if (!atomic_get(&send_data_enable)) {
 		return;
 	}
 


### PR DESCRIPTION
Removes the position of switch 2 on nRF9160 DK as condition for sending
GPS data. This check is left over from earlier behaviour, and no longer
useful.

This fixes NCSDK-3661, an issue of not being able to send GPS data from the nRF9160
DK depending on the position of Switch 2