### PR TITLE
drivers: lte_lc: Ignore non-CEREG notifications when connnecting

### DIFF
--- a/drivers/lte_link_control/lte_lc.c
+++ b/drivers/lte_link_control/lte_lc.c
@@ -147,8 +147,6 @@ void at_handler(void *context, char *response)
 		return;
 	}
 
-	LOG_DBG("recv: %s", log_strdup(response));
-
 	err = parse_nw_reg_status(response, &status);
 	if (err) {
 		LOG_ERR("Could not get network registration status");
@@ -534,8 +532,8 @@ static int parse_nw_reg_status(const char *at_response,
 
 	if (!response_is_valid(response_prefix, response_prefix_len,
 			       AT_CEREG_RESPONSE_PREFIX)) {
-		LOG_ERR("Invalid CEREG response");
-		err = -EIO;
+		/* The unsolicited response is not a CEREG response, ignore it.
+		 */
 		goto clean_exit;
 	}
 


### PR DESCRIPTION
After the at_notif module was added, the link controller has
parsed all notifications intended for other users than the
link controller as if they were CEREG notifications, and
printing errors when it turns out they're not.
This patch fixes the issue by silently ignoring every notification
that's not a CEREG response.
It also removes logging all incoming notifications, as they are
often not relevant, for the same reasons.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>