### PR TITLE
subsys: dfu_target: Fix re-initialization of modem socket

### DIFF
--- a/subsys/dfu/src/dfu_target.c
+++ b/subsys/dfu/src/dfu_target.c
@@ -68,10 +68,12 @@ int dfu_target_init(int img_type, size_t file_size)
 	}
 
 	/* The user is re-initializing with an previously aborted target.
-	 * Avoid re-initializing to ensure that the download can continue where
-	 * it left off.
+	 * Avoid re-initializing generally to ensure that the download can
+	 * continue where it left off. Re-initializing is required for modem
+	 * upgrades to re-open the DFU socket that is closed on abort.
 	 */
-	if (new_target == current_target) {
+	if (new_target == current_target
+	   && img_type != DFU_TARGET_IMAGE_TYPE_MODEM_DELTA) {
 		return 0;
 	}
 


### PR DESCRIPTION
Checks if the image type is a modem upgrade if it is we need to
re-initialize the modem socket which was closed. For an application upgrade we don't have resources which needs to be re/de-initialized.

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>