### PR TITLE
manifest: nrfxlib: minor NFC documentation update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -72,7 +72,7 @@ manifest:
       revision: 30b7efa827b04d2e47840716b0372737fe7d6c92
     - name: nrfxlib
       path: nrfxlib
-      revision: 4de8eebe8cfecb4fd268868263eb6ede54bbb86b
+      revision: 4f70d0ac68389d5d81ba520ecaa2313b0ee1d6b7
     - name: cmock
       path: test/cmock
       revision: c243b9a7a7b3c471023193992b46cf1bd1910450


### PR DESCRIPTION
NFC tag libraries documentation was updated by removing
outdated information.

nrfxlib PR: https://github.com/NordicPlayground/nrfxlib/pull/84