### PR TITLE
mpsl: subsys: Add IRQ connects in MPSL subsys init

### DIFF
--- a/subsys/mpsl/mpsl_init.c
+++ b/subsys/mpsl/mpsl_init.c
@@ -43,6 +43,7 @@ static int mpsl_lib_init(struct device *dev)
 	ARG_UNUSED(dev);
 
 	int err = 0;
+
 	mpsl_clock_lf_cfg_t clock_cfg;
 
 	clock_cfg.source = m_config_clock_source_get();
@@ -54,8 +55,14 @@ static int mpsl_lib_init(struct device *dev)
 		return err;
 	}
 
+	IRQ_DIRECT_CONNECT(TIMER0_IRQn, MPSL_HIGH_IRQ_PRIORITY,
+			   MPSL_IRQ_TIMER0_Handler, IRQ_ZERO_LATENCY);
+	IRQ_DIRECT_CONNECT(RTC0_IRQn, MPSL_HIGH_IRQ_PRIORITY,
+			   MPSL_IRQ_RTC0_Handler, IRQ_ZERO_LATENCY);
+	IRQ_DIRECT_CONNECT(RADIO_IRQn, MPSL_HIGH_IRQ_PRIORITY,
+			   MPSL_IRQ_RADIO_Handler, IRQ_ZERO_LATENCY);
 	IRQ_CONNECT(MPSL_LOW_PRIO_IRQ, MPSL_LOW_PRIO,
-		mpsl_low_prio_irq_handler, NULL, 0);
+		    mpsl_low_prio_irq_handler, NULL, 0);
 	irq_enable(MPSL_LOW_PRIO_IRQ);
 
 	return 0;

--- a/west.yml
+++ b/west.yml
@@ -72,7 +72,7 @@ manifest:
       revision: 30b7efa827b04d2e47840716b0372737fe7d6c92
     - name: nrfxlib
       path: nrfxlib
-      revision: 4de8eebe8cfecb4fd268868263eb6ede54bbb86b
+      revision: dc9e1fbd146f5032fd3651b1e7705d8b3258ecc2
     - name: cmock
       path: test/cmock
       revision: c243b9a7a7b3c471023193992b46cf1bd1910450


### PR DESCRIPTION
In MPSL subsys initialization, add IRQ connects
from RTC0, Timer0 and Radio to MPSLs internal IRQ
handlers. Thus, the application will not need to
do the connects, and it aligns with the Nordic BLE
controller.

Signed-off-by: Solveig Fure <Solveig.Fure@nordicsemi.no>