### PR TITLE
[Manual backport] doc: add outdated note to nRF9160 user guide

### DIFF
--- a/doc/nrf/samples.rst
+++ b/doc/nrf/samples.rst
@@ -25,6 +25,8 @@ In addition, the |NCS| provides the following samples that showcase the use of a
 
    ../../samples/nfc/*/README
 
+.. _nrf9160_samples:
+
 .. toctree::
    :maxdepth: 1
    :caption: nRF9160 samples:

--- a/doc/nrf/ug_nrf9160.rst
+++ b/doc/nrf/ug_nrf9160.rst
@@ -239,6 +239,10 @@ Available drivers, libraries, and samples
 Currently the following drivers, libraries, and samples can be used to develop and test
 applications on the nRF9160 SiP.
 
+.. warning::
+   The following sections are currently outdated.
+   See the :ref:`drivers`, :ref:`libraries`, and :ref:`nRF9160 samples <nrf9160_samples>` sections and the respective repository folders for up-to-date information.
+
 Drivers
 =======
 


### PR DESCRIPTION
Manual backport from https://github.com/NordicPlayground/fw-nrfconnect-nrf/pull/1475/


Some information in the nRF9160 user guide is outdated and
will probably not be updated for the release. Since the release
will contain updated information in other parts of the user
guide, we need to point out the part that is outdated.

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>