### PR TITLE
Bluetooth: Samples: Switch to synchronous bt_init before main loop

### DIFF
--- a/samples/bluetooth/llpm/src/main.c
+++ b/samples/bluetooth/llpm/src/main.c
@@ -327,12 +327,9 @@ static const struct bt_gatt_latency_c_cb latency_client_cb = {
 	.latency_response = latency_response_handler
 };
 
-static void bt_ready(int err)
+static void bt_ready(void)
 {
-	if (err) {
-		printk("Bluetooth init failed (err %d)\n", err);
-		return;
-	}
+	int err;
 
 	printk("Bluetooth initialized\n");
 
@@ -410,11 +407,13 @@ void main(void)
 
 	console_init();
 
-	err = bt_enable(bt_ready);
+	err = bt_enable(NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
 		return;
 	}
+
+	bt_ready();
 
 	if (enable_qos_conn_evt_report()) {
 		printk("Enable LLPM QoS failed.\n");

--- a/samples/bluetooth/llpm/src/main.c
+++ b/samples/bluetooth/llpm/src/main.c
@@ -327,34 +327,6 @@ static const struct bt_gatt_latency_c_cb latency_client_cb = {
 	.latency_response = latency_response_handler
 };
 
-static void bt_ready(void)
-{
-	int err;
-
-	printk("Bluetooth initialized\n");
-
-	scan_init();
-
-	err = bt_gatt_latency_init(&gatt_latency, NULL);
-	if (err) {
-		printk("Latency service initialization failed (err %d)\n", err);
-		return;
-	}
-
-	err = bt_gatt_latency_c_init(&gatt_latency_client, &latency_client_cb);
-	if (err) {
-		printk("Latency client initialization failed (err %d)\n", err);
-		return;
-	}
-
-	if (enable_llpm_mode()) {
-		printk("Enable LLPM mode failed.\n");
-		return;
-	}
-
-	advertise_and_scan();
-}
-
 static void test_run(void)
 {
 	int err;
@@ -407,20 +379,41 @@ void main(void)
 
 	console_init();
 
+	bt_conn_cb_register(&conn_callbacks);
+
 	err = bt_enable(NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
 		return;
 	}
 
-	bt_ready();
+	printk("Bluetooth initialized\n");
+
+	scan_init();
+
+	err = bt_gatt_latency_init(&gatt_latency, NULL);
+	if (err) {
+		printk("Latency service initialization failed (err %d)\n", err);
+		return;
+	}
+
+	err = bt_gatt_latency_c_init(&gatt_latency_client, &latency_client_cb);
+	if (err) {
+		printk("Latency client initialization failed (err %d)\n", err);
+		return;
+	}
+
+	if (enable_llpm_mode()) {
+		printk("Enable LLPM mode failed.\n");
+		return;
+	}
+
+	advertise_and_scan();
 
 	if (enable_qos_conn_evt_report()) {
 		printk("Enable LLPM QoS failed.\n");
 		return;
 	}
-
-	bt_conn_cb_register(&conn_callbacks);
 
 	for (;;) {
 		if (test_ready) {

--- a/samples/bluetooth/peripheral_hids_keyboard/src/main.c
+++ b/samples/bluetooth/peripheral_hids_keyboard/src/main.c
@@ -512,13 +512,8 @@ static void hid_init(void)
 }
 
 
-static void bt_ready(int err)
+static void bt_ready(void)
 {
-	if (err) {
-		printk("Bluetooth init failed (err %d)\n", err);
-		return;
-	}
-
 	printk("Bluetooth initialized\n");
 
 	hid_init();
@@ -959,11 +954,13 @@ void main(void)
 	bt_conn_cb_register(&conn_callbacks);
 	bt_conn_auth_cb_register(&conn_auth_callbacks);
 
-	err = bt_enable(bt_ready);
+	err = bt_enable(NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
 		return;
 	}
+
+	bt_ready();
 
 	for (;;) {
 		if (is_adv) {

--- a/samples/bluetooth/peripheral_hids_keyboard/src/main.c
+++ b/samples/bluetooth/peripheral_hids_keyboard/src/main.c
@@ -511,27 +511,6 @@ static void hid_init(void)
 	__ASSERT(err == 0, "HIDS initialization failed\n");
 }
 
-
-static void bt_ready(void)
-{
-	printk("Bluetooth initialized\n");
-
-	hid_init();
-
-	if (IS_ENABLED(CONFIG_SETTINGS)) {
-		settings_load();
-	}
-
-#if CONFIG_NFC_OOB_PAIRING
-	k_work_init(&adv_work, delayed_advertising_start);
-	app_nfc_init();
-#else
-	advertising_start();
-#endif
-
-	k_work_init(&pairing_work, pairing_process);
-}
-
 static void auth_passkey_display(struct bt_conn *conn, unsigned int passkey)
 {
 	char addr[BT_ADDR_LE_STR_LEN];
@@ -960,7 +939,22 @@ void main(void)
 		return;
 	}
 
-	bt_ready();
+	printk("Bluetooth initialized\n");
+
+	hid_init();
+
+	if (IS_ENABLED(CONFIG_SETTINGS)) {
+		settings_load();
+	}
+
+#if CONFIG_NFC_OOB_PAIRING
+	k_work_init(&adv_work, delayed_advertising_start);
+	app_nfc_init();
+#else
+	advertising_start();
+#endif
+
+	k_work_init(&pairing_work, pairing_process);
 
 	for (;;) {
 		if (is_adv) {

--- a/samples/bluetooth/peripheral_hids_mouse/src/main.c
+++ b/samples/bluetooth/peripheral_hids_mouse/src/main.c
@@ -553,25 +553,6 @@ static void mouse_handler(struct k_work *work)
 	}
 }
 
-
-static void bt_ready(void)
-{
-	printk("Bluetooth initialized\n");
-
-	/* DIS initialized at system boot with SYS_INIT macro. */
-	hid_init();
-
-	k_delayed_work_init(&hids_work, mouse_handler);
-	k_work_init(&pairing_work, pairing_process);
-
-	if (IS_ENABLED(CONFIG_SETTINGS)) {
-		settings_load();
-	}
-
-	advertising_start();
-}
-
-
 #if defined(CONFIG_BT_GATT_HIDS_SECURITY_ENABLED)
 static void auth_passkey_display(struct bt_conn *conn, unsigned int passkey)
 {
@@ -792,7 +773,19 @@ void main(void)
 		return;
 	}
 
-	bt_ready();
+	printk("Bluetooth initialized\n");
+
+	/* DIS initialized at system boot with SYS_INIT macro. */
+	hid_init();
+
+	k_delayed_work_init(&hids_work, mouse_handler);
+	k_work_init(&pairing_work, pairing_process);
+
+	if (IS_ENABLED(CONFIG_SETTINGS)) {
+		settings_load();
+	}
+
+	advertising_start();
 
 	configure_buttons();
 

--- a/samples/bluetooth/peripheral_hids_mouse/src/main.c
+++ b/samples/bluetooth/peripheral_hids_mouse/src/main.c
@@ -554,13 +554,8 @@ static void mouse_handler(struct k_work *work)
 }
 
 
-static void bt_ready(int err)
+static void bt_ready(void)
 {
-	if (err) {
-		printk("Bluetooth init failed (err %d)\n", err);
-		return;
-	}
-
 	printk("Bluetooth initialized\n");
 
 	/* DIS initialized at system boot with SYS_INIT macro. */
@@ -791,11 +786,13 @@ void main(void)
 		bt_conn_auth_cb_register(&conn_auth_callbacks);
 	}
 
-	err = bt_enable(bt_ready);
+	err = bt_enable(NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
 		return;
 	}
+
+	bt_ready();
 
 	configure_buttons();
 

--- a/samples/bluetooth/shell_bt_nus/src/main.c
+++ b/samples/bluetooth/shell_bt_nus/src/main.c
@@ -123,10 +123,20 @@ static struct bt_conn_auth_cb conn_auth_callbacks = {
 	.pairing_failed = pairing_failed
 };
 
-static void bt_ready(int err)
+void main(void)
 {
+	int err;
+
+	printk("Starting Bluetooth NUS shell transport example\n");
+
+	bt_conn_cb_register(&conn_callbacks);
+	if (IS_ENABLED(CONFIG_BT_SMP)) {
+		bt_conn_auth_cb_register(&conn_auth_callbacks);
+	}
+
+	err = bt_enable(NULL);
 	if (err) {
-		LOG_ERR("BLE init failed (err: %d)", err);
+		LOG_ERR("BLE enable failed (err: %d)", err);
 		return;
 	}
 
@@ -144,24 +154,6 @@ static void bt_ready(int err)
 	}
 
 	LOG_INF("Bluetooth ready. Advertising started.");
-}
 
-void main(void)
-{
-	int err;
-
-	printk("Starting Bluetooth NUS shell transport example\n");
-
-	err = bt_enable(bt_ready);
-	if (err) {
-		LOG_ERR("BLE enable failed (err: %d)", err);
-		return;
-	}
-
-	bt_conn_cb_register(&conn_callbacks);
-
-	if (IS_ENABLED(CONFIG_BT_SMP)) {
-		bt_conn_auth_cb_register(&conn_auth_callbacks);
-	}
 }
 

--- a/samples/bluetooth/throughput/src/main.c
+++ b/samples/bluetooth/throughput/src/main.c
@@ -277,25 +277,6 @@ static const struct bt_gatt_throughput_cb throughput_cb = {
 	.data_send = throughput_send
 };
 
-static void bt_ready(int err)
-{
-	if (err) {
-		printk("Bluetooth init failed (err %d)\n", err);
-		return;
-	}
-
-	printk("Bluetooth initialized\n");
-
-	scan_init();
-	bt_gatt_throughput_init(&gatt_throughput, &throughput_cb);
-	if (err) {
-		printk("Throughput service initialization failed.\n");
-		return;
-	}
-
-	advertise_and_scan();
-}
-
 static void test_run(void)
 {
 	int err;
@@ -375,13 +356,24 @@ void main(void)
 
 	console_init();
 
-	err = bt_enable(bt_ready);
+	bt_conn_cb_register(&conn_callbacks);
+
+	err = bt_enable(NULL);
 	if (err) {
 		printk("Bluetooth init failed (err %d)\n", err);
 		return;
 	}
 
-	bt_conn_cb_register(&conn_callbacks);
+	printk("Bluetooth initialized\n");
+
+	scan_init();
+	bt_gatt_throughput_init(&gatt_throughput, &throughput_cb);
+	if (err) {
+		printk("Throughput service initialization failed.\n");
+		return;
+	}
+
+	advertise_and_scan();
 
 	for (;;) {
 		if (test_ready) {


### PR DESCRIPTION
Switch to using the synchronous bt_init call before starting the main
loop in the peripheral samples. This is to avoid sending notifications
before bluetooth has been properly initialized.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>