### PR TITLE
drivers: gps_sim: Increase default stack size

### DIFF
--- a/drivers/gps_sim/Kconfig
+++ b/drivers/gps_sim/Kconfig
@@ -150,7 +150,7 @@ config GPS_SIM_THREAD_PRIORITY
 config GPS_SIM_THREAD_STACK_SIZE
 	int "Trigger thread stack size"
 	depends on GPS_SIM_TRIGGER
-	default 512
+	default 1024
 	help
 	  Stack size of thread used by the driver to handle interrupts.
 


### PR DESCRIPTION
Increases default stack size from 512 bytes to 1024 bytes in
order to fix stack overflow issue.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>