### PR TITLE
manifest: update nrfxlib for Oberon 3.0.3

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -72,7 +72,7 @@ manifest:
       revision: 30b7efa827b04d2e47840716b0372737fe7d6c92
     - name: nrfxlib
       path: nrfxlib
-      revision: d491c7ebec5ce2ad393a331315c08690f8f819cb
+      revision: f579faa502d3fbbfe41af966dcec82d3f6664958
     - name: cmock
       path: test/cmock
       revision: c243b9a7a7b3c471023193992b46cf1bd1910450


### PR DESCRIPTION
Update nrfxlib to get oberon 3.0.3
nrfxlib revision:f579faa502d3fbbfe41af966dcec82d3f6664958 ~https://github.com/NordicPlayground/nrfxlib/pull/120~

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>