### PR TITLE
doc: PM: clarifications and fixes

### DIFF
--- a/doc/nrf/ug_bootloader.rst
+++ b/doc/nrf/ug_bootloader.rst
@@ -44,6 +44,8 @@ The following image shows an abstract representation of the memory layout, assum
 For detailed information about the memory layout, see the partition configuration in the DTS overlay file for the board that you are using.
 This file is located in ``subsys\bootloader\dts``.
 
+.. _immutable_bootloader:
+
 Immutable bootloader
 ====================
 

--- a/doc/nrf/ug_multi_image.rst
+++ b/doc/nrf/ug_multi_image.rst
@@ -72,6 +72,7 @@ To change the default configuration and configure how a child image is handled, 
 For example, to use a prebuilt HEX file of the :ref:`secure_partition_manager` instead of building it, select :option:`CONFIG_SPM_BUILD_STRATEGY_USE_HEX_FILE` instead of the default :option:`CONFIG_SPM_BUILD_STRATEGY_FROM_SOURCE`, and specify the HEX file in :option:`CONFIG_SPM_HEX_FILE`.
 To ignore an MCUboot child image, select :option:`CONFIG_MCUBOOT_BUILD_STRATEGY_SKIP_BUILD` instead of :option:`CONFIG_MCUBOOT_BUILD_STRATEGY_FROM_SOURCE`.
 
+.. _ug_multi_image_defining:
 
 Defining and enabling a child image
 ***********************************


### PR DESCRIPTION
Various minor things I thought about while reviewing #1581 that I didn't want to lose track of.

- Move some YAML comments around to avoid horizontal scrollbars in generated output
- add links to documentation when forward references are used
- correct the types of the placement and span option values
- clarifications for potentially confusing areas

I'm generally trying to better understand how PM works when thinking about when code related to multi-image really has to go into zephyr/, mcuboot/, etc., and when it might go into nRF, e.g. for https://github.com/NordicPlayground/fw-nrfconnect-mcuboot/pull/68. This PR contains what I think the answers are to points I personally found confusing in the existing docs.