### PR TITLE
CODEOWNERS: Update nrfxlib codeowners and add Bluetooth Mesh entry

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -35,6 +35,7 @@ Kconfig*                                  @SebastianBoe
 /include/                                 @anangl @rlubos @pizi-nordic
 /include/bluetooth/                       @joerchan
 /include/bluetooth/**/*.rst               @b-gent
+/include/bluetooth/mesh/**/*.rst          @greg-fer
 /include/bluetooth/mesh/                  @trond-snekvik @joerchan
 /include/debug/**/*.rst                   @b-gent
 /include/drivers/                         @anangl
@@ -56,8 +57,9 @@ Kconfig*                                  @SebastianBoe
 /lib/multithreading_lock/                 @joerchan @rugeGerritsen
 /samples/sensor/bh1749/                   @wlgrd
 /samples/bluetooth/                       @joerchan @lemrey @carlescufi
-/samples/bluetooth/**/README.rst          @b-gent
+/samples/bluetooth/**/*.rst               @b-gent
 /samples/bluetooth/mesh/                  @trond-snekvik @joerchan
+/samples/bluetooth/mesh/**/*.rst          @b-gent
 /samples/bootloader/                      @hakonfam @ioannisg
 /subsys/debug/CMakeLists.txt              @nordic-krch
 /samples/debug/ppi_trace/                 @nordic-krch
@@ -65,7 +67,7 @@ Kconfig*                                  @SebastianBoe
 /samples/esb/                             @lemrey
 /samples/event_manager/README.rst         @b-gent
 /samples/mpsl/                            @joerchan @rugeGerritsen
-/samples/mpsl/**/README.rst               @b-gent
+/samples/mpsl/**/*.rst                    @b-gent
 /samples/nfc/                             @grochu
 /samples/nfc/**/README.rst                @b-gent
 /samples/nrf9160/                         @rlubos @lemrey

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -35,7 +35,7 @@ Kconfig*                                  @SebastianBoe
 /include/                                 @anangl @rlubos @pizi-nordic
 /include/bluetooth/                       @joerchan
 /include/bluetooth/**/*.rst               @b-gent
-/include/bluetooth/mesh/**/*.rst          @greg-fer
+/include/bluetooth/mesh/**/*.rst          @ru-fu
 /include/bluetooth/mesh/                  @trond-snekvik @joerchan
 /include/debug/**/*.rst                   @b-gent
 /include/drivers/                         @anangl
@@ -59,7 +59,7 @@ Kconfig*                                  @SebastianBoe
 /samples/bluetooth/                       @joerchan @lemrey @carlescufi
 /samples/bluetooth/**/*.rst               @b-gent
 /samples/bluetooth/mesh/                  @trond-snekvik @joerchan
-/samples/bluetooth/mesh/**/*.rst          @b-gent
+/samples/bluetooth/mesh/**/*.rst          @ru-fu
 /samples/bootloader/                      @hakonfam @ioannisg
 /subsys/debug/CMakeLists.txt              @nordic-krch
 /samples/debug/ppi_trace/                 @nordic-krch

--- a/west.yml
+++ b/west.yml
@@ -72,7 +72,7 @@ manifest:
       revision: 30b7efa827b04d2e47840716b0372737fe7d6c92
     - name: nrfxlib
       path: nrfxlib
-      revision: dc9e1fbd146f5032fd3651b1e7705d8b3258ecc2
+      revision: 3a67af06c5953c0a18b9333ec66645cfa83a228b
     - name: cmock
       path: test/cmock
       revision: c243b9a7a7b3c471023193992b46cf1bd1910450


### PR DESCRIPTION
Add greg-fer as the codeowner for Bluetooth Mesh documentation related
files. Also switch to *.rst for bluetooth related files, this will catch
more files in case more are added.

Update manifest revision to include addition of codeowners file to nrfxlib