### PR TITLE
doc: removing links to content not in the release

### DIFF
--- a/doc/release-notes-1.1.0.rst
+++ b/doc/release-notes-1.1.0.rst
@@ -451,8 +451,6 @@ Documentation
   * Bluetooth Low Energy:
 
     * :ref:`bas_c_readme`
-    * :ref:`latency_readme`
-    * :ref:`latency_c_readme`
     * :ref:`bt_mesh`
 
 
@@ -483,7 +481,6 @@ Documentation
   * :ref:`nrfxlib:ble_controller`
   * :ref:`nrfxlib:bsdlib`
   * :ref:`nrfxlib:nrf_cc310_platform_readme`
-  * :ref:`nrfxlib:mpsl`
   * :ref:`nrf_security_readme`
   * :ref:`mcuboot:mcuboot_wrapper`
   * :ref:`mcuboot:mcuboot_ncs`


### PR DESCRIPTION
To align with https://github.com/NordicPlayground/fw-nrfconnect-nrf/pull/1543

Some of the mentioned documentation updates were for master
and are not present in the release. Removing those.

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>