### PR TITLE
samples: bluetooth: throughput: fix docs for nRF53 network config

### DIFF
--- a/samples/bluetooth/throughput/README.rst
+++ b/samples/bluetooth/throughput/README.rst
@@ -73,6 +73,7 @@ Requirements
 
        CONFIG_BT_CTLR_TX_BUFFER_SIZE=251
        CONFIG_BT_CTLR_DATA_LENGTH_MAX=251
+       CONFIG_BT_RX_BUF_LEN=255
 
   * nRF52840 Development Kit board (PCA10056)
   * nRF52 Development Kit board (PCA10040)


### PR DESCRIPTION
Added one more necessary Kconfig option to the nRF53 Network sample
configuration in Readme. This option extends HCI RX buffer length so
that they can accommodate long ACL packets coming from the Host when
nRF53 acts as a Peripheral device.

Signed-off-by: Kamil Piszczek <Kamil.Piszczek@nordicsemi.no>