### PR TITLE
scripts: Fix warning in partition_manager.py

### DIFF
--- a/scripts/partition_manager.py
+++ b/scripts/partition_manager.py
@@ -14,7 +14,7 @@ PERMITTED_STR_KEYS = ['size']
 
 
 def remove_item_not_in_list(list_to_remove_from, list_to_check):
-    to_remove = [x for x in list_to_remove_from.copy() if x not in list_to_check and x is not 'app']
+    to_remove = [x for x in list_to_remove_from.copy() if x not in list_to_check and x != 'app']
     list(map(list_to_remove_from.remove, to_remove))
 
 
@@ -250,7 +250,7 @@ def get_dependent_partitions(all_reqs, target):
 
 
 def app_size(reqs, total_size):
-    size = total_size - sum([req['size'] for name, req in reqs.items() if 'size' in req.keys() and name is not 'app'])
+    size = total_size - sum([req['size'] for name, req in reqs.items() if 'size' in req.keys() and name != 'app'])
     return size
 
 


### PR DESCRIPTION
Python 3.8 throws a warning when identity comparison (`is not`) is used with a literal (which sounds reasonable):

```
Running Partition Manager...
/home/rolu/repos/zephyrproject/nrf/cmake/../scripts/partition_manager.py:17: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  to_remove = [x for x in list_to_remove_from.copy() if x not in list_to_check and x is not 'app']
/home/rolu/repos/zephyrproject/nrf/cmake/../scripts/partition_manager.py:253: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  size = total_size - sum([req['size'] for name, req in reqs.items() if 'size' in req.keys() and name is not 'app'])
```

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>