### PR TITLE
dfu: dfu_target: Fix missing refrences to dfu_target_* functions

### DIFF
--- a/subsys/dfu/src/dfu_target.c
+++ b/subsys/dfu/src/dfu_target.c
@@ -10,19 +10,23 @@
 #include "dfu_target_mcuboot.h"
 #include "dfu_target_modem.h"
 
+#ifdef CONFIG_DFU_TARGET_MODEM
 const struct dfu_target dfu_target_modem = {
 	.init = dfu_target_modem_init,
 	.offset_get = dfu_target_modem_offset_get,
 	.write = dfu_target_modem_write,
 	.done = dfu_target_modem_done,
 };
+#endif
 
+#ifdef CONFIG_DFU_TARGET_MCUBOOT
 const struct dfu_target dfu_target_mcuboot = {
 	.init  = dfu_target_mcuboot_init,
 	.offset_get = dfu_target_mcuboot_offset_get,
 	.write = dfu_target_mcuboot_write,
 	.done  = dfu_target_mcuboot_done,
 };
+#endif
 
 #define MIN_SIZE_IDENTIFY_BUF 32
 


### PR DESCRIPTION
It should be possible to enable DFU targets separately currently the
structs are not wrapped in `#ifdef` making the compile fail when you
only select one target.

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>