### PR TITLE
[Manual Backport] doc: lwm2m lib doc review

### DIFF
--- a/doc/nrf/libraries.rst
+++ b/doc/nrf/libraries.rst
@@ -35,6 +35,14 @@ Here you can find documentation for these libraries, including API documentation
 
 .. toctree::
    :maxdepth: 1
+   :caption: Binary libraries:
+   :glob:
+
+   ../../lib/bin/*/*
+
+
+.. toctree::
+   :maxdepth: 1
    :caption: Other libraries:
    :glob:
 
@@ -45,5 +53,4 @@ Here you can find documentation for these libraries, including API documentation
    ../../include/nfc/t4t/*
    ../../include/debug/*
    ../../include/shell/*
-   ../../lib/bin/lwm2m_carrier/lwm2m_carrier.rst
    ../../include/at_cmd_parser/*

--- a/lib/bin/lwm2m_carrier/doc/CHANGELOG.rst
+++ b/lib/bin/lwm2m_carrier/doc/CHANGELOG.rst
@@ -8,7 +8,7 @@ All notable changes to this project are documented in this file.
 liblwm2m_carrier 0.8.0
 **********************
 
-Release for modem firmware version 1.1.0 with support for Verizon Wireless.
+Release for modem firmware version 1.1.0 and |NCS| v1.1.0, with support for Verizon Wireless.
 
 Certification status
 ====================
@@ -19,9 +19,21 @@ Changes
 =======
 
 * Abstracted several new functions in the glue layer to improve compatibility on top of the master branch.
-* Re-organized NVS keys usage to make it range-bound (0xCA00, 0xCAFF); this range is not backward compatible, so you should not rely on pre-existing information saved in flash by earlier versions of this library.
-* Added APIs to set the following values from the application. The application should set and maintain these values to reflect the state of the device. Updated values are pushed to the servers autonomously.
-	* Available Power Sources, Power Source Voltage, Power Source Current, Battery Level, Battery Status, Memory Free, Memory Total, Error Code.
+* Reorganized NVS keys usage to make it range-bound (0xCA00, 0xCAFF).
+  This range is not backward compatible, so you should not rely on pre-existing information saved in flash by earlier versions of this library.
+* Added APIs to set the following values from the application:
+
+   * Available Power Sources
+   * Power Source Voltage
+   * Power Source Current
+   * Battery Level
+   * Battery Status
+   * Memory Total
+   * Error Code
+
+  The application must set and maintain these values to reflect the state of the device.
+  Updated values are pushed to the servers autonomously.
+
 * Added API to set the "Device Type" resource. If not set, this is reported as "Smart Device".
 * Added API to set the "Software Version" resource. If not set, this is reported as "LwM2M 0.8.0".
 * Added API to set the "Hardware Version" resource. If not set, this is reported as "1.0".

--- a/lib/bin/lwm2m_carrier/lwm2m_carrier.rst
+++ b/lib/bin/lwm2m_carrier/lwm2m_carrier.rst
@@ -4,56 +4,68 @@ LwM2M carrier
 #############
 
 You can use the **LwM2M carrier** library in your nRF91 application in order to connect to the operator LwM2M network.
-Integrating this library into an application will cause the device to connect to the device management platform autonomously.
+Integrating this library into an application causes the device to connect to the device management platform autonomously.
+
 Every released version is considered for certification with carriers.
-Refer to the release notes for each version of the library to check the certification status of a particular release.
-Your final device must go through certification by Verizon Wireless.
+Refer to the :ref:`liblwm2m_carrier_changelog` to check the certification status of a particular release.
+Your final device must go through certification by the carrier.
+
+The :ref:`lwm2m_carrier` sample demonstrates how to run this library in an application.
 
 Prerequisites
 *************
-The LwM2M carrier library has dependencies on Zephyr and the nRF Connect SDK.
-Check the release notes for the library to see which version of |NCS| it is built for.
-To integrate the library in an application, the application must be based on a supported nRF Connect SDK version.
+The LwM2M carrier library has dependencies on Zephyr and the |NCS|.
+See the :ref:`liblwm2m_carrier_changelog` of the library to check which version of |NCS| it is built for.
+To integrate the library into an application, the application must be based on a supported |NCS| version.
 
 Application integration
 ***********************
-To run the library in an application, it is mandatory to implement the application with the API of the library.
-The application has to keep the following values up to date, and the library with automatically report the updated values to the relevant server:
-Available Power Sources, Power Source Voltage, Power Source Current, Battery Level, Battery Status, Memory Free, Memory Total, Error Code, Device Type.
-The application also needs to implement an event handler and error handlers as shown in the client sample.
-The bsdlib_init function is called by the library because of the need to track modem update state.
+To run the library in an application, you must implement the application with the API of the library.
 
-Features
-********
+The following values that reflect the state of the device must be kept up to date by the application:
 
+* Available Power Sources
+* Power Source Voltage
+* Power Source Current
+* Battery Level
+* Battery Status
+* Memory Total
+* Error Code
+* Device Type
+
+The library automatically reports the updated values to the relevant server.
+
+The application must also implement an event handler and error handlers, as shown in the :ref:`lwm2m_carrier` sample.
+The ``bsdlib_init`` function is called by the library because of the need to track modem update state.
 
 Application limitations
 ***********************
 While running this module, the application has some limitations.
-The library depends on the LTE link controller to maintain connections to carrier servers when required, and the application has to run module.
-Several system resources are used to maintain the device management platform connection.
-While running the module, the application cannot do the following:
 
-* Use the AT command module. This prevents the application from:
-    * subscribing to SMS from the modem,
-    * reading net registration status.
-* Use DTLS through the modem.
+Several system resources are used to maintain the device management platform connection.
+
+While running the module, the application cannot use DTLS through the modem.
 
 Additionally, you must apply workarounds for the following limitations:
 
-* TLS through the modem is available, but requires that the application respects the LWM2M_CARRIER_EVENT_FOTA_START event.
+* TLS through the modem is available, but requires that the application respects the :c:type:`LWM2M_CARRIER_EVENT_FOTA_START` event.
 * TLS handshakes through the modem might fail if the module is performing one at the same time.
   Implement a retry mechanism so that the application can perform its handshake later.
 
-See the changelog for the latest updates in the library, and for the list of known issues and limitations.
-The changelog also contains information about the certification status of each library.
+Certification
+*************
+The changelog contains information about the certification status of each version of the library.
 Your final product will typically need certification from the carrier as well.
 Contact the carrier for information about their device certification program.
+
+Library changelog
+*****************
+See the changelog for the latest updates in the library, and for a list of known issues and limitations.
 
 .. toctree::
     :maxdepth: 1
 
-    CHANGELOG.rst
+    doc/CHANGELOG.rst
 
 
 API documentation


### PR DESCRIPTION
Some reorganizing and rewording of the RST files.
Adding cross links to the samples and changelog.

Signed-off-by: Bartosz Gentkowski <bartosz.gentkowski@nordicsemi.no>

Opening the PR to v1.1 as the backport bot didn't work.

Original PR: https://github.com/NordicPlayground/fw-nrfconnect-nrf/pull/1490