### PR TITLE
[DNM] subsys: Bluetooth: Aquire multithreading lock before processing

### DIFF
--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -308,7 +308,15 @@ static void signal_thread(void *p1, void *p2, void *p3)
 
 	while (true) {
 		k_sem_take(&sem_signal, K_FOREVER);
-		ble_controller_low_prio_tasks_process();
+
+		/* We might be interrupting another thread that's currently
+		 * using a ble-controller API.
+		 */
+		err = MULTITHREADING_LOCK_ACQUIRE();
+		if (!err) {
+			ble_controller_low_prio_tasks_process();
+			MULTITHREADING_LOCK_RELEASE();
+		}
 	}
 }
 


### PR DESCRIPTION
Although the ble_controller_low_prio_task_process() call is a
cooperative thread and should continue until it makes itself unready, it
may be interrupting another thread that's currently calling a
ble-controller API.

FYI: @rugeGerritsen @sofu1 