### PR TITLE
Hci driver debug

### DIFF
--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -79,13 +79,15 @@ void blectlr_assertion_handler(const char *const file, const u32_t line)
 #ifdef CONFIG_BT_CTLR_ASSERT_HANDLER
 	bt_ctlr_assert_handle(file, line);
 #else
-	BT_ERR("BleCtlr ASSERT: %s, %d", file, line);
+	BT_ERR("BleCtlr ASSERT: %s, %d", log_strdup(file), line);
 	k_oops();
 #endif
 }
 
 static int cmd_handle(struct net_buf *cmd)
 {
+	BT_DBG("");
+
 	int errcode = MULTITHREADING_LOCK_ACQUIRE();
 
 	if (!errcode) {


### PR DESCRIPTION
Add own debug print for receiving command status, also only print
command complete using the command complete structure. We reported all
events using the command complete byte order.
    
Also did general cleanup in the hci_driver.

Missing log_strdup in assert handler will lead to assert in log_core.c