### PR TITLE
doc: fix style sheet

### DIFF
--- a/doc/static/css/common.css
+++ b/doc/static/css/common.css
@@ -88,3 +88,14 @@ div.figure {
 .rst-content div.breathe-sectiondef {
   padding-left: 0 !important;
 }
+
+
+/* Fixing definition lists (changed in Sphinx > 1.7.5) */
+.rst-content dl:not(.docutils) dt {
+ color: #404040;
+ border-top: none;
+ background: none;
+ font-size: 100%;
+ margin-bottom: 12px;
+ padding: initial;
+}


### PR DESCRIPTION
Do not merge yet - need to check output.


Newer versions of give definition lists a "simple" class instead of
the previous "docutils" class. Therefore, the dl's are displayed
strangely. Fix the css to go back to the old formatting.

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>