### PR TITLE
manifest: update manifest for nRF5340 BLE split stack architecture

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -38,7 +38,7 @@ manifest:
     - name: zephyr
       repo-path: fw-nrfconnect-zephyr
       west-commands: scripts/west-commands.yml
-      revision: 65f2d54708f4d0914fb5f500a4e00cb4e9f83dd8
+      revision: 7e20180c004a71f145c9aed61f02f97ed8841df2
     - name: nffs
       revision: bc62a2fa9d98ddb5d633c932ea199bc68e10f194
       path: modules/fs/nffs


### PR DESCRIPTION
Manifest update to integrate and test the nRF5340 BLE stack
split architecture.

Signed-off-by: Ioannis Glaropoulos <Ioannis.Glaropoulos@nordicsemi.no>