### PR TITLE
profiler: Update Kconfig and add requirements

### DIFF
--- a/scripts/profiler/requirements.txt
+++ b/scripts/profiler/requirements.txt
@@ -1,0 +1,3 @@
+pynrfjprog
+matplotlib
+numpy

--- a/subsys/profiler/Kconfig
+++ b/subsys/profiler/Kconfig
@@ -24,17 +24,17 @@ config MAX_LENGTH_OF_CUSTOM_EVENTS_DESCRIPTIONS
 
 choice
 	prompt "Profiler selection"
-	default PROFILER_SYSVIEW
+	default PROFILER_NORDIC
 	depends on PROFILER
 
 config PROFILER_SYSVIEW
 	bool "SysView profiler"
-	select RTT_CONSOLE
+	select USE_SEGGER_RTT
 	select SEGGER_SYSTEMVIEW
 
 config PROFILER_NORDIC
 	bool "Nordic profiler"
-	select RTT_CONSOLE
+	select USE_SEGGER_RTT
 
 endchoice
 


### PR DESCRIPTION
Update Kconfig dependencies for the Profiler (fix build error).
By default use custom (Nordic) Profiler instead of SystemView.
Add `requirements.txt` file for Profiler scripts.