### PR TITLE
lib: at_cmd_parser: tests

### DIFF
--- a/tests/lib/at_cmd_parser/at_cmd_parser/src/main.c
+++ b/tests/lib/at_cmd_parser/at_cmd_parser/src/main.c
@@ -202,7 +202,7 @@ static void test_params_string_parsing(void)
 	ret = at_parser_params_from_str(remainder, (char **)&remainder,
 					&test_list2);
 
-	zassert_true(ret = -EAGAIN, "Parser did not return -EAGAIN");
+	zassert_true(ret == -EAGAIN, "Parser did not return -EAGAIN");
 
 	tmpbuf_len = sizeof(tmpbuf);
 	zassert_equal(0, at_params_string_get(&test_list2, 0,


### PR DESCRIPTION
Fix a compilation error. This makes the test passing.

Signed-off-by: Christopher Métrailler <christopher.metrailler@nordicsemi.no>