### PR TITLE
samples: debug: ppi_trace: Fix ppi_trace sample

### DIFF
--- a/samples/debug/ppi_trace/README.rst
+++ b/samples/debug/ppi_trace/README.rst
@@ -11,12 +11,12 @@ Overview
 
 The sample initializes trace pins to observe the following hardware events:
 
-* RTC Compare event (``NRF_RTC_EVENT_COMPARE_1``)
+* RTC Compare event (``NRF_RTC_EVENT_COMPARE_0``)
 * RTC Tick event (``NRF_RTC_EVENT_TICK``)
 * Low frequency clock (LFCLK) Started event (``NRF_CLOCK_EVENT_LFCLKSTARTED``)
 * Radio activity during *Bluetooth* advertising (available only for Bluetooth capable devices)
 
-The sample sets up a :ref:`zephyr:counter_interface` to generate an ``NRF_RTC_EVENT_COMPARE_1`` event every 50 ms.
+The sample sets up a :ref:`zephyr:counter_interface` to generate an ``NRF_RTC_EVENT_COMPARE_0`` event every 50 ms.
 Initially, RTC runs on RC low frequency (lower precision) as clock source.
 When the crystal is ready, it switches seamlessly to crystal (precise) as clock source.
 When the low-frequency crystal is ready, an ``NRF_CLOCK_EVENT_LFCLKSTARTED`` event is generated.

--- a/samples/debug/ppi_trace/src/main.c
+++ b/samples/debug/ppi_trace/src/main.c
@@ -48,11 +48,8 @@ static void ppi_trace_pin_setup(u32_t pin, u32_t evt)
 
 static void ppi_trace_setup(void)
 {
-	/* chan_id=0 maps to COMPARE_1, COMPARE_0 is internally used by the
-	 * driver.
-	 */
 	ppi_trace_pin_setup(CONFIG_PPI_TRACE_PIN_RTC_COMPARE_EVT,
-		nrf_rtc_event_address_get(RTC, NRF_RTC_EVENT_COMPARE_1));
+		nrf_rtc_event_address_get(RTC, NRF_RTC_EVENT_COMPARE_0));
 
 	/* Due to low power domain events must be explicitly enabled in RTC. */
 	nrf_rtc_event_enable(RTC, NRF_RTC_INT_TICK_MASK);


### PR DESCRIPTION
PPI_trace was tracing RTC channel 1 instead of 0. Because of
that compare event was not traced on the pin.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>