### PR TITLE
samples: align welcome logs in NFC and BLE samples

### DIFF
--- a/samples/bluetooth/central_bas/src/main.c
+++ b/samples/bluetooth/central_bas/src/main.c
@@ -346,6 +346,8 @@ void main(void)
 {
 	int err;
 
+	printk("Starting Bluetooth Central BAS example\n");
+
 	bt_gatt_bas_c_init(&bas_c);
 
 	err = bt_enable(NULL);

--- a/samples/bluetooth/central_dfu_smp/src/main.c
+++ b/samples/bluetooth/central_dfu_smp/src/main.c
@@ -383,7 +383,7 @@ void main(void)
 {
 	int err;
 
-	printk("Starting DFU SMP Client example\n");
+	printk("Starting Bluetooth Central DFU SMP example\n");
 
 	bt_gatt_dfu_smp_c_init(&dfu_smp_c, &init_params);
 

--- a/samples/bluetooth/central_hids/src/main.c
+++ b/samples/bluetooth/central_hids/src/main.c
@@ -561,7 +561,7 @@ void main(void)
 {
 	int err;
 
-	printk("Starting HIDS Client example\n");
+	printk("Starting Bluetooth Central HIDS example\n");
 
 	bt_gatt_hids_c_init(&hids_c, &hids_c_init_params);
 

--- a/samples/bluetooth/central_uart/src/main.c
+++ b/samples/bluetooth/central_uart/src/main.c
@@ -432,7 +432,7 @@ void main(void)
 {
 	int err;
 
-	printk("Starting NUS Client example\n");
+	printk("Starting Bluetooth Central UART example\n");
 
 	err = bt_conn_auth_cb_register(&conn_auth_callbacks);
 	if (err) {

--- a/samples/bluetooth/llpm/src/main.c
+++ b/samples/bluetooth/llpm/src/main.c
@@ -406,6 +406,8 @@ void main(void)
 		.le_param_updated = le_param_updated,
 	};
 
+	printk("Starting Bluetooth LLPM example\n");
+
 	console_init();
 
 	err = bt_enable(bt_ready);

--- a/samples/bluetooth/peripheral_hids_keyboard/src/main.c
+++ b/samples/bluetooth/peripheral_hids_keyboard/src/main.c
@@ -952,7 +952,7 @@ void main(void)
 	int err;
 	int blink_status = 0;
 
-	printk("Starting Nordic HID service keyboard example\n");
+	printk("Starting Bluetooth Peripheral HIDS keyboard example\n");
 
 	configure_gpio();
 

--- a/samples/bluetooth/peripheral_hids_mouse/src/main.c
+++ b/samples/bluetooth/peripheral_hids_mouse/src/main.c
@@ -783,7 +783,7 @@ void main(void)
 {
 	int err;
 
-	printk("Start zephyr\n");
+	printk("Starting Bluetooth Peripheral HIDS mouse example\n");
 
 	bt_conn_cb_register(&conn_callbacks);
 

--- a/samples/bluetooth/peripheral_lbs/src/main.c
+++ b/samples/bluetooth/peripheral_lbs/src/main.c
@@ -233,7 +233,7 @@ void main(void)
 	int blink_status = 0;
 	int err;
 
-	printk("Starting Nordic LED-Button service example\n");
+	printk("Starting Bluetooth Peripheral LBS example\n");
 
 	err = dk_leds_init();
 	if (!err) {

--- a/samples/bluetooth/shell_bt_nus/src/main.c
+++ b/samples/bluetooth/shell_bt_nus/src/main.c
@@ -150,6 +150,8 @@ void main(void)
 {
 	int err;
 
+	printk("Starting Bluetooth NUS shell transport example\n");
+
 	err = bt_enable(bt_ready);
 	if (err) {
 		LOG_ERR("BLE enable failed (err: %d)", err);

--- a/samples/bluetooth/throughput/src/main.c
+++ b/samples/bluetooth/throughput/src/main.c
@@ -371,6 +371,8 @@ void main(void)
 	    .le_param_req = le_param_req,
 	};
 
+	printk("Starting Bluetooth Throughput example\n");
+
 	console_init();
 
 	err = bt_enable(bt_ready);

--- a/samples/nfc/record_text/src/main.c
+++ b/samples/nfc/record_text/src/main.c
@@ -134,7 +134,7 @@ int main(void)
 {
 	u32_t len = sizeof(ndef_msg_buf);
 
-	printk("NFC configuration start\n");
+	printk("Starting NFC Text Record example\n");
 
 	/* Configure LED-pins as outputs */
 	if (dk_leds_init() < 0) {

--- a/samples/nfc/tag_reader/src/main.c
+++ b/samples/nfc/tag_reader/src/main.c
@@ -600,7 +600,7 @@ void main(void)
 {
 	int err;
 
-	printk("NFC reader sample started.\n");
+	printk("Starting NFC TAG Reader example\n");
 	nfc_t4t_hl_procedure_cb_register(&t4t_hl_procedure_cb);
 
 	k_delayed_work_init(&transmit_work, transfer_handler);

--- a/samples/nfc/writable_ndef_msg/src/main.c
+++ b/samples/nfc/writable_ndef_msg/src/main.c
@@ -115,7 +115,7 @@ static int board_init(void)
  */
 int main(void)
 {
-	printk("NFC configuration start.\n");
+	printk("Starting Nordic NFC Writable NDEF Message example\n");
 
 	/* Configure LED-pins as outputs. */
 	if (board_init() < 0) {
@@ -163,7 +163,7 @@ int main(void)
 		printk("Cannot start emulation!\n");
 		goto fail;
 	}
-	printk("Writable NDEF message example started.\n");
+	printk("Starting NFC Writable NDEF Message example\n");
 
 	while (true) {
 		if (atomic_cas(&op_flags, FLASH_BUF_PREP_FINISHED,


### PR DESCRIPTION
Provide uniform welcome logs in samples using names from
README.rst.

Changes as per NCSDK-3220