### PR TITLE
Bluetooth: Mesh: Support extension in models

### DIFF
--- a/subsys/bluetooth/mesh/gen_plvl_srv.c
+++ b/subsys/bluetooth/mesh/gen_plvl_srv.c
@@ -527,6 +527,24 @@ static int bt_mesh_plvl_srv_init(struct bt_mesh_model *mod)
 	bt_mesh_plvl_srv_reset(mod);
 	net_buf_simple_init(mod->pub->msg, 0);
 
+	if (IS_ENABLED(CONFIG_BT_MESH_MODEL_EXTENSIONS)) {
+		/* Model extensions:
+		 * To simplify the model extension tree, we're flipping the
+		 * relationship between the plvl server and the plvl setup
+		 * server. In the specification, the plvl setup server extends
+		 * the plvl server, which is the opposite of what we're doing
+		 * here. This makes no difference for the mesh stack, but it
+		 * makes it a lot easier to extend this model, as we won't have
+		 * to support multiple extenders.
+		 */
+		bt_mesh_model_extend(mod, srv->ponoff.ponoff_model);
+		bt_mesh_model_extend(
+			mod,
+			bt_mesh_model_find(
+				bt_mesh_model_elem(mod),
+				BT_MESH_MODEL_ID_GEN_POWER_LEVEL_SETUP_SRV));
+	}
+
 	return 0;
 }
 

--- a/subsys/bluetooth/mesh/gen_ponoff_srv.c
+++ b/subsys/bluetooth/mesh/gen_ponoff_srv.c
@@ -178,6 +178,25 @@ static int bt_mesh_ponoff_srv_init(struct bt_mesh_model *model)
 	srv->ponoff_model = model;
 	net_buf_simple_init(model->pub->msg, 0);
 
+	if (IS_ENABLED(CONFIG_BT_MESH_MODEL_EXTENSIONS)) {
+		/* Model extensions:
+		 * To simplify the model extension tree, we're flipping the
+		 * relationship between the ponoff server and the ponoff setup
+		 * server. In the specification, the ponoff setup server extends
+		 * the ponoff server, which is the opposite of what we're doing
+		 * here. This makes no difference for the mesh stack, but it
+		 * makes it a lot easier to extend this model, as we won't have
+		 * to support multiple extenders.
+		 */
+		bt_mesh_model_extend(model, srv->onoff.model);
+		bt_mesh_model_extend(model, srv->dtt.model);
+		bt_mesh_model_extend(
+			model,
+			bt_mesh_model_find(
+				bt_mesh_model_elem(model),
+				BT_MESH_MODEL_ID_GEN_POWER_ONOFF_SETUP_SRV));
+	}
+
 	return 0;
 }
 

--- a/subsys/bluetooth/mesh/gen_prop_srv.c
+++ b/subsys/bluetooth/mesh/gen_prop_srv.c
@@ -466,6 +466,14 @@ static int bt_mesh_prop_srv_init(struct bt_mesh_model *mod)
 	srv->mod = mod;
 	net_buf_simple_init(mod->pub->msg, 0);
 
+	if (IS_ENABLED(CONFIG_BT_MESH_MODEL_EXTENSIONS) &&
+	    mod->id != BT_MESH_MODEL_ID_GEN_USER_PROP_SRV) {
+		bt_mesh_model_extend(
+			mod,
+			bt_mesh_model_find(bt_mesh_model_elem(mod),
+					   BT_MESH_MODEL_ID_GEN_USER_PROP_SRV));
+	}
+
 	if (IS_MFR_SRV(mod)) {
 		/* Manufacturer properties aren't writable */
 		struct bt_mesh_prop *prop;


### PR DESCRIPTION
Adds all necessary calls to the new bt_mesh_model_extend API in the
model implementations. Does not add the extension concept config option
as a dependency for the models, as there is a valid use case for not
enabling the feature.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>