### PR TITLE
samples: peripheral_uart: fix workqueue overflow

### DIFF
--- a/samples/bluetooth/peripheral_uart/prj.conf
+++ b/samples/bluetooth/peripheral_uart/prj.conf
@@ -36,3 +36,6 @@ CONFIG_SETTINGS_FCB=y
 
 # Enable DK LED and Buttons library
 CONFIG_DK_LIBRARY=y
+
+# This example requires more workqueue stack
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048


### PR DESCRIPTION
Increased stack size of the Workqueue for Peripheral UART sample to
prevent overflow.

Signed-off-by: Kamil Piszczek <Kamil.Piszczek@nordicsemi.no>