### PR TITLE
Bluetooth: Mesh: Initialize all model members

### DIFF
--- a/subsys/bluetooth/mesh/gen_battery_cli.c
+++ b/subsys/bluetooth/mesh/gen_battery_cli.c
@@ -66,6 +66,9 @@ static int bt_mesh_battery_cli_init(struct bt_mesh_model *model)
 	struct bt_mesh_battery_cli *cli = model->user_data;
 
 	cli->model = model;
+	net_buf_simple_init(model->pub->msg, 0);
+	model_ack_init(&cli->ack_ctx);
+
 	return 0;
 }
 

--- a/subsys/bluetooth/mesh/gen_battery_srv.c
+++ b/subsys/bluetooth/mesh/gen_battery_srv.c
@@ -78,6 +78,8 @@ static int bt_mesh_battery_srv_init(struct bt_mesh_model *model)
 	struct bt_mesh_battery_srv *srv = model->user_data;
 
 	srv->model = model;
+	net_buf_simple_init(model->pub->msg, 0);
+
 	return 0;
 }
 

--- a/subsys/bluetooth/mesh/gen_dtt_cli.c
+++ b/subsys/bluetooth/mesh/gen_dtt_cli.c
@@ -40,6 +40,9 @@ static int bt_mesh_dtt_init(struct bt_mesh_model *mod)
 	struct bt_mesh_dtt_cli *cli = mod->user_data;
 
 	cli->model = mod;
+	net_buf_simple_init(mod->pub->msg, 0);
+	model_ack_init(&cli->ack_ctx);
+
 	return 0;
 }
 

--- a/subsys/bluetooth/mesh/gen_dtt_srv.c
+++ b/subsys/bluetooth/mesh/gen_dtt_srv.c
@@ -93,6 +93,8 @@ static int bt_mesh_dtt_srv_init(struct bt_mesh_model *model)
 	struct bt_mesh_dtt_srv *srv = model->user_data;
 
 	srv->model = model;
+	net_buf_simple_init(model->pub->msg, 0);
+
 	return 0;
 }
 

--- a/subsys/bluetooth/mesh/gen_loc_cli.c
+++ b/subsys/bluetooth/mesh/gen_loc_cli.c
@@ -73,6 +73,9 @@ static int bt_mesh_loc_init(struct bt_mesh_model *mod)
 	struct bt_mesh_loc_cli *cli = mod->user_data;
 
 	cli->model = mod;
+	net_buf_simple_init(mod->pub->msg, 0);
+	model_ack_init(&cli->ack_ctx);
+
 	return 0;
 }
 

--- a/subsys/bluetooth/mesh/gen_loc_srv.c
+++ b/subsys/bluetooth/mesh/gen_loc_srv.c
@@ -192,6 +192,8 @@ static int bt_mesh_loc_srv_init(struct bt_mesh_model *model)
 	struct bt_mesh_loc_srv *srv = model->user_data;
 
 	srv->model = model;
+	net_buf_simple_init(model->pub->msg, 0);
+
 	return 0;
 }
 

--- a/subsys/bluetooth/mesh/gen_lvl_cli.c
+++ b/subsys/bluetooth/mesh/gen_lvl_cli.c
@@ -51,6 +51,9 @@ static int bt_mesh_lvl_init(struct bt_mesh_model *mod)
 	struct bt_mesh_lvl_cli *cli = mod->user_data;
 
 	cli->model = mod;
+	net_buf_simple_init(mod->pub->msg, 0);
+	model_ack_init(&cli->ack_ctx);
+
 	return 0;
 }
 

--- a/subsys/bluetooth/mesh/gen_lvl_srv.c
+++ b/subsys/bluetooth/mesh/gen_lvl_srv.c
@@ -208,6 +208,8 @@ static int bt_mesh_lvl_srv_init(struct bt_mesh_model *model)
 	struct bt_mesh_lvl_srv *srv = model->user_data;
 
 	srv->model = model;
+	net_buf_simple_init(model->pub->msg, 0);
+
 	return 0;
 }
 

--- a/subsys/bluetooth/mesh/gen_onoff_cli.c
+++ b/subsys/bluetooth/mesh/gen_onoff_cli.c
@@ -61,6 +61,9 @@ static int bt_mesh_onoff_cli_init(struct bt_mesh_model *model)
 	struct bt_mesh_onoff_cli *cli = model->user_data;
 
 	cli->model = model;
+	net_buf_simple_init(cli->pub.msg, 0);
+	model_ack_init(&cli->ack_ctx);
+
 	return 0;
 }
 

--- a/subsys/bluetooth/mesh/gen_onoff_srv.c
+++ b/subsys/bluetooth/mesh/gen_onoff_srv.c
@@ -116,6 +116,8 @@ static int bt_mesh_onoff_srv_init(struct bt_mesh_model *model)
 	struct bt_mesh_onoff_srv *srv = model->user_data;
 
 	srv->model = model;
+	net_buf_simple_init(model->pub->msg, 0);
+
 	return 0;
 }
 

--- a/subsys/bluetooth/mesh/gen_plvl_cli.c
+++ b/subsys/bluetooth/mesh/gen_plvl_cli.c
@@ -126,6 +126,9 @@ static int bt_mesh_lvl_cli_init(struct bt_mesh_model *mod)
 	struct bt_mesh_plvl_cli *cli = mod->user_data;
 
 	cli->model = mod;
+	net_buf_simple_init(mod->pub->msg, 0);
+	model_ack_init(&cli->ack_ctx);
+
 	return 0;
 }
 

--- a/subsys/bluetooth/mesh/gen_plvl_srv.c
+++ b/subsys/bluetooth/mesh/gen_plvl_srv.c
@@ -525,6 +525,7 @@ static int bt_mesh_plvl_srv_init(struct bt_mesh_model *mod)
 
 	srv->plvl_model = mod;
 	bt_mesh_plvl_srv_reset(mod);
+	net_buf_simple_init(mod->pub->msg, 0);
 
 	return 0;
 }

--- a/subsys/bluetooth/mesh/gen_ponoff_cli.c
+++ b/subsys/bluetooth/mesh/gen_ponoff_cli.c
@@ -42,6 +42,9 @@ static int bt_mesh_ponoff_cli_init(struct bt_mesh_model *mod)
 	struct bt_mesh_ponoff_cli *cli = mod->user_data;
 
 	cli->model = mod;
+	net_buf_simple_init(mod->pub->msg, 0);
+	model_ack_init(&cli->ack_ctx);
+
 	return 0;
 }
 

--- a/subsys/bluetooth/mesh/gen_ponoff_srv.c
+++ b/subsys/bluetooth/mesh/gen_ponoff_srv.c
@@ -176,6 +176,8 @@ static int bt_mesh_ponoff_srv_init(struct bt_mesh_model *model)
 	struct bt_mesh_ponoff_srv *srv = model->user_data;
 
 	srv->ponoff_model = model;
+	net_buf_simple_init(model->pub->msg, 0);
+
 	return 0;
 }
 

--- a/subsys/bluetooth/mesh/gen_prop_cli.c
+++ b/subsys/bluetooth/mesh/gen_prop_cli.c
@@ -150,6 +150,9 @@ static int bt_mesh_prop_cli_init(struct bt_mesh_model *mod)
 	struct bt_mesh_prop_cli *cli = mod->user_data;
 
 	cli->model = mod;
+	net_buf_simple_init(mod->pub->msg, 0);
+	model_ack_init(&cli->ack_ctx);
+
 	return 0;
 }
 

--- a/subsys/bluetooth/mesh/gen_prop_srv.c
+++ b/subsys/bluetooth/mesh/gen_prop_srv.c
@@ -464,6 +464,7 @@ static int bt_mesh_prop_srv_init(struct bt_mesh_model *mod)
 	struct bt_mesh_prop_srv *srv = mod->user_data;
 
 	srv->mod = mod;
+	net_buf_simple_init(mod->pub->msg, 0);
 
 	if (IS_MFR_SRV(mod)) {
 		/* Manufacturer properties aren't writable */

--- a/subsys/bluetooth/mesh/model_utils.h
+++ b/subsys/bluetooth/mesh/model_utils.h
@@ -67,6 +67,11 @@ int model_ackd_send(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 		    struct bt_mesh_model_ack_ctx *ack, u32_t rsp_op,
 		    void *user_data);
 
+static inline void model_ack_init(struct bt_mesh_model_ack_ctx *ack)
+{
+	k_sem_init(&ack->sem, 0, 1);
+}
+
 static inline int model_ack_ctx_prepare(struct bt_mesh_model_ack_ctx *ack,
 					u32_t op, u16_t dst, void *user_data)
 {


### PR DESCRIPTION
Adds initialization of all model members that need explicit init calls.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>