### PR TITLE
doc: updated nRF9160 samples with ug link, added shortcuts to DKs

### DIFF
--- a/applications/asset_tracker/README.rst
+++ b/applications/asset_tracker/README.rst
@@ -51,8 +51,8 @@ Requirements
 
 * One of the following development boards:
 
-    * nRF9160 DK board (PCA10090)
-    * Thingy:91 (PCA20035)
+    * |nRF9160DK|
+    * |Thingy91|
 
 * .. include:: /includes/spm.txt
 

--- a/applications/nrf_desktop/README.rst
+++ b/applications/nrf_desktop/README.rst
@@ -28,7 +28,7 @@ Requirements
 
 The project contains configuration files for following boards:
 
-    * PCA10056 (nRF52840 DK) - a sample where the mouse is emulated using DK buttons
+    * |nRF52840DK| - a sample where the mouse is emulated using DK buttons
     * PCA20041 - nRF Desktop gaming mouse reference design
     * PCA20037 - nRF Desktop keyboard reference design
     * PCA20044 - nRF Desktop casual mouse reference design (nRF52832)

--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -14,3 +14,8 @@
 
 .. |nRF9160DK| replace:: nRF9160 DK board (PCA10090) - see :ref:`ug_nrf9160`
 .. |nRF5340DK| replace:: nRF5340 PDK board (PCA10095) - see :ref:`ug_nrf5340`
+.. |nRF52840DK| replace:: nRF52840 DK board (PCA10056)
+.. |nRF51DK| replace:: nRF51 DK board (PCA10028)
+.. |nRF52DK| replace:: nRF52 DK board (PCA10040)
+.. |nRF52840Dongle| replace:: nRF52840 Dongle (PCA10059)
+.. |Thingy91| replace:: Thingy:91 (PCA20035)

--- a/samples/bluetooth/central_bas/README.rst
+++ b/samples/bluetooth/central_bas/README.rst
@@ -22,9 +22,9 @@ Requirements
 
   * |nRF9160DK|
   * |nRF5340DK|
-  * nRF52840 Development Kit board (PCA10056)
-  * nRF52 Development Kit board (PCA10040)
-  * nRF51 Development Kit board (PCA10028)
+  * |nRF52840DK|
+  * |nRF52DK|
+  * |nRF51DK|
 
 * A device running a BAS Server to connect with (for example, another board running the :ref:`peripheral_hids_mouse` or :ref:`peripheral_hids_keyboard` sample, or a Bluetooth Low Energy dongle and nRF Connect for Desktop)
 

--- a/samples/bluetooth/central_dfu_smp/README.rst
+++ b/samples/bluetooth/central_dfu_smp/README.rst
@@ -26,9 +26,9 @@ Requirements
 
   * |nRF9160DK|
   * |nRF5340DK|
-  * nRF52840 Development Kit board (PCA10056)
-  * nRF52 Development Kit board (PCA10040)
-  * nRF51 Development Kit board (PCA10028)
+  * |nRF52840DK|
+  * |nRF52DK|
+  * |nRF51DK|
 
 * A device running `MCUmgr`_ with `SMP over Bluetooth`_, for example, another board running the :ref:`smp_svr_sample`
 

--- a/samples/bluetooth/central_hids/README.rst
+++ b/samples/bluetooth/central_hids/README.rst
@@ -26,9 +26,9 @@ Requirements
 
   * |nRF9160DK|
   * |nRF5340DK|
-  * nRF52840 Development Kit board (PCA10056)
-  * nRF52 Development Kit board (PCA10040)
-  * nRF51 Development Kit board (PCA10028)
+  * |nRF52840DK|
+  * |nRF52DK|
+  * |nRF51DK|
 
 * HIDS device to connect with (for example, another board running the :ref:`peripheral_hids_mouse` or :ref:`peripheral_hids_keyboard` sample, or a Bluetooth Low Energy dongle and nRF Connect for Desktop)
 

--- a/samples/bluetooth/central_uart/README.rst
+++ b/samples/bluetooth/central_uart/README.rst
@@ -21,8 +21,8 @@ Requirements
 * One of the following development boards:
 
   * |nRF5340DK|
-  * nRF52840 Development Kit board (PCA10056)
-  * nRF52 Development Kit board (PCA10040)
+  * |nRF52840DK|
+  * |nRF52DK|
 
 * Another development board running a compatible application (see :ref:`peripheral_uart`).
 

--- a/samples/bluetooth/llpm/README.rst
+++ b/samples/bluetooth/llpm/README.rst
@@ -77,8 +77,8 @@ Requirements
 
 * Two of the following nRF52-series development kit boards:
 
-  * PCA10040
-  * PCA10056
+  * |nRF52DK|
+  * |nRF52840DK|
   * Other boards running BLE Controller variants that support LLPM (see :ref:`nrfxlib:ble_controller` Proprietary feature support)
 
   You can mix different boards.

--- a/samples/bluetooth/mesh/light/README.rst
+++ b/samples/bluetooth/mesh/light/README.rst
@@ -82,9 +82,9 @@ Requirements
 
 * One of the following development boards:
 
-  * nRF52840 Development Kit board (PCA10056)
-  * nRF52 Development Kit board (PCA10040)
-  * nRF51 Development Kit board (PCA10028)
+  * |nRF52840DK|
+  * |nRF52DK|
+  * |nRF51DK|
 
 * The Nordic Semiconductor nRF Mesh app for Android or iOS.
 

--- a/samples/bluetooth/peripheral_hids_keyboard/README.rst
+++ b/samples/bluetooth/peripheral_hids_keyboard/README.rst
@@ -39,9 +39,9 @@ Requirements
 * One of the following development boards:
 
   * |nRF5340DK|
-  * nRF52840 Development Kit board (PCA10056)
-  * nRF52 Development Kit board (PCA10040)
-  * nRF51 Development Kit board (PCA10028) (with the `NFC_OOB_PAIRING` option disabled)
+  * |nRF52840DK|
+  * |nRF52DK|
+  * |nRF51DK| (with the `NFC_OOB_PAIRING` option disabled)
 
 If the `NFC_OOB_PAIRING` feature is enabled:
 

--- a/samples/bluetooth/peripheral_hids_mouse/README.rst
+++ b/samples/bluetooth/peripheral_hids_mouse/README.rst
@@ -29,9 +29,9 @@ Requirements
 
   * |nRF9160DK|
   * |nRF5340DK|
-  * nRF52840 Development Kit board (PCA10056)
-  * nRF52 Development Kit board (PCA10040)
-  * nRF51 Development Kit board (PCA10028)
+  * |nRF52840DK|
+  * |nRF52DK|
+  * |nRF51DK|
 
 User interface
 **************

--- a/samples/bluetooth/peripheral_lbs/README.rst
+++ b/samples/bluetooth/peripheral_lbs/README.rst
@@ -19,10 +19,10 @@ Requirements
 * One of the Nordic development boards:
 
   * |nRF5340DK|
-  * nRF52840 Dongle (PCA10059)
-  * nRF52840 Development Kit board (PCA10056)
-  * nRF52 Development Kit board (PCA10040)
-  * nRF51 Development Kit board (PCA10028)
+  * |nRF52840Dongle|
+  * |nRF52840DK|
+  * |nRF52DK|
+  * |nRF51DK|
 
 * A phone or tablet running a compatible application, for example `nRF Connect for Mobile`_, `nRF Blinky`_, or `nRF Toolbox`_.
 

--- a/samples/bluetooth/peripheral_uart/README.rst
+++ b/samples/bluetooth/peripheral_uart/README.rst
@@ -21,8 +21,8 @@ Requirements
 * One of the following development boards:
 
   * |nRF5340DK|
-  * nRF52840 Development Kit board (PCA10056)
-  * nRF52 Development Kit board (PCA10040)
+  * |nRF52840DK|
+  * |nRF52DK|
 
 * A phone or tablet running a compatible application. The `Testing`_ instructions refer to nRF Connect for Mobile, but similar applications (for example, nRF Toolbox) can be used as well.
 

--- a/samples/bluetooth/shell_bt_nus/README.rst
+++ b/samples/bluetooth/shell_bt_nus/README.rst
@@ -18,8 +18,8 @@ Requirements
 * One of the following development boards:
 
   * |nRF5340DK|
-  * nRF52840 Development Kit board (PCA10056)
-  * nRF52 Development Kit board (PCA10040)
+  * |nRF52840DK|
+  * |nRF52DK|
 
 * A second nRF52 Development Kit board (PCA10040) for connecting with bt_nus_shell.py.
   Alternatively, you can use :ref:`ble_console_readme` for connecting (Linux only).

--- a/samples/bluetooth/throughput/README.rst
+++ b/samples/bluetooth/throughput/README.rst
@@ -74,9 +74,9 @@ Requirements
        CONFIG_BT_CTLR_TX_BUFFER_SIZE=251
        CONFIG_BT_CTLR_DATA_LENGTH_MAX=251
 
-  * nRF52840 Development Kit board (PCA10056)
-  * nRF52 Development Kit board (PCA10040)
-  * nRF51 Development Kit board (PCA10028) - limited support;
+  * |nRF52840DK|
+  * |nRF52DK|
+  * |nRF51DK| - limited support;
     some features, like an over-the-air data rate of 2 Ms/s, are not available on this board
 
   You can mix different boards.

--- a/samples/bootloader/README.rst
+++ b/samples/bootloader/README.rst
@@ -73,10 +73,10 @@ Requirements
 
 * One of the following development boards:
 
-  * nRF9160 DK board (PCA10090)
-  * nRF52840 Development Kit board (PCA10056)
-  * nRF52 Development Kit board (PCA10040)
-  * nRF51 Development Kit board (PCA10028)
+  * |nRF9160DK|
+  * |nRF52840DK|
+  * |nRF52DK|
+  * |nRF51DK|
 
 .. _bootloader_build_and_run:
 

--- a/samples/debug/ppi_trace/README.rst
+++ b/samples/debug/ppi_trace/README.rst
@@ -27,9 +27,9 @@ Requirements
 
 * One of the following development boards:
 
-  * nRF9160 DK board (PCA10090)
-  * nRF52840 Development Kit board (PCA10056)
-  * nRF52 Development Kit board (PCA10040)
+  * |nRF9160DK|
+  * |nRF52840DK|
+  * |nRF52DK|
 * Logic analyzer
 
 

--- a/samples/esb/README.rst
+++ b/samples/esb/README.rst
@@ -31,9 +31,9 @@ Requirements
 
 * Two of the following development boards:
 
-  * nRF52840 Development Kit board (PCA10056)
-  * nRF52 Development Kit board (PCA10040)
-  * nRF51 Development Kit board (PCA10028)
+  * |nRF52840DK|
+  * |nRF52DK|
+  * |nRF51DK|
 
   You can mix different boards.
 

--- a/samples/event_manager/README.rst
+++ b/samples/event_manager/README.rst
@@ -32,10 +32,10 @@ Requirements
 
 * One of the following development boards:
 
-  * nRF9160 DK board (PCA10090)
-  * nRF52840 Development Kit board (PCA10056)
-  * nRF52 Development Kit board (PCA10040)
-  * nRF51 Development Kit board (PCA10028)
+  * |nRF9160DK|
+  * |nRF52840DK|
+  * |nRF52DK|
+  * |nRF51DK|
 
 
 Building and running

--- a/samples/nfc/record_text/README.rst
+++ b/samples/nfc/record_text/README.rst
@@ -19,8 +19,8 @@ Requirements
 
 * One of the following development boards:
 
-  * nRF52840 Development Kit board (PCA10056)
-  * nRF52 Development Kit board (PCA10040)
+  * |nRF52840DK|
+  * |nRF52DK|
 
 * Smartphone or tablet
 

--- a/samples/nfc/tag_reader/README.rst
+++ b/samples/nfc/tag_reader/README.rst
@@ -26,8 +26,8 @@ Requirements
 
 * One of the following development boards:
 
-  * nRF52840 Development Kit board (PCA10056)
-  * nRF52 Development Kit board (PCA10040)
+  * |nRF52840DK|
+  * |nRF52DK|
 
 * NFC Reader ST25R3911B Nucleo expansion board (X-NUCLEO-NFC05A1)
 * NFC Type 2 Tag or Type 4 Tag

--- a/samples/nfc/writable_ndef_msg/README.rst
+++ b/samples/nfc/writable_ndef_msg/README.rst
@@ -22,8 +22,8 @@ Requirements
 
 * One of the following development boards:
 
-  * nRF52840 Development Kit board (PCA10056)
-  * nRF52 Development Kit board (PCA10040)
+  * |nRF52840DK|
+  * |nRF52DK|
 
 * Smartphone or tablet with NFC Tools application (or equivalent)
 

--- a/samples/nrf9160/at_client/README.rst
+++ b/samples/nrf9160/at_client/README.rst
@@ -22,7 +22,7 @@ Requirements
 
 * The following development board:
 
-  * nRF9160 DK board (PCA10090)
+  * |nRF9160DK|
 
 * .. include:: /includes/spm.txt
 

--- a/samples/nrf9160/aws_fota/README.rst
+++ b/samples/nrf9160/aws_fota/README.rst
@@ -104,7 +104,7 @@ Requirements
 
 * The following development board:
 
-  * nRF9160 DK board (PCA10090)
+  * |nRF9160DK|
 
 * An `AWS account`_ with access to Simple Storage Service (S3) and the IoT Core service
 

--- a/samples/nrf9160/coap_client/README.rst
+++ b/samples/nrf9160/coap_client/README.rst
@@ -15,7 +15,7 @@ Requirements
 
 * The following development board:
 
-  * nRF9160 DK board (PCA10090)
+  * |nRF9160DK|
 
 * .. include:: /includes/spm.txt
 

--- a/samples/nrf9160/http_application_update/README.rst
+++ b/samples/nrf9160/http_application_update/README.rst
@@ -23,7 +23,7 @@ Requirements
 
 * The following development board:
 
-  * nRF9160 DK board (PCA10090)
+  * |nRF9160DK|
 
 * A signed firmware image that is available for download from an HTTP server.
   This image is automatically generated when building the application.

--- a/samples/nrf9160/lte_ble_gateway/README.rst
+++ b/samples/nrf9160/lte_ble_gateway/README.rst
@@ -25,7 +25,7 @@ Requirements
 * A `Nordic Thingy:52`_
 * The following development board:
 
-  * nRF9160 DK board (PCA10090)
+  * |nRF9160DK|
 
 * :ref:`zephyr:bluetooth-hci-uart-sample` must be programmed to the nRF52 board controller on the board.
 * .. include:: /includes/spm.txt

--- a/samples/nrf9160/lwm2m_carrier/README.rst
+++ b/samples/nrf9160/lwm2m_carrier/README.rst
@@ -10,7 +10,7 @@ Requirements
 
 * The following development board:
 
-  * nRF9160 DK board (PCA10090)
+  * |nRF9160DK|
 
 * .. include:: /includes/spm.txt
 

--- a/samples/nrf9160/lwm2m_client/README.rst
+++ b/samples/nrf9160/lwm2m_client/README.rst
@@ -44,7 +44,7 @@ Requirements
 
 * The following development board:
 
-    * nRF9160 DK board (PCA10090)
+    * |nRF9160DK|
 
 * .. include:: /includes/spm.txt
 

--- a/samples/nrf9160/mqtt_simple/README.rst
+++ b/samples/nrf9160/mqtt_simple/README.rst
@@ -15,7 +15,7 @@ Requirements
 
 * The following development board:
 
-  * nRF9160 DK board (PCA10090)
+  * |nRF9160DK|
 
 * .. include:: /includes/spm.txt
 

--- a/samples/nrf9160/secure_services/README.rst
+++ b/samples/nrf9160/secure_services/README.rst
@@ -17,7 +17,7 @@ Requirements
 
 The following development board:
 
-* nRF9160 DK board (PCA10090)
+* |nRF9160DK|
 
 * .. include:: /includes/spm.txt
 

--- a/samples/nrf9160/serial_lte_modem/README.rst
+++ b/samples/nrf9160/serial_lte_modem/README.rst
@@ -19,7 +19,7 @@ Requirements
 
 * The following development board:
 
-    * nRF9160 DK board (PCA10090)
+    * |nRF9160DK|
 
 * If the client is a PC:
 
@@ -27,8 +27,8 @@ Requirements
 
 * If the client is an nRF52 device:
 
-    * nRF52840 DK board (PCA10056)
-    * nRF52832 DK board (PCA10040)
+    * |nRF52840DK|
+    * |nRF52DK|
 
 .. terminal_config
 

--- a/samples/nrf9160/spm/README.rst
+++ b/samples/nrf9160/spm/README.rst
@@ -54,7 +54,7 @@ Requirements
 
 The following development board:
 
-* nRF9160 DK board (PCA10090)
+* |nRF9160DK|
 
 Building and running
 ********************

--- a/samples/profiler/README.rst
+++ b/samples/profiler/README.rst
@@ -25,10 +25,10 @@ Requirements
 
 * One of the following development boards:
 
-  * nRF9160 DK board (PCA10090)
-  * nRF52840 Development Kit board (PCA10056)
-  * nRF52 Development Kit board (PCA10040)
-  * nRF51 Development Kit board (PCA10028)
+  * |nRF9160DK|
+  * |nRF52840DK|
+  * |nRF52DK|
+  * |nRF51DK|
 
 
 Building and running

--- a/samples/sensor/bh1749/README.rst
+++ b/samples/sensor/bh1749/README.rst
@@ -1,4 +1,4 @@
-.. _bh1749:
+﻿.. _bh1749:
 
 BH1749: Ambient Light Sensor IC
 #####################################################
@@ -22,7 +22,7 @@ Requirements
 
 * The following development board:
 
-  * PCA20035
+  * |Thingy91|
 
 Building and Running
 ********************

--- a/samples/usb/usb_uart_bridge/README.rst
+++ b/samples/usb/usb_uart_bridge/README.rst
@@ -11,7 +11,7 @@ Requirements
 
 * One of the following development boards:
 
-  * Thingy:91 board (PCA20035)
+  * |Thingy91|
 
 * A USB host which can communicate with CDC ACM devices, like a Windows or Linux PC
 


### PR DESCRIPTION
updated nRF9160 samples with user guide link, added shortcuts to
DKs in the requirements section across all samples and applications

Signed-off-by: UMA PRASEEDA <uma.praseeda@nordicsemi.no>