### PR TITLE
manifest: NVS settings initialization fix with PM

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -38,7 +38,7 @@ manifest:
     - name: zephyr
       repo-path: fw-nrfconnect-zephyr
       west-commands: scripts/west-commands.yml
-      revision: 96738704c697bfe7655b69713ae61f1c053b07d4
+      revision: b687d5d02214db82e5bd224e73b8050742a234e0
     - name: nffs
       revision: bc62a2fa9d98ddb5d633c932ea199bc68e10f194
       path: modules/fs/nffs


### PR DESCRIPTION
Update Zephyr manifest entry with a revision containing the
aforementioned bugfix.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>