### PR TITLE
bluetooth: services: clients: adding volatile subscribe flag

### DIFF
--- a/subsys/bluetooth/services/bas_c.c
+++ b/subsys/bluetooth/services/bas_c.c
@@ -311,7 +311,8 @@ int bt_gatt_bas_c_subscribe(struct bt_gatt_bas_c *bas_c,
 	bas_c->notify_params.value = BT_GATT_CCC_NOTIFY;
 	bas_c->notify_params.value_handle = bas_c->val_handle;
 	bas_c->notify_params.ccc_handle = bas_c->ccc_handle;
-	atomic_set(bas_c->notify_params.flags, BT_GATT_SUBSCRIBE_FLAG_VOLATILE);
+	atomic_set_bit(bas_c->notify_params.flags,
+		       BT_GATT_SUBSCRIBE_FLAG_VOLATILE);
 
 	LOG_DBG("Subscribe: val: %u, ccc: %u",
 		bas_c->notify_params.value_handle,

--- a/subsys/bluetooth/services/dfu_smp_c.c
+++ b/subsys/bluetooth/services/dfu_smp_c.c
@@ -159,6 +159,8 @@ int bt_gatt_dfu_smp_c_command(struct bt_gatt_dfu_smp_c *dfu_smp_c,
 		dfu_smp_c->notification_params.notify =
 			bt_gatt_dfu_smp_c_notify;
 		dfu_smp_c->notification_params.value  = BT_GATT_CCC_NOTIFY;
+		atomic_set_bit(dfu_smp_c->notification_params.flags,
+			       BT_GATT_SUBSCRIBE_FLAG_VOLATILE);
 
 		ret = bt_gatt_subscribe(dfu_smp_c->conn,
 					&dfu_smp_c->notification_params);

--- a/subsys/bluetooth/services/nus_c.c
+++ b/subsys/bluetooth/services/nus_c.c
@@ -177,6 +177,8 @@ int bt_gatt_nus_c_tx_notif_enable(struct bt_gatt_nus_c *nus_c)
 	nus_c->tx_notif_params.value = BT_GATT_CCC_NOTIFY;
 	nus_c->tx_notif_params.value_handle = nus_c->handles.tx;
 	nus_c->tx_notif_params.ccc_handle = nus_c->handles.tx_ccc;
+	atomic_set_bit(nus_c->tx_notif_params.flags,
+		       BT_GATT_SUBSCRIBE_FLAG_VOLATILE);
 
 	err = bt_gatt_subscribe(nus_c->conn, &nus_c->tx_notif_params);
 	if (err) {


### PR DESCRIPTION
Use BT_GATT_SUBSCRIBE_FLAG_VOLATILE flag so it is possible to
repeatedly call bt_gatt_subscribe. This function is used to enable
notifications.

Signed-off-by: Kamil Piszczek <Kamil.Piszczek@nordicsemi.no>