### PR TITLE
Bluetooth: Mesh: Model unack client setters

### DIFF
--- a/include/bluetooth/mesh/gen_dtt_cli.h
+++ b/include/bluetooth/mesh/gen_dtt_cli.h
@@ -79,15 +79,15 @@ struct bt_mesh_dtt_cli {
 /** @brief Get the Default Transition Time of the server.
  *
  * This call is blocking if the @p rsp_transition_time buffer is non-NULL.
- * Otherwise, this function will not request a response from the server, and
- * return immediately.
+ * Otherwise, this function will return, and the response will be passed to the
+ * @ref bt_mesh_dtt_cli::status_handler callback.
  *
  * @param[in] cli Client making the request.
  * @param[in] ctx Message context to use for sending, or NULL to publish with
  * the configured parameters.
- * @param[out] rsp_transition_time Pointer to a response buffer. Cannot be
- * NULL. Note that the response is a signed value, that can be K_FOREVER if the
- * current state is unknown or too large to represent.
+ * @param[out] rsp_transition_time Pointer to a response buffer, or NULL to keep
+ * from blocking. Note that the response is a signed value, that can be
+ * K_FOREVER if the current state is unknown or too large to represent.
  *
  * @retval 0 Successfully retrieved the status of the bound srv.
  * @retval -EALREADY A blocking operation is already in progress in this model.
@@ -99,26 +99,46 @@ int bt_mesh_dtt_get(struct bt_mesh_dtt_cli *cli, struct bt_mesh_msg_ctx *ctx,
 /** @brief Set the Default Transition Time of the server.
  *
  * This call is blocking if the @p rsp_transition_time buffer is non-NULL.
- * Otherwise, this function will not request a response from the server, and
- * return immediately.
+ * Otherwise, this function will return, and the response will be passed to the
+ * @ref bt_mesh_dtt_cli::status_handler callback.
  *
  * @param[in] cli Client model to send on.
  * @param[in] ctx Message context to use for sending, or NULL to publish with
  * the configured parameters.
  * @param[in] transition_time Transition time to set (in milliseconds). Must be
  * less than @ref BT_MESH_MODEL_TRANSITION_TIME_MAX_MS.
- * @param[out] rsp_transition_time Response buffer, or NULL to send an
- * unacknowledged message. Note that the response is a signed value, that can
- * be K_FOREVER if the current state is unknown or too large to represent.
+ * @param[out] rsp_transition_time Response buffer, or NULL to keep from
+ * blocking. Note that the response is a signed value, that can be K_FOREVER if
+ * the current state is unknown or too large to represent.
  *
- * @retval 0 Successfully sent the message. If the message is acknowledged,
- * the response buffer has been set according to the srv's response.
+ * @retval 0 Successfully sent the message and populated the
+ * @p rsp_transition_time buffer.
  * @retval -EINVAL The given transition time is invalid.
  * @retval -EALREADY A blocking operation is already in progress in this model.
  * @retval -EAGAIN The request timed out.
  */
 int bt_mesh_dtt_set(struct bt_mesh_dtt_cli *cli, struct bt_mesh_msg_ctx *ctx,
 		    u32_t transition_time, s32_t *rsp_transition_time);
+
+/** @brief Set the Default Transition Time of the server without requesting a
+ * response.
+ *
+ * @param[in] cli Client model to send on.
+ * @param[in] ctx Message context to use for sending, or NULL to publish with
+ * the configured parameters.
+ * @param[in] transition_time Transition time to set (in milliseconds). Must be
+ * less than @ref BT_MESH_MODEL_TRANSITION_TIME_MAX_MS.
+ *
+ * @retval 0 Successfully sent the message.
+ * @retval -EINVAL The given transition time is invalid.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ */
+int bt_mesh_dtt_set_unack(struct bt_mesh_dtt_cli *cli,
+			  struct bt_mesh_msg_ctx *ctx, u32_t transition_time);
 
 /** @cond INTERNAL_HIDDEN */
 extern const struct bt_mesh_model_op _bt_mesh_dtt_cli_op[];

--- a/include/bluetooth/mesh/gen_loc_cli.h
+++ b/include/bluetooth/mesh/gen_loc_cli.h
@@ -122,15 +122,14 @@ int bt_mesh_loc_cli_global_get(struct bt_mesh_loc_cli *cli,
 /** @brief Set the Global Location in the server.
  *
  * This call is blocking if the @p rsp buffer is non-NULL. Otherwise, this
- * function will not request a response from the server, and return
- * immediately.
+ * function will return, and the response will be passed to the
+ * @ref bt_mesh_loc_cli_handlers::global_status callback.
  *
  * @param[in] cli Client model to send on.
  * @param[in] ctx Message context, or NULL to use the configured publish
  * parameters.
  * @param[in] loc New Global Location value to set.
- * @param[out] rsp Response status buffer, or NULL to send an unacknowledged
- * message.
+ * @param[out] rsp Response status buffer, or NULL to keep from blocking.
  *
  * @retval 0 Successfully sent the message and populated the @p rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
@@ -145,6 +144,24 @@ int bt_mesh_loc_cli_global_set(struct bt_mesh_loc_cli *cli,
 			       struct bt_mesh_msg_ctx *ctx,
 			       const struct bt_mesh_loc_global *loc,
 			       struct bt_mesh_loc_global *rsp);
+
+/** @brief Set the Global Location in the server without requesting a response.
+ *
+ * @param[in] cli Client model to send on.
+ * @param[in] ctx Message context, or NULL to use the configured publish
+ * parameters.
+ * @param[in] loc New Global Location value to set.
+ *
+ * @retval 0 Successfully sent the message.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ */
+int bt_mesh_loc_cli_global_set_unack(struct bt_mesh_loc_cli *cli,
+				     struct bt_mesh_msg_ctx *ctx,
+				     const struct bt_mesh_loc_global *loc);
 
 /** @brief Get the local location of the bound srv.
  *
@@ -174,15 +191,14 @@ int bt_mesh_loc_cli_local_get(struct bt_mesh_loc_cli *cli,
 /** @brief Set the Local Location in the server.
  *
  * This call is blocking if the @p rsp buffer is non-NULL. Otherwise, this
- * function will not request a response from the server, and return
- * immediately.
+ * function will return, and the response will be passed to the
+ * @ref bt_mesh_loc_cli_handlers::local_status callback.
  *
  * @param[in] cli Client model to send on.
  * @param[in] ctx Message context, or NULL to use the configured publish
  * parameters.
  * @param[in] loc New Local Location value to set.
- * @param[out] rsp Response status buffer, or NULL to send an unacknowledged
- * message.
+ * @param[out] rsp Response status buffer, or NULL to keep from blocking.
  *
  * @retval 0 Successfully sent the message and populated the @p rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
@@ -197,6 +213,24 @@ int bt_mesh_loc_cli_local_set(struct bt_mesh_loc_cli *cli,
 			      struct bt_mesh_msg_ctx *ctx,
 			      const struct bt_mesh_loc_local *loc,
 			      struct bt_mesh_loc_local *rsp);
+
+/** @brief Set the Local Location in the server without requesting a response.
+ *
+ * @param[in] cli Client model to send on.
+ * @param[in] ctx Message context, or NULL to use the configured publish
+ * parameters.
+ * @param[in] loc New Local Location value to set.
+ *
+ * @retval 0 Successfully sent the message.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ */
+int bt_mesh_loc_cli_local_set_unack(struct bt_mesh_loc_cli *cli,
+				    struct bt_mesh_msg_ctx *ctx,
+				    const struct bt_mesh_loc_local *loc);
 
 /** @cond INTERNAL_HIDDEN */
 extern const struct bt_mesh_model_op _bt_mesh_loc_cli_op[];

--- a/include/bluetooth/mesh/gen_lvl_cli.h
+++ b/include/bluetooth/mesh/gen_lvl_cli.h
@@ -101,16 +101,15 @@ int bt_mesh_lvl_cli_get(struct bt_mesh_lvl_cli *cli,
 /** @brief Set the level state in the server.
  *
  * This call is blocking if the @p rsp buffer is non-NULL. Otherwise, this
- * function will not request a response from the server, and return
- * immediately.
+ * function will return, and the response will be passed to the
+ * @ref bt_mesh_lvl_cli::status_handler callback.
  *
  * @param[in] cli Client model to send on.
  * @param[in] ctx Message context, or NULL to use the configured publish
  * parameters.
  * @param[in] set New level value to set. Set @p set::transition to NULL to use
  * the server's default transition parameters.
- * @param[out] rsp Response status buffer, or NULL to send an unacknowledged
- * message.
+ * @param[out] rsp Response status buffer, or NULL to keep from blocking.
  *
  * @retval 0 Successfully sent the message and populated the @p rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
@@ -126,25 +125,39 @@ int bt_mesh_lvl_cli_set(struct bt_mesh_lvl_cli *cli,
 			const struct bt_mesh_lvl_set *set,
 			struct bt_mesh_lvl_status *rsp);
 
+/** @brief Set the level state in the server without requesting a response.
+ *
+ * @param[in] cli Client model to send on.
+ * @param[in] ctx Message context, or NULL to use the configured publish
+ * parameters.
+ * @param[in] set New level value to set. Set @p set::transition to NULL to use
+ * the server's default transition parameters.
+ *
+ * @retval 0 Successfully sent the message.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ */
+int bt_mesh_lvl_cli_set_unack(struct bt_mesh_lvl_cli *cli,
+			      struct bt_mesh_msg_ctx *ctx,
+			      const struct bt_mesh_lvl_set *set);
+
 /** @brief Trigger a differential level state change in the server.
  *
- * Makes the server move its level state by some delta value. If multiple
- * delta_set messages are sent in a row (with less than 6 seconds interval),
- * and @p delta_set::new_transaction is set to false, the server will continue
- * using the same base value for its delta as in the first message, unless
- * some other client made changes to the server.
+ * @copydetails bt_mesh_lvl_cli_delta_set_unack
  *
  * This call is blocking if the @p rsp buffer is non-NULL. Otherwise, this
- * function will not request a response from the server, and return
- * immediately.
+ * function will return, and the response will be passed to the
+ * @ref bt_mesh_lvl_cli::status_handler callback.
  *
  * @param[in] cli Client model to send on.
  * @param[in] ctx Message context, or NULL to use the configured publish
  * parameters.
  * @param[in] delta_set State change to make. Set @p set::transition to NULL to
  * use the server's default transition parameters.
- * @param[out] rsp Response status buffer, or NULL to send an unacknowledged
- * message.
+ * @param[out] rsp Response status buffer, or NULL to keep from blocking.
  *
  * @retval 0 Successfully sent the message and populated the @p rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
@@ -160,30 +173,46 @@ int bt_mesh_lvl_cli_delta_set(struct bt_mesh_lvl_cli *cli,
 			      const struct bt_mesh_lvl_delta_set *delta_set,
 			      struct bt_mesh_lvl_status *rsp);
 
+/** @brief Trigger a differential level state change in the server without
+ * requesting a response.
+ *
+ * Makes the server move its level state by some delta value. If multiple
+ * delta_set messages are sent in a row (with less than 6 seconds interval),
+ * and @p delta_set::new_transaction is set to false, the server will continue
+ * using the same base value for its delta as in the first message, unless
+ * some other client made changes to the server.
+ *
+ * @param[in] cli Client model to send on.
+ * @param[in] ctx Message context, or NULL to use the configured publish
+ * parameters.
+ * @param[in] delta_set State change to make. Set @p set::transition to NULL to
+ * use the server's default transition parameters.
+ *
+ * @retval 0 Successfully sent the message.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ */
+int bt_mesh_lvl_cli_delta_set_unack(
+	struct bt_mesh_lvl_cli *cli, struct bt_mesh_msg_ctx *ctx,
+	const struct bt_mesh_lvl_delta_set *delta_set);
+
 /** @brief Trigger a continuous level change in the server.
  *
- * Makes the server continuously move its level state by the set rate:
- *
- * @code
- * rate_of_change = move_set->delta / move_set->transition->time
- * @endcode
- *
- * The server will continue moving its level until it is told to stop, or until
- * it reaches some application specific boundary value. The server may choose
- * to wrap around the level value, depending on its usage. The move can be
- * stopped by sending a new move message with a delta value of 0.
+ * @copydetails bt_mesh_lvl_cli_move_set_unack
  *
  * This call is blocking if the @p rsp buffer is non-NULL. Otherwise, this
- * function will not request a response from the server, and return
- * immediately.
+ * function will return, and the response will be passed to the
+ * @ref bt_mesh_lvl_cli::status_handler callback.
  *
  * @param[in] cli Client model to send on.
  * @param[in] ctx Message context, or NULL to use the configured publish
  * parameters.
  * @param[in] move_set State change to make. Set @p set::transition to NULL to
  * use the server's default transition parameters.
- * @param[out] rsp Response status buffer, or NULL to send an unacknowledged
- * message.
+ * @param[out] rsp Response status buffer, or NULL to keep from blocking.
  *
  * @retval 0 Successfully sent the message and populated the @p rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
@@ -198,6 +227,37 @@ int bt_mesh_lvl_cli_move_set(struct bt_mesh_lvl_cli *cli,
 			     struct bt_mesh_msg_ctx *ctx,
 			     const struct bt_mesh_lvl_move_set *move_set,
 			     struct bt_mesh_lvl_status *rsp);
+
+/** @brief Trigger a continuous level change in the server without requesting
+ * a response.
+ *
+ * Makes the server continuously move its level state by the set rate:
+ *
+ * @code
+ * rate_of_change = move_set->delta / move_set->transition->time
+ * @endcode
+ *
+ * The server will continue moving its level until it is told to stop, or until
+ * it reaches some application specific boundary value. The server may choose
+ * to wrap around the level value, depending on its usage. The move can be
+ * stopped by sending a new move message with a delta value of 0.
+ *
+ * @param[in] cli Client model to send on.
+ * @param[in] ctx Message context, or NULL to use the configured publish
+ * parameters.
+ * @param[in] move_set State change to make. Set @p set::transition to NULL to
+ * use the server's default transition parameters.
+ *
+ * @retval 0 Successfully sent the message.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ */
+int bt_mesh_lvl_cli_move_set_unack(struct bt_mesh_lvl_cli *cli,
+				   struct bt_mesh_msg_ctx *ctx,
+				   const struct bt_mesh_lvl_move_set *move_set);
 
 /** @cond INTERNAL_HIDDEN */
 extern const struct bt_mesh_model_op _bt_mesh_lvl_cli_op[];

--- a/include/bluetooth/mesh/gen_onoff_cli.h
+++ b/include/bluetooth/mesh/gen_onoff_cli.h
@@ -102,8 +102,8 @@ int bt_mesh_onoff_cli_get(struct bt_mesh_onoff_cli *cli,
 /** @brief Set the OnOff state in the srv.
  *
  * This call is blocking if the @p rsp buffer is non-NULL. Otherwise, this
- * function will not request a response from the server, and return
- * immediately.
+ * function will return, and the response will be passed to the
+ * @ref bt_mesh_onoff_cli::status_handler callback.
  *
  * @param[in] cli Client model to send on.
  * @param[in] ctx Message context, or NULL to use the configured publish
@@ -111,8 +111,7 @@ int bt_mesh_onoff_cli_get(struct bt_mesh_onoff_cli *cli,
  * @param[in] set New OnOff parameters to set. @p set::transition can either
  * point to a transition structure, or be left to NULL to use the default
  * transition parameters on the server.
- * @param[out] rsp Response status buffer, or NULL to send an unacknowledged
- * message.
+ * @param[in] rsp Status response buffer, or NULL to keep from blocking.
  *
  * @retval 0 Successfully sent the message and populated the @p rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
@@ -127,6 +126,26 @@ int bt_mesh_onoff_cli_set(struct bt_mesh_onoff_cli *cli,
 			  struct bt_mesh_msg_ctx *ctx,
 			  const struct bt_mesh_onoff_set *set,
 			  struct bt_mesh_onoff_status *rsp);
+
+/** @brief Set the OnOff state in the srv without requesting a response.
+ *
+ * @param[in] cli Client model to send on.
+ * @param[in] ctx Message context, or NULL to use the configured publish
+ * parameters.
+ * @param[in] set New OnOff parameters to set. @p set::transition can either
+ * point to a transition structure, or be left to NULL to use the default
+ * transition parameters on the server.
+ *
+ * @retval 0 Successfully sent the message.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ */
+int bt_mesh_onoff_cli_set_unack(struct bt_mesh_onoff_cli *cli,
+				struct bt_mesh_msg_ctx *ctx,
+				const struct bt_mesh_onoff_set *set);
 
 /** @cond INTERNAL_HIDDEN */
 extern const struct bt_mesh_model_op _bt_mesh_onoff_cli_op[];

--- a/include/bluetooth/mesh/gen_plvl_cli.h
+++ b/include/bluetooth/mesh/gen_plvl_cli.h
@@ -137,16 +137,15 @@ int bt_mesh_plvl_cli_power_get(struct bt_mesh_plvl_cli *cli,
 /** @brief Set the Power Level of the server.
  *
  * This call is blocking if the @p rsp buffer is non-NULL. Otherwise, this
- * function will not request a response from the server, and return
- * immediately.
+ * function will return, and the response will be passed to the
+ * @ref bt_mesh_plvl_cli_handlers::power_status callback.
  *
  * @param[in] cli Client model to send on.
  * @param[in] ctx Message context, or NULL to use the configured publish
  * parameters.
  * @param[in] set New Power Level value to set. Set @p set::transition to NULL
  * to use the server's default transition parameters.
- * @param[in] rsp Response status buffer, or NULL to send an unacknowledged
- * message.
+ * @param[in] rsp Response status buffer, or NULL to keep from blocking.
  *
  * @retval 0 Successfully sent the message and populated the @p rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
@@ -161,6 +160,25 @@ int bt_mesh_plvl_cli_power_set(struct bt_mesh_plvl_cli *cli,
 			       struct bt_mesh_msg_ctx *ctx,
 			       const struct bt_mesh_plvl_set *set,
 			       struct bt_mesh_plvl_status *rsp);
+
+/** @brief Set the Power Level of the server without requesting a response.
+ *
+ * @param[in] cli Client model to send on.
+ * @param[in] ctx Message context, or NULL to use the configured publish
+ * parameters.
+ * @param[in] set New Power Level value to set. Set @p set::transition to NULL
+ * to use the server's default transition parameters.
+ *
+ * @retval 0 Successfully sent the message.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ */
+int bt_mesh_plvl_cli_power_set_unack(struct bt_mesh_plvl_cli *cli,
+				     struct bt_mesh_msg_ctx *ctx,
+				     const struct bt_mesh_plvl_set *set);
 
 /** @brief Get the Power Range of the bound server.
  *
@@ -189,15 +207,14 @@ int bt_mesh_plvl_cli_range_get(struct bt_mesh_plvl_cli *cli,
 /** @brief Set the Power Range state in the server.
  *
  * This call is blocking if the @p rsp buffer is non-NULL. Otherwise, this
- * function will not request a response from the server, and return
- * immediately.
+ * function will return, and the response will be passed to the
+ * @ref bt_mesh_plvl_cli_handlers::range_status callback.
  *
  * @param[in] cli Client model to send on.
  * @param[in] ctx Message context, or NULL to use the configured publish
  * parameters.
  * @param[in] range New Power Range value to set.
- * @param[in] rsp Response status buffer, or NULL to send an unacknowledged
- * message.
+ * @param[in] rsp Response status buffer, or NULL to keep from blocking.
  *
  * @retval 0 Successfully sent the message and populated the @p rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
@@ -212,6 +229,25 @@ int bt_mesh_plvl_cli_range_set(struct bt_mesh_plvl_cli *cli,
 			       struct bt_mesh_msg_ctx *ctx,
 			       const struct bt_mesh_plvl_range *range,
 			       struct bt_mesh_plvl_range_status *rsp);
+
+/** @brief Set the Power Range state in the server without requesting a
+ * response.
+ *
+ * @param[in] cli Client model to send on.
+ * @param[in] ctx Message context, or NULL to use the configured publish
+ * parameters.
+ * @param[in] range New Power Range value to set.
+ *
+ * @retval 0 Successfully sent the message.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ */
+int bt_mesh_plvl_cli_range_set_unack(struct bt_mesh_plvl_cli *cli,
+				     struct bt_mesh_msg_ctx *ctx,
+				     const struct bt_mesh_plvl_range *range);
 
 /** @brief Get the Default Power of the bound server.
  *
@@ -239,15 +275,14 @@ int bt_mesh_plvl_cli_default_get(struct bt_mesh_plvl_cli *cli,
 /** @brief Set the Default Power state in the server.
  *
  * This call is blocking if the @p rsp buffer is non-NULL. Otherwise, this
- * function will not request a response from the server, and return
- * immediately.
+ * function will return, and the response will be passed to the
+ * @ref bt_mesh_plvl_cli_handlers::default_status callback.
  *
  * @param[in] cli Client model to send on.
  * @param[in] ctx Message context, or NULL to use the configured publish
  * parameters.
  * @param[in] default_power New Default Power value to set.
- * @param[in] rsp Response status buffer, or NULL to send an unacknowledged
- * message.
+ * @param[in] rsp Response status buffer, or NULL to keep from blocking.
  *
  * @retval 0 Successfully sent the message and populated the @p rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
@@ -261,6 +296,27 @@ int bt_mesh_plvl_cli_default_get(struct bt_mesh_plvl_cli *cli,
 int bt_mesh_plvl_cli_default_set(struct bt_mesh_plvl_cli *cli,
 				 struct bt_mesh_msg_ctx *ctx,
 				 u16_t default_power, u16_t *rsp);
+
+/** @brief Set the Default Power state in the server without requesting a
+ * response.
+ *
+ * @param[in] cli Client model to send on.
+ * @param[in] ctx Message context, or NULL to use the configured publish
+ * parameters.
+ * @param[in] default_power New Default Power value to set.
+ *
+ * @retval 0 Successfully sent the message.
+ * @retval -EALREADY A blocking request is already in progress.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ * @retval -ETIMEDOUT The request timed out without a response.
+ */
+int bt_mesh_plvl_cli_default_set_unack(struct bt_mesh_plvl_cli *cli,
+				 struct bt_mesh_msg_ctx *ctx,
+				 u16_t default_power);
 
 /** @brief Get the last non-zero Power Level of the bound server.
  *

--- a/include/bluetooth/mesh/gen_ponoff_cli.h
+++ b/include/bluetooth/mesh/gen_ponoff_cli.h
@@ -88,6 +88,8 @@ struct bt_mesh_ponoff_cli {
  * @retval 0 Successfully sent a get message. If a response buffer is
  * provided, it has been populated.
  * @retval -EALREADY A blocking request is already in progress.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -99,16 +101,22 @@ int bt_mesh_ponoff_cli_on_power_up_get(struct bt_mesh_ponoff_cli *cli,
 
 /** @brief Set the OnPowerUp state of a server.
  *
+ * This call is blocking if the @p rsp buffer is non-NULL. Otherwise, this
+ * function will return, and the response will be passed to the
+ * @ref bt_mesh_ponoff_cli::status_handler callback.
+ *
  * @param[in] cli Power OnOff client to send the message on.
  * @param[in] ctx Context of the message, or NULL to send with the configured
  * publish parameters.
  * @param[in] on_power_up New OnPowerUp state of the server.
  * @param[out] rsp Response buffer to put the received response in, or NULL to
- * send an unacknowledged message.
+ * keep from blocking.
  *
  * @retval 0 Successfully sent a set message. If a response buffer is
  * provided, it has been populated.
  * @retval -EALREADY A blocking request is already in progress.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
  * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
  * not configured.
  * @retval -EAGAIN The device has not been provisioned.
@@ -118,6 +126,24 @@ int bt_mesh_ponoff_cli_on_power_up_set(struct bt_mesh_ponoff_cli *cli,
 				       struct bt_mesh_msg_ctx *ctx,
 				       enum bt_mesh_on_power_up on_power_up,
 				       enum bt_mesh_on_power_up *rsp);
+
+/** @brief Set the OnPowerUp state of a server without requesting a response.
+ *
+ * @param[in] cli Power OnOff client to send the message on.
+ * @param[in] ctx Context of the message, or NULL to send with the configured
+ * publish parameters.
+ * @param[in] on_power_up New OnPowerUp state of the server.
+ *
+ * @retval 0 Successfully sent a set message.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ */
+int bt_mesh_ponoff_cli_on_power_up_set_unack(
+	struct bt_mesh_ponoff_cli *cli, struct bt_mesh_msg_ctx *ctx,
+	enum bt_mesh_on_power_up on_power_up);
 
 /** @cond INTERNAL_HIDDEN */
 extern const struct bt_mesh_model_op _bt_mesh_ponoff_cli_op[];

--- a/include/bluetooth/mesh/gen_prop_cli.h
+++ b/include/bluetooth/mesh/gen_prop_cli.h
@@ -160,23 +160,18 @@ int bt_mesh_prop_cli_prop_get(struct bt_mesh_prop_cli *cli,
 
 /** @brief Set a property value in a User Property Server.
  *
- * The User Property may only be set if the server enabled user write access to
- * it. If this is not the case, the server will only respond with the set user
- * access mode for the given property.
+ * @copydetails bt_mesH_prop_cli_user_prop_set_unack
  *
  * This call is blocking if the @p rsp buffer is non-NULL. Otherwise, this
- * function will not request a response from the server, and return
- * immediately.
- *
- * @note The @p val::meta::user_access level will be ignored.
+ * function will return, and the response will be passed to the
+ * @ref bt_mesh_prop_cli::prop_status callback.
  *
  * @param[in] cli Client model to send on.
  * @param[in] ctx Message context, or NULL to use the configured publish
  * parameters.
  * @param[in] val New property value to set. Note that the user_access mode
  * will be ignored.
- * @param[out] rsp Response status buffer, or NULL to send an unacknowledged
- * message.
+ * @param[out] rsp Response status buffer, or NULL to keep from blocking.
  *
  * @retval 0 Successfully sent the message and populated the @p rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
@@ -192,18 +187,43 @@ int bt_mesh_prop_cli_user_prop_set(struct bt_mesh_prop_cli *cli,
 				   const struct bt_mesh_prop_val *val,
 				   struct bt_mesh_prop_val *rsp);
 
+/** @brief Set a property value in a User Property Server without requesting a
+ * response.
+ *
+ * The User Property may only be set if the server enabled user write access to
+ * it. If this is not the case, the server will only respond with the set user
+ * access mode for the given property.
+ *
+ * @note The @p val::meta::user_access level will be ignored.
+ *
+ * @param[in] cli Client model to send on.
+ * @param[in] ctx Message context, or NULL to use the configured publish
+ * parameters.
+ * @param[in] val New property value to set. Note that the user_access mode
+ * will be ignored.
+ *
+ * @retval 0 Successfully sent the message.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ */
+int bt_mesh_prop_cli_user_prop_set_unack(struct bt_mesh_prop_cli *cli,
+					 struct bt_mesh_msg_ctx *ctx,
+					 const struct bt_mesh_prop_val *val);
+
 /** @brief Set a property value in an Admin Property server.
  *
  * This call is blocking if the @p rsp buffer is non-NULL. Otherwise, this
- * function will not request a response from the server, and return
- * immediately.
+ * function will return, and the response will be passed to the
+ * @ref bt_mesh_prop_cli::prop_status callback.
  *
  * @param[in] cli Client model to send on.
  * @param[in] ctx Message context, or NULL to use the configured publish
  * parameters.
  * @param[in] val New property value to set.
- * @param[out] rsp Response status buffer, or NULL to send an unacknowledged
- * message.
+ * @param[out] rsp Response status buffer, or NULL to keep from blocking.
  *
  * @retval 0 Successfully sent the message and populated the @p rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
@@ -219,18 +239,36 @@ int bt_mesh_prop_cli_admin_prop_set(struct bt_mesh_prop_cli *cli,
 				    const struct bt_mesh_prop_val *val,
 				    struct bt_mesh_prop_val *rsp);
 
-/** @brief Set the user access of a property in a Manufacturer Property server.
- *
- * This call is blocking if the @p rsp buffer is non-NULL. Otherwise, this
- * function will not request a response from the server, and return
- * immediately.
+/** @brief Set a property value in an Admin Property server without requesting
+ * a response.
  *
  * @param[in] cli Client model to send on.
  * @param[in] ctx Message context, or NULL to use the configured publish
  * parameters.
  * @param[in] val New property value to set.
- * @param[out] rsp Response status buffer, or NULL to send an unacknowledged
- * message.
+ *
+ * @retval 0 Successfully sent the message.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ */
+int bt_mesh_prop_cli_admin_prop_set_unack(struct bt_mesh_prop_cli *cli,
+					  struct bt_mesh_msg_ctx *ctx,
+					  const struct bt_mesh_prop_val *val);
+
+/** @brief Set the user access of a property in a Manufacturer Property server.
+ *
+ * This call is blocking if the @p rsp buffer is non-NULL. Otherwise, this
+ * function will return, and the response will be passed to the
+ * @ref bt_mesh_prop_cli::prop_status callback.
+ *
+ * @param[in] cli Client model to send on.
+ * @param[in] ctx Message context, or NULL to use the configured publish
+ * parameters.
+ * @param[in] val New property value to set.
+ * @param[out] rsp Response status buffer, or NULL to keep from blocking.
  *
  * @retval 0 Successfully sent the message and populated the @p rsp buffer.
  * @retval -EALREADY A blocking request is already in progress.
@@ -245,6 +283,25 @@ int bt_mesh_prop_cli_mfr_prop_set(struct bt_mesh_prop_cli *cli,
 				  struct bt_mesh_msg_ctx *ctx,
 				  const struct bt_mesh_prop *prop,
 				  struct bt_mesh_prop_val *rsp);
+
+/** @brief Set the user access of a property in a Manufacturer Property server
+ * without requesting a response.
+ *
+ * @param[in] cli Client model to send on.
+ * @param[in] ctx Message context, or NULL to use the configured publish
+ * parameters.
+ * @param[in] val New property value to set.
+ *
+ * @retval 0 Successfully sent the message.
+ * @retval -ENOTSUP A message context was not provided and publishing is not
+ * supported.
+ * @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ * not configured.
+ * @retval -EAGAIN The device has not been provisioned.
+ */
+int bt_mesh_prop_cli_mfr_prop_set_unack(struct bt_mesh_prop_cli *cli,
+					struct bt_mesh_msg_ctx *ctx,
+					const struct bt_mesh_prop *prop);
 
 /** @cond INTERNAL_HIDDEN */
 extern const struct bt_mesh_model_op _bt_mesh_prop_cli_op[];

--- a/include/bluetooth/mesh/models.h
+++ b/include/bluetooth/mesh/models.h
@@ -35,4 +35,12 @@
 #include <bluetooth/mesh/gen_prop_srv.h>
 #include <bluetooth/mesh/gen_prop_cli.h>
 
+/** @brief Check whether the model publishes to a unicast address.
+ *
+ * @param[in] mod Model to check
+ *
+ * @return true if the model publishes to a unicast address, false otherwise.
+ */
+bool bt_mesh_model_pub_is_unicast(const struct bt_mesh_model *mod);
+
 #endif /* BT_MESH_MODELS_H__ */

--- a/subsys/bluetooth/mesh/CMakeLists.txt
+++ b/subsys/bluetooth/mesh/CMakeLists.txt
@@ -4,28 +4,28 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-zephyr_sources(model_utils.c)
+zephyr_library_sources(model_utils.c)
 
-zephyr_sources_ifdef(CONFIG_BT_MESH_ONOFF_SRV gen_onoff_srv.c)
-zephyr_sources_ifdef(CONFIG_BT_MESH_ONOFF_CLI gen_onoff_cli.c)
+zephyr_library_sources_ifdef(CONFIG_BT_MESH_ONOFF_SRV gen_onoff_srv.c)
+zephyr_library_sources_ifdef(CONFIG_BT_MESH_ONOFF_CLI gen_onoff_cli.c)
 
-zephyr_sources_ifdef(CONFIG_BT_MESH_LVL_SRV gen_lvl_srv.c)
-zephyr_sources_ifdef(CONFIG_BT_MESH_LVL_CLI gen_lvl_cli.c)
+zephyr_library_sources_ifdef(CONFIG_BT_MESH_LVL_SRV gen_lvl_srv.c)
+zephyr_library_sources_ifdef(CONFIG_BT_MESH_LVL_CLI gen_lvl_cli.c)
 
-zephyr_sources_ifdef(CONFIG_BT_MESH_DTT_SRV gen_dtt_srv.c)
-zephyr_sources_ifdef(CONFIG_BT_MESH_DTT_CLI gen_dtt_cli.c)
+zephyr_library_sources_ifdef(CONFIG_BT_MESH_DTT_SRV gen_dtt_srv.c)
+zephyr_library_sources_ifdef(CONFIG_BT_MESH_DTT_CLI gen_dtt_cli.c)
 
-zephyr_sources_ifdef(CONFIG_BT_MESH_PONOFF_SRV gen_ponoff_srv.c)
-zephyr_sources_ifdef(CONFIG_BT_MESH_PONOFF_CLI gen_ponoff_cli.c)
+zephyr_library_sources_ifdef(CONFIG_BT_MESH_PONOFF_SRV gen_ponoff_srv.c)
+zephyr_library_sources_ifdef(CONFIG_BT_MESH_PONOFF_CLI gen_ponoff_cli.c)
 
-zephyr_sources_ifdef(CONFIG_BT_MESH_PLVL_SRV gen_plvl_srv.c)
-zephyr_sources_ifdef(CONFIG_BT_MESH_PLVL_CLI gen_plvl_cli.c)
+zephyr_library_sources_ifdef(CONFIG_BT_MESH_PLVL_SRV gen_plvl_srv.c)
+zephyr_library_sources_ifdef(CONFIG_BT_MESH_PLVL_CLI gen_plvl_cli.c)
 
-zephyr_sources_ifdef(CONFIG_BT_MESH_BATTERY_SRV gen_battery_srv.c)
-zephyr_sources_ifdef(CONFIG_BT_MESH_BATTERY_CLI gen_battery_cli.c)
+zephyr_library_sources_ifdef(CONFIG_BT_MESH_BATTERY_SRV gen_battery_srv.c)
+zephyr_library_sources_ifdef(CONFIG_BT_MESH_BATTERY_CLI gen_battery_cli.c)
 
-zephyr_sources_ifdef(CONFIG_BT_MESH_LOC_SRV gen_loc_srv.c)
-zephyr_sources_ifdef(CONFIG_BT_MESH_LOC_CLI gen_loc_cli.c)
+zephyr_library_sources_ifdef(CONFIG_BT_MESH_LOC_SRV gen_loc_srv.c)
+zephyr_library_sources_ifdef(CONFIG_BT_MESH_LOC_CLI gen_loc_cli.c)
 
-zephyr_sources_ifdef(CONFIG_BT_MESH_PROP_SRV gen_prop_srv.c)
-zephyr_sources_ifdef(CONFIG_BT_MESH_PROP_CLI gen_prop_cli.c)
+zephyr_library_sources_ifdef(CONFIG_BT_MESH_PROP_SRV gen_prop_srv.c)
+zephyr_library_sources_ifdef(CONFIG_BT_MESH_PROP_CLI gen_prop_cli.c)

--- a/subsys/bluetooth/mesh/gen_dtt_cli.c
+++ b/subsys/bluetooth/mesh/gen_dtt_cli.c
@@ -67,13 +67,23 @@ int bt_mesh_dtt_set(struct bt_mesh_dtt_cli *cli, struct bt_mesh_msg_ctx *ctx,
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_DTT_OP_SET,
 				 BT_MESH_DTT_MSG_LEN_SET);
-	bt_mesh_model_msg_init(&msg, rsp_transition_time ?
-					     BT_MESH_DTT_OP_SET :
-					     BT_MESH_DTT_OP_SET_UNACK);
+	bt_mesh_model_msg_init(&msg, BT_MESH_DTT_OP_SET);
 	net_buf_simple_add_u8(&msg,
 			      model_transition_encode((s32_t)transition_time));
 
 	return model_ackd_send(cli->model, ctx, &msg,
 			       rsp_transition_time ? &cli->ack_ctx : NULL,
 			       BT_MESH_DTT_OP_STATUS, rsp_transition_time);
+}
+
+int bt_mesh_dtt_set_unack(struct bt_mesh_dtt_cli *cli,
+			  struct bt_mesh_msg_ctx *ctx, u32_t transition_time)
+{
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_DTT_OP_SET_UNACK,
+				 BT_MESH_DTT_MSG_LEN_SET);
+	bt_mesh_model_msg_init(&msg, BT_MESH_DTT_OP_SET_UNACK);
+	net_buf_simple_add_u8(&msg,
+			      model_transition_encode((s32_t)transition_time));
+
+	return model_send(cli->model, ctx, &msg);
 }

--- a/subsys/bluetooth/mesh/gen_loc_cli.c
+++ b/subsys/bluetooth/mesh/gen_loc_cli.c
@@ -105,13 +105,25 @@ int bt_mesh_loc_cli_global_set(struct bt_mesh_loc_cli *cli,
 	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_LOC_OP_GLOBAL_SET,
 				 BT_MESH_LOC_MSG_LEN_GLOBAL_SET);
 
-	bt_mesh_model_msg_init(&msg, rsp ? BT_MESH_LOC_OP_GLOBAL_SET :
-					   BT_MESH_LOC_OP_GLOBAL_SET_UNACK);
+	bt_mesh_model_msg_init(&msg, BT_MESH_LOC_OP_GLOBAL_SET);
 	bt_mesh_loc_global_encode(&msg, loc);
 
 	return model_ackd_send(cli->model, ctx, &msg,
 			       rsp ? &cli->ack_ctx : NULL,
 			       BT_MESH_LOC_OP_GLOBAL_STATUS, rsp);
+}
+
+int bt_mesh_loc_cli_global_set_unack(struct bt_mesh_loc_cli *cli,
+				     struct bt_mesh_msg_ctx *ctx,
+				     const struct bt_mesh_loc_global *loc)
+{
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_LOC_OP_GLOBAL_SET_UNACK,
+				 BT_MESH_LOC_MSG_LEN_GLOBAL_SET);
+
+	bt_mesh_model_msg_init(&msg, BT_MESH_LOC_OP_GLOBAL_SET_UNACK);
+	bt_mesh_loc_global_encode(&msg, loc);
+
+	return model_send(cli->model, ctx, &msg);
 }
 
 int bt_mesh_loc_cli_local_get(struct bt_mesh_loc_cli *cli,
@@ -136,11 +148,23 @@ int bt_mesh_loc_cli_local_set(struct bt_mesh_loc_cli *cli,
 	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_LOC_OP_LOCAL_SET,
 				 BT_MESH_LOC_MSG_LEN_LOCAL_SET);
 
-	bt_mesh_model_msg_init(&msg, rsp ? BT_MESH_LOC_OP_LOCAL_SET :
-					   BT_MESH_LOC_OP_LOCAL_SET_UNACK);
+	bt_mesh_model_msg_init(&msg, BT_MESH_LOC_OP_LOCAL_SET);
 	bt_mesh_loc_local_encode(&msg, loc);
 
 	return model_ackd_send(cli->model, ctx, &msg,
 			       rsp ? &cli->ack_ctx : NULL,
 			       BT_MESH_LOC_OP_LOCAL_STATUS, rsp);
+}
+
+int bt_mesh_loc_cli_local_set_unack(struct bt_mesh_loc_cli *cli,
+				    struct bt_mesh_msg_ctx *ctx,
+				    const struct bt_mesh_loc_local *loc)
+{
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_LOC_OP_LOCAL_SET_UNACK,
+				 BT_MESH_LOC_MSG_LEN_LOCAL_SET);
+
+	bt_mesh_model_msg_init(&msg, BT_MESH_LOC_OP_LOCAL_SET_UNACK);
+	bt_mesh_loc_local_encode(&msg, loc);
+
+	return model_send(cli->model, ctx, &msg);
 }

--- a/subsys/bluetooth/mesh/gen_lvl_cli.c
+++ b/subsys/bluetooth/mesh/gen_lvl_cli.c
@@ -85,8 +85,7 @@ int bt_mesh_lvl_cli_set(struct bt_mesh_lvl_cli *cli,
 
 	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_LVL_OP_SET,
 				 BT_MESH_LVL_MSG_MAXLEN_SET);
-	bt_mesh_model_msg_init(&msg, rsp ? BT_MESH_LVL_OP_SET :
-					   BT_MESH_LVL_OP_SET_UNACK);
+	bt_mesh_model_msg_init(&msg, BT_MESH_LVL_OP_SET);
 
 	net_buf_simple_add_le16(&msg, set->lvl);
 	net_buf_simple_add_u8(&msg, cli->tid);
@@ -97,6 +96,27 @@ int bt_mesh_lvl_cli_set(struct bt_mesh_lvl_cli *cli,
 	return model_ackd_send(cli->model, ctx, &msg,
 			       rsp ? &cli->ack_ctx : NULL,
 			       BT_MESH_LVL_OP_STATUS, rsp);
+}
+
+int bt_mesh_lvl_cli_set_unack(struct bt_mesh_lvl_cli *cli,
+			      struct bt_mesh_msg_ctx *ctx,
+			      const struct bt_mesh_lvl_set *set)
+{
+	if (set->new_transaction) {
+		cli->tid++;
+	}
+
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_LVL_OP_SET_UNACK,
+				 BT_MESH_LVL_MSG_MAXLEN_SET);
+	bt_mesh_model_msg_init(&msg, BT_MESH_LVL_OP_SET_UNACK);
+
+	net_buf_simple_add_le16(&msg, set->lvl);
+	net_buf_simple_add_u8(&msg, cli->tid);
+	if (set->transition) {
+		model_transition_buf_add(&msg, set->transition);
+	}
+
+	return model_send(cli->model, ctx, &msg);
 }
 
 int bt_mesh_lvl_cli_delta_set(struct bt_mesh_lvl_cli *cli,
@@ -110,8 +130,7 @@ int bt_mesh_lvl_cli_delta_set(struct bt_mesh_lvl_cli *cli,
 
 	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_LVL_OP_DELTA_SET,
 				 BT_MESH_LVL_MSG_MAXLEN_DELTA_SET);
-	bt_mesh_model_msg_init(&msg, rsp ? BT_MESH_LVL_OP_DELTA_SET :
-					   BT_MESH_LVL_OP_DELTA_SET_UNACK);
+	bt_mesh_model_msg_init(&msg, BT_MESH_LVL_OP_DELTA_SET);
 
 	net_buf_simple_add_le32(&msg, delta_set->delta);
 	net_buf_simple_add_u8(&msg, cli->tid);
@@ -122,6 +141,27 @@ int bt_mesh_lvl_cli_delta_set(struct bt_mesh_lvl_cli *cli,
 	return model_ackd_send(cli->model, ctx, &msg,
 			       rsp ? &cli->ack_ctx : NULL,
 			       BT_MESH_LVL_OP_STATUS, rsp);
+}
+
+int bt_mesh_lvl_cli_delta_set_unack(
+	struct bt_mesh_lvl_cli *cli, struct bt_mesh_msg_ctx *ctx,
+	const struct bt_mesh_lvl_delta_set *delta_set)
+{
+	if (delta_set->new_transaction) {
+		cli->tid++;
+	}
+
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_LVL_OP_DELTA_SET_UNACK,
+				 BT_MESH_LVL_MSG_MAXLEN_DELTA_SET);
+	bt_mesh_model_msg_init(&msg, BT_MESH_LVL_OP_DELTA_SET_UNACK);
+
+	net_buf_simple_add_le32(&msg, delta_set->delta);
+	net_buf_simple_add_u8(&msg, cli->tid);
+	if (delta_set->transition) {
+		model_transition_buf_add(&msg, delta_set->transition);
+	}
+
+	return model_send(cli->model, ctx, &msg);
 }
 
 int bt_mesh_lvl_cli_move_set(struct bt_mesh_lvl_cli *cli,
@@ -135,8 +175,7 @@ int bt_mesh_lvl_cli_move_set(struct bt_mesh_lvl_cli *cli,
 
 	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_LVL_OP_MOVE_SET,
 				 BT_MESH_LVL_MSG_MAXLEN_MOVE_SET);
-	bt_mesh_model_msg_init(&msg, rsp ? BT_MESH_LVL_OP_MOVE_SET :
-					   BT_MESH_LVL_OP_MOVE_SET_UNACK);
+	bt_mesh_model_msg_init(&msg, BT_MESH_LVL_OP_MOVE_SET);
 
 	net_buf_simple_add_le16(&msg, move_set->delta);
 	net_buf_simple_add_u8(&msg, cli->tid);
@@ -148,4 +187,26 @@ int bt_mesh_lvl_cli_move_set(struct bt_mesh_lvl_cli *cli,
 	return model_ackd_send(cli->model, ctx, &msg,
 			       rsp ? &cli->ack_ctx : NULL,
 			       BT_MESH_LVL_OP_STATUS, rsp);
+}
+
+int bt_mesh_lvl_cli_move_set_unack(struct bt_mesh_lvl_cli *cli,
+				   struct bt_mesh_msg_ctx *ctx,
+				   const struct bt_mesh_lvl_move_set *move_set)
+{
+	if (move_set->new_transaction) {
+		cli->tid++;
+	}
+
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_LVL_OP_MOVE_SET_UNACK,
+				 BT_MESH_LVL_MSG_MAXLEN_MOVE_SET);
+	bt_mesh_model_msg_init(&msg, BT_MESH_LVL_OP_MOVE_SET_UNACK);
+
+	net_buf_simple_add_le16(&msg, move_set->delta);
+	net_buf_simple_add_u8(&msg, cli->tid);
+
+	if (move_set->transition) {
+		model_transition_buf_add(&msg, move_set->transition);
+	}
+
+	return model_send(cli->model, ctx, &msg);
 }

--- a/subsys/bluetooth/mesh/gen_onoff_cli.c
+++ b/subsys/bluetooth/mesh/gen_onoff_cli.c
@@ -91,8 +91,7 @@ int bt_mesh_onoff_cli_set(struct bt_mesh_onoff_cli *cli,
 {
 	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_ONOFF_OP_SET,
 				 BT_MESH_ONOFF_MSG_MAXLEN_SET);
-	bt_mesh_model_msg_init(&msg, (rsp ? BT_MESH_ONOFF_OP_SET :
-					    BT_MESH_ONOFF_OP_SET_UNACK));
+	bt_mesh_model_msg_init(&msg, BT_MESH_ONOFF_OP_SET);
 
 	net_buf_simple_add_u8(&msg, set->on_off);
 	net_buf_simple_add_u8(&msg, cli->tid++);
@@ -103,4 +102,21 @@ int bt_mesh_onoff_cli_set(struct bt_mesh_onoff_cli *cli,
 	return model_ackd_send(cli->model, ctx, &msg,
 			       rsp ? &cli->ack_ctx : NULL,
 			       BT_MESH_ONOFF_OP_STATUS, rsp);
+}
+
+int bt_mesh_onoff_cli_set_unack(struct bt_mesh_onoff_cli *cli,
+				struct bt_mesh_msg_ctx *ctx,
+				const struct bt_mesh_onoff_set *set)
+{
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_ONOFF_OP_SET_UNACK,
+				 BT_MESH_ONOFF_MSG_MAXLEN_SET);
+	bt_mesh_model_msg_init(&msg, BT_MESH_ONOFF_OP_SET_UNACK);
+
+	net_buf_simple_add_u8(&msg, set->on_off);
+	net_buf_simple_add_u8(&msg, cli->tid++);
+	if (set->transition) {
+		model_transition_buf_add(&msg, set->transition);
+	}
+
+	return model_send(cli->model, ctx, &msg);
 }

--- a/subsys/bluetooth/mesh/gen_plvl_cli.c
+++ b/subsys/bluetooth/mesh/gen_plvl_cli.c
@@ -169,6 +169,23 @@ int bt_mesh_plvl_cli_power_set(struct bt_mesh_plvl_cli *cli,
 			       BT_MESH_PLVL_OP_LEVEL_STATUS, rsp);
 }
 
+int bt_mesh_plvl_cli_power_set_unack(struct bt_mesh_plvl_cli *cli,
+			       struct bt_mesh_msg_ctx *ctx,
+			       const struct bt_mesh_plvl_set *set)
+{
+	BT_MESH_MODEL_BUF_DEFINE(buf, BT_MESH_PLVL_OP_LEVEL_SET_UNACK,
+				 BT_MESH_PLVL_MSG_MAXLEN_LEVEL_SET);
+	bt_mesh_model_msg_init(&buf, BT_MESH_PLVL_OP_LEVEL_SET_UNACK);
+
+	net_buf_simple_add_le16(&buf, set->power_lvl);
+	net_buf_simple_add_u8(&buf, cli->tid++);
+	if (set->transition) {
+		model_transition_buf_add(&buf, set->transition);
+	}
+
+	return model_send(cli->model, ctx, &buf);
+}
+
 int bt_mesh_plvl_cli_range_get(struct bt_mesh_plvl_cli *cli,
 			       struct bt_mesh_msg_ctx *ctx,
 			       struct bt_mesh_plvl_range_status *rsp)
@@ -198,6 +215,19 @@ int bt_mesh_plvl_cli_range_set(struct bt_mesh_plvl_cli *cli,
 			       BT_MESH_PLVL_OP_RANGE_STATUS, rsp);
 }
 
+int bt_mesh_plvl_cli_range_set_unack(struct bt_mesh_plvl_cli *cli,
+				     struct bt_mesh_msg_ctx *ctx,
+				     const struct bt_mesh_plvl_range *range)
+{
+	BT_MESH_MODEL_BUF_DEFINE(buf, BT_MESH_PLVL_OP_RANGE_SET_UNACK,
+				 BT_MESH_PLVL_MSG_LEN_RANGE_SET);
+	bt_mesh_model_msg_init(&buf, BT_MESH_PLVL_OP_RANGE_SET_UNACK);
+	net_buf_simple_add_le16(&buf, range->min);
+	net_buf_simple_add_le16(&buf, range->max);
+
+	return model_send(cli->model, ctx, &buf);
+}
+
 int bt_mesh_plvl_cli_default_get(struct bt_mesh_plvl_cli *cli,
 				 struct bt_mesh_msg_ctx *ctx, u16_t *rsp)
 {
@@ -222,6 +252,18 @@ int bt_mesh_plvl_cli_default_set(struct bt_mesh_plvl_cli *cli,
 	return model_ackd_send(cli->model, ctx, &buf,
 			       rsp ? &cli->ack_ctx : NULL,
 			       BT_MESH_PLVL_OP_DEFAULT_STATUS, rsp);
+}
+
+int bt_mesh_plvl_cli_default_set_unack(struct bt_mesh_plvl_cli *cli,
+				       struct bt_mesh_msg_ctx *ctx,
+				       u16_t default_power)
+{
+	BT_MESH_MODEL_BUF_DEFINE(buf, BT_MESH_PLVL_OP_DEFAULT_SET_UNACK,
+				 BT_MESH_PLVL_MSG_LEN_DEFAULT_SET);
+	bt_mesh_model_msg_init(&buf, BT_MESH_PLVL_OP_DEFAULT_SET_UNACK);
+	net_buf_simple_add_le16(&buf, default_power);
+
+	return model_send(cli->model, ctx, &buf);
 }
 
 int bt_mesh_plvl_cli_last_get(struct bt_mesh_plvl_cli *cli,

--- a/subsys/bluetooth/mesh/gen_ponoff_cli.c
+++ b/subsys/bluetooth/mesh/gen_ponoff_cli.c
@@ -83,3 +83,19 @@ int bt_mesh_ponoff_cli_on_power_up_set(struct bt_mesh_ponoff_cli *cli,
 			       (rsp ? &cli->ack_ctx : NULL),
 			       BT_MESH_PONOFF_OP_STATUS, rsp);
 }
+
+int bt_mesh_ponoff_cli_on_power_up_set_unack(
+	struct bt_mesh_ponoff_cli *cli, struct bt_mesh_msg_ctx *ctx,
+	enum bt_mesh_on_power_up on_power_up)
+{
+	if (on_power_up >= BT_MESH_ON_POWER_UP_INVALID) {
+		return -EINVAL;
+	}
+
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_PONOFF_OP_SET_UNACK,
+				 BT_MESH_PONOFF_MSG_LEN_SET);
+	bt_mesh_model_msg_init(&msg, BT_MESH_PONOFF_OP_SET_UNACK);
+	net_buf_simple_add_u8(&msg, on_power_up);
+
+	return model_send(cli->model, ctx, &msg);
+}

--- a/subsys/bluetooth/mesh/gen_prop_cli.c
+++ b/subsys/bluetooth/mesh/gen_prop_cli.c
@@ -208,14 +208,27 @@ int bt_mesh_prop_cli_user_prop_set(struct bt_mesh_prop_cli *cli,
 	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_PROP_OP_USER_PROP_SET,
 				 BT_MESH_PROP_MSG_MAXLEN_USER_PROP_SET);
 
-	bt_mesh_model_msg_init(&msg, rsp ? BT_MESH_PROP_OP_USER_PROP_SET :
-					   BT_MESH_PROP_OP_USER_PROP_SET_UNACK);
+	bt_mesh_model_msg_init(&msg, BT_MESH_PROP_OP_USER_PROP_SET);
 	net_buf_simple_add_le16(&msg, val->meta.id);
 	net_buf_simple_add_mem(&msg, val->value, val->size);
 
 	return model_ackd_send(cli->model, ctx, &msg,
 			       rsp ? &cli->ack_ctx : NULL,
 			       BT_MESH_PROP_OP_PROPS_STATUS, rsp);
+}
+
+int bt_mesh_prop_cli_user_prop_set_unack(struct bt_mesh_prop_cli *cli,
+					 struct bt_mesh_msg_ctx *ctx,
+					 const struct bt_mesh_prop_val *val)
+{
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_PROP_OP_USER_PROP_SET_UNACK,
+				 BT_MESH_PROP_MSG_MAXLEN_USER_PROP_SET);
+
+	bt_mesh_model_msg_init(&msg, BT_MESH_PROP_OP_USER_PROP_SET_UNACK);
+	net_buf_simple_add_le16(&msg, val->meta.id);
+	net_buf_simple_add_mem(&msg, val->value, val->size);
+
+	return model_send(cli->model, ctx, &msg);
 }
 
 int bt_mesh_prop_cli_admin_prop_set(struct bt_mesh_prop_cli *cli,
@@ -226,9 +239,7 @@ int bt_mesh_prop_cli_admin_prop_set(struct bt_mesh_prop_cli *cli,
 	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_PROP_OP_ADMIN_PROP_SET,
 				 BT_MESH_PROP_MSG_MAXLEN_ADMIN_PROP_SET);
 
-	bt_mesh_model_msg_init(&msg,
-			       rsp ? BT_MESH_PROP_OP_ADMIN_PROP_SET :
-				     BT_MESH_PROP_OP_ADMIN_PROP_SET_UNACK);
+	bt_mesh_model_msg_init(&msg, BT_MESH_PROP_OP_ADMIN_PROP_SET);
 	net_buf_simple_add_le16(&msg, val->meta.id);
 	net_buf_simple_add_u8(&msg, val->meta.user_access);
 	net_buf_simple_add_mem(&msg, val->value, val->size);
@@ -236,6 +247,21 @@ int bt_mesh_prop_cli_admin_prop_set(struct bt_mesh_prop_cli *cli,
 	return model_ackd_send(cli->model, ctx, &msg,
 			       rsp ? &cli->ack_ctx : NULL,
 			       BT_MESH_PROP_OP_PROPS_STATUS, rsp);
+}
+
+int bt_mesh_prop_cli_admin_prop_set_unack(struct bt_mesh_prop_cli *cli,
+					  struct bt_mesh_msg_ctx *ctx,
+					  const struct bt_mesh_prop_val *val)
+{
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_PROP_OP_ADMIN_PROP_SET_UNACK,
+				 BT_MESH_PROP_MSG_MAXLEN_ADMIN_PROP_SET);
+
+	bt_mesh_model_msg_init(&msg, BT_MESH_PROP_OP_ADMIN_PROP_SET_UNACK);
+	net_buf_simple_add_le16(&msg, val->meta.id);
+	net_buf_simple_add_u8(&msg, val->meta.user_access);
+	net_buf_simple_add_mem(&msg, val->value, val->size);
+
+	return model_send(cli->model, ctx, &msg);
 }
 
 int bt_mesh_prop_cli_mfr_prop_set(struct bt_mesh_prop_cli *cli,
@@ -246,12 +272,25 @@ int bt_mesh_prop_cli_mfr_prop_set(struct bt_mesh_prop_cli *cli,
 	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_PROP_OP_MFR_PROP_SET,
 				 BT_MESH_PROP_MSG_LEN_MFR_PROP_SET);
 
-	bt_mesh_model_msg_init(&msg, rsp ? BT_MESH_PROP_OP_MFR_PROP_SET :
-					   BT_MESH_PROP_OP_MFR_PROP_SET_UNACK);
+	bt_mesh_model_msg_init(&msg, BT_MESH_PROP_OP_MFR_PROP_SET);
 	net_buf_simple_add_le16(&msg, prop->id);
 	net_buf_simple_add_u8(&msg, prop->user_access);
 
 	return model_ackd_send(cli->model, ctx, &msg,
 			       rsp ? &cli->ack_ctx : NULL,
 			       BT_MESH_PROP_OP_PROPS_STATUS, rsp);
+}
+
+int bt_mesh_prop_cli_mfr_prop_set_unack(struct bt_mesh_prop_cli *cli,
+					struct bt_mesh_msg_ctx *ctx,
+					const struct bt_mesh_prop *prop)
+{
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_PROP_OP_MFR_PROP_SET_UNACK,
+				 BT_MESH_PROP_MSG_LEN_MFR_PROP_SET);
+
+	bt_mesh_model_msg_init(&msg, BT_MESH_PROP_OP_MFR_PROP_SET_UNACK);
+	net_buf_simple_add_le16(&msg, prop->id);
+	net_buf_simple_add_u8(&msg, prop->user_access);
+
+	return model_send(cli->model, ctx, &msg);
 }

--- a/subsys/bluetooth/mesh/model_utils.c
+++ b/subsys/bluetooth/mesh/model_utils.c
@@ -5,6 +5,7 @@
  */
 #include <bluetooth/mesh/models.h>
 #include "model_utils.h"
+#include "mesh/mesh.h"
 
 /** Unknown encoded transition time value */
 #define TRANSITION_TIME_UNKNOWN (0x3F)
@@ -145,4 +146,9 @@ int model_ackd_send(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
 		model_ack_clear(ack);
 	}
 	return retval;
+}
+
+bool bt_mesh_model_pub_is_unicast(const struct bt_mesh_model *mod)
+{
+	return mod->pub && BT_MESH_ADDR_IS_UNICAST(mod->pub->addr);
 }


### PR DESCRIPTION
Adds explicit unacknowledged versions of all client setter functions,
making the original setters acknowledged, regardless of argument values.

The original API tried to control two parameters of the command with a
single parameter check: Setting the rsp parameter would make the call
blocking and acknowledged, while leaving it to NULL would make the call
asynchronous and unacknowledged. This made it impossible to do
acknowledged unblocking calls, which is a reasonable requirement in some
cases.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>