### PR TITLE
west: update manifest with zephyr west pristine bugfix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -38,7 +38,7 @@ manifest:
     - name: zephyr
       repo-path: fw-nrfconnect-zephyr
       west-commands: scripts/west-commands.yml
-      revision: 7e20180c004a71f145c9aed61f02f97ed8841df2
+      revision:  pull/244/head
     - name: nffs
       revision: bc62a2fa9d98ddb5d633c932ea199bc68e10f194
       path: modules/fs/nffs


### PR DESCRIPTION
Update the manifest with a zephyr west pristine bugfix.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>