### PR TITLE
dfu: Fix strnlen declaration

### DIFF
--- a/subsys/dfu/src/dfu_target_mcuboot.c
+++ b/subsys/dfu/src/dfu_target_mcuboot.c
@@ -3,6 +3,19 @@
  *
  * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */
+
+/*
+ * Ensure 'strnlen' is available even with -std=c99. If
+ * _POSIX_C_SOURCE was defined we will get a warning when referencing
+ * 'strnlen'. If this proves to cause trouble we could easily
+ * re-implement strnlen instead, perhaps with a different name, as it
+ * is such a simple function.
+ */
+#if !defined(_POSIX_C_SOURCE)
+#define _POSIX_C_SOURCE 200809L
+#endif
+#include <string.h>
+
 #include <zephyr.h>
 #include <flash.h>
 #include <pm_config.h>


### PR DESCRIPTION
Ensure 'strnlen' is available even though we use -std=c99. If this
proves to cause trouble we could easily re-implement strnlen instead,
perhaps with a different name, as it is such a simple function.

This fixes a warning about the prototype of strnlen not being found.