### PR TITLE
manifest: nrfxlib: minor bsdlib update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -72,7 +72,7 @@ manifest:
       revision: 30b7efa827b04d2e47840716b0372737fe7d6c92
     - name: nrfxlib
       path: nrfxlib
-      revision: f579faa502d3fbbfe41af966dcec82d3f6664958
+      revision: 562c6785b3ac863cc3d0a994d6f53c780a858891
     - name: cmock
       path: test/cmock
       revision: c243b9a7a7b3c471023193992b46cf1bd1910450


### PR DESCRIPTION
Updated nrfxlib revision with:
- bsdlib, v0.5.1

  Fixes memory issues when running GPS sockets for many hours

nrfxlib PR: https://github.com/NordicPlayground/nrfxlib/pull/114

Signed-off-by: Even Falch-Larsen <even.falch-larsen@nordicsemi.no>