### PR TITLE
sample: nrf9160: serial_lte_modem upgrade to v1.1

### DIFF
--- a/samples/nrf9160/serial_lte_modem/README.rst
+++ b/samples/nrf9160/serial_lte_modem/README.rst
@@ -90,15 +90,15 @@ TCP/IP AT commands
 
 The following proprietary TCP/IP AT commands are used in this sample:
 
-* AT#XSOCKET=<op>,<type>
+* AT#XSOCKET=<op>[,<type>]
 * AT#XSOCKET?
-* AT#XBIND=<local_ip>,<local_port>
+* AT#XBIND=<port>
 * AT#XTCPCONN=<url>,<port>
 * AT#XTCPCONN?
 * AT#XTCPSEND=<data>
-* AT#XTCPRECV=<length>,<time>
+* AT#XTCPRECV=<length>,<timeout>
 * AT#XUDPSENDTO=<url>,<port>,<data>
-* AT#XUDPRECVFROM=<url>,<port>,<length>,<time>
+* AT#XUDPRECVFROM=<url>,<port>,<length>,<timeout>
 
 GPS AT Commands
 ***************

--- a/samples/nrf9160/serial_lte_modem/src/main.c
+++ b/samples/nrf9160/serial_lte_modem/src/main.c
@@ -55,11 +55,11 @@ void start_execute(void)
 #ifdef CONFIG_SLM_GPIO_WAKEUP
 void main(void)
 {
-	u32_t rr = nrf_power_resetreas_get();
+	u32_t rr = nrf_power_resetreas_get(NRF_POWER_NS);
 
 	LOG_DBG("RR: 0x%08x", rr);
 	if (rr & NRF_POWER_RESETREAS_OFF_MASK) {
-		nrf_power_resetreas_clear(0x70017);
+		nrf_power_resetreas_clear(NRF_POWER_NS, 0x70017);
 		start_execute();
 	} else {
 		LOG_INF("Sleep");

--- a/samples/nrf9160/serial_lte_modem/src/slm_at_gps.h
+++ b/samples/nrf9160/serial_lte_modem/src/slm_at_gps.h
@@ -20,12 +20,11 @@
  * @brief GPS AT command parser.
  *
  * @param at_cmd  AT command string.
- * @param param   Length of string.
  *
  * @retval 0 If the operation was successful.
  *           Otherwise, a (negative) error code is returned.
  */
-int slm_at_gps_parse(const u8_t *at_cmd, u8_t length);
+int slm_at_gps_parse(const char *at_cmd);
 
 /**
  * @brief Initialize GPS AT command parser.

--- a/samples/nrf9160/serial_lte_modem/src/slm_at_host.c
+++ b/samples/nrf9160/serial_lte_modem/src/slm_at_host.c
@@ -33,9 +33,8 @@ LOG_MODULE_REGISTER(at_host, CONFIG_SLM_LOG_LEVEL);
 
 #define SLM_SYNC_STR "Ready\r\n"
 
-#define AT_CMD_SLMVER_U	"AT#XSLMVER"
-#define AT_CMD_SLMVER_L	"at#xslmver"
-#define SLM_VERSION	"#XSLMVER: 1.0\r\n"
+#define AT_CMD_SLMVER	"AT#XSLMVER"
+#define SLM_VERSION	"#XSLMVER: 1.1\r\n"
 
 #define AT_MAX_CMD_LEN		CONFIG_AT_CMD_RESPONSE_MAX_LEN
 
@@ -91,7 +90,7 @@ static void cmd_send(struct k_work *work)
 	static char buf[AT_MAX_CMD_LEN];
 	enum at_cmd_state state;
 	int err;
-	size_t size_slmver = sizeof(AT_CMD_SLMVER_U) - 1;
+	size_t size_slmver = sizeof(AT_CMD_SLMVER) - 1;
 
 	ARG_UNUSED(work);
 
@@ -100,15 +99,14 @@ static void cmd_send(struct k_work *work)
 
 	LOG_HEXDUMP_DBG(at_buf, at_buf_len, "RX");
 
-	if (strncmp(at_buf, AT_CMD_SLMVER_U, size_slmver) == 0 ||
-		strncmp(at_buf, AT_CMD_SLMVER_L, size_slmver) == 0) {
+	if (slm_at_cmd_cmp(at_buf, AT_CMD_SLMVER, size_slmver)) {
 		write_uart_string(SLM_VERSION, sizeof(SLM_VERSION));
 		write_uart_string(OK_STR, sizeof(OK_STR));
 		goto done;
 	}
 
 #if defined(CONFIG_SLM_TCPIP_AT_MODE)
-	err = slm_at_tcpip_parse(at_buf, at_buf_len);
+	err = slm_at_tcpip_parse(at_buf);
 	if (err == 0) {
 		write_uart_string(OK_STR, sizeof(OK_STR));
 		goto done;
@@ -119,7 +117,7 @@ static void cmd_send(struct k_work *work)
 #endif /** CONFIG_SLM_TCPIP_AT_MODE */
 
 #if defined(CONFIG_SLM_GPS_AT_MODE)
-	err = slm_at_gps_parse(at_buf, at_buf_len);
+	err = slm_at_gps_parse(at_buf);
 	if (err == 0) {
 		write_uart_string(OK_STR, sizeof(OK_STR));
 		goto done;

--- a/samples/nrf9160/serial_lte_modem/src/slm_at_host.h
+++ b/samples/nrf9160/serial_lte_modem/src/slm_at_host.h
@@ -14,16 +14,16 @@
  */
 
 #include <zephyr/types.h>
+#include <ctype.h>
 #include <at_cmd_parser/at_cmd_parser.h>
 #include <at_cmd.h>
 
 /**@brief AT command handler type. */
-typedef int (*slm_at_handler_t) (const char *at_cmd, size_t param_offset);
+typedef int (*slm_at_handler_t) (enum at_cmd_type);
 
 typedef struct slm_at_cmd_list {
 	u8_t type;
-	char *string_upper;
-	char *string_lower;
+	char *string;
 	slm_at_handler_t handler;
 } slm_at_cmd_list_t;
 
@@ -35,6 +35,27 @@ typedef struct slm_at_cmd_list {
  */
 int slm_at_host_init(void);
 
+/**
+ * @brief Compare name of AT command ignoring case
+ *
+ * @param cmd Command string received from UART
+ * @param slm_cmd Propreiatry command supported by SLM
+ * @param length Length of string to compare
+ *
+ * @retval true If two commands match, false if not.
+ */
+static inline bool slm_at_cmd_cmp(const char *cmd,
+				const char *slm_cmd,
+				u8_t length)
+{
+	for (int i = 0; i < length; i++) {
+		if (toupper(*(cmd + i)) != *(slm_cmd + i)) {
+			return false;
+		}
+	}
+
+	return true;
+}
 /** @} */
 
 #endif /* SLM_AT_HOST_ */

--- a/samples/nrf9160/serial_lte_modem/src/slm_at_tcpip.c
+++ b/samples/nrf9160/serial_lte_modem/src/slm_at_tcpip.c
@@ -44,30 +44,23 @@ enum slm_tcpip_at_cmd_type {
 };
 
 /** forward declaration of cmd handlers **/
-static int handle_at_socket(const char *at_cmd, size_t param_offset);
-static int handle_at_bind(const char *at_cmd, size_t param_offset);
-static int handle_at_tcp_conn(const char *at_cmd, size_t param_offset);
-static int handle_at_tcp_send(const char *at_cmd, size_t param_offset);
-static int handle_at_tcp_recv(const char *at_cmd, size_t param_offset);
-static int handle_at_udp_sendto(const char *at_cmd, size_t param_offset);
-static int handle_at_udp_recvfrom(const char *at_cmd, size_t param_offset);
+static int handle_at_socket(enum at_cmd_type cmd_type);
+static int handle_at_bind(enum at_cmd_type cmd_type);
+static int handle_at_tcp_conn(enum at_cmd_type cmd_type);
+static int handle_at_tcp_send(enum at_cmd_type cmd_type);
+static int handle_at_tcp_recv(enum at_cmd_type cmd_type);
+static int handle_at_udp_sendto(enum at_cmd_type cmd_type);
+static int handle_at_udp_recvfrom(enum at_cmd_type cmd_type);
 
 /**@brief SLM AT Command list type. */
-static slm_at_cmd_list_t m_at_list[AT_TCPIP_MAX] = {
-	{AT_SOCKET, "AT#XSOCKET", "at#xsocket",
-		handle_at_socket},
-	{AT_BIND, "AT#XBIND", "at#xbind",
-		handle_at_bind},
-	{AT_TCP_CONNECT, "AT#XTCPCONN", "at#xtcpconn",
-		handle_at_tcp_conn},
-	{AT_TCP_SEND, "AT#XTCPSEND", "at#xtcpsend",
-		handle_at_tcp_send},
-	{AT_TCP_RECV, "AT#XTCPRECV", "at#xtcprecv",
-		handle_at_tcp_recv},
-	{AT_UDP_SENDTO, "AT#XUDPSENDTO", "at#xudpsendto",
-		handle_at_udp_sendto},
-	{AT_UDP_RECVFROM, "AT#XUDPRECVFROM", "at#xudprecvfrom",
-		handle_at_udp_recvfrom},
+static slm_at_cmd_list_t m_tcpip_at_list[AT_TCPIP_MAX] = {
+	{AT_SOCKET, "AT#XSOCKET", handle_at_socket},
+	{AT_BIND, "AT#XBIND", handle_at_bind},
+	{AT_TCP_CONNECT, "AT#XTCPCONN", handle_at_tcp_conn},
+	{AT_TCP_SEND, "AT#XTCPSEND", handle_at_tcp_send},
+	{AT_TCP_RECV, "AT#XTCPRECV", handle_at_tcp_recv},
+	{AT_UDP_SENDTO, "AT#XUDPSENDTO", handle_at_udp_sendto},
+	{AT_UDP_RECVFROM, "AT#XUDPRECVFROM", handle_at_udp_recvfrom},
 };
 
 static struct sockaddr_storage remote;
@@ -211,26 +204,14 @@ static int do_socket_close(int error)
 	return ret;
 }
 
-static int do_bind(const char *ip, u16_t port)
+static int do_bind(u16_t port)
 {
 	int ret;
 	struct sockaddr_in local;
 
-	LOG_DBG("%s:%d", log_strdup(ip), port);
-
-	if (!check_for_ipv4(ip, strlen(ip))) {
-		LOG_ERR("Not IPv4 address");
-		return -EINVAL;
-	}
-
 	local.sin_family = AF_INET;
 	local.sin_port = htons(port);
-	/* NOTE inet_pton() returns 1 as success */
-	if (inet_pton(AF_INET, ip, &local.sin_addr) != 1) {
-		LOG_ERR("Parse failed: %d", -errno);
-		return -EINVAL;
-	}
-
+	local.sin_addr.s_addr = htonl(INADDR_ANY);
 	ret = bind(client.sock, (struct sockaddr *)&local,
 		 sizeof(struct sockaddr_in));
 	if (ret < 0) {
@@ -451,21 +432,13 @@ static int do_udp_recvfrom(const char *url, u16_t port, u16_t length,
  *  AT#XSOCKET?
  *  AT#XSOCKET=? TEST command not supported
  */
-static int handle_at_socket(const char *at_cmd, size_t param_offset)
+static int handle_at_socket(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;
-	char *at_param = (char *)at_cmd + param_offset;
 	u16_t op;
 
-	if (*(at_param) == '=') {
-		at_param++;
-		if (*(at_param) == '?') {
-			return err;
-		}
-		err = at_parser_params_from_str(at_cmd, NULL, &m_param_list);
-		if (err < 0) {
-			return err;
-		};
+	switch (cmd_type) {
+	case AT_CMD_TYPE_SET_COMMAND:
 		if (at_params_valid_count_get(&m_param_list) < 2) {
 			return -EINVAL;
 		}
@@ -494,8 +467,9 @@ static int handle_at_socket(const char *at_cmd, size_t param_offset)
 			} else {
 				err = do_socket_close(0);
 			}
-		}
-	} else if (*(at_param) == '?') {
+		} break;
+
+	case AT_CMD_TYPE_READ_COMMAND:
 		if (client.sock != INVALID_SOCKET) {
 			sprintf(buf, "#XSOCKET: %d, %d\r\n", client.sock,
 				client.ip_proto);
@@ -504,46 +478,44 @@ static int handle_at_socket(const char *at_cmd, size_t param_offset)
 		}
 		client.callback(buf);
 		err = 0;
+		break;
+
+	default:
+		break;
 	}
 
 	return err;
 }
 
 /**@brief handle AT#XBIND commands
- *  AT#XBIND=<local_ip>,<port>
+ *  AT#XBIND=<port>
  *  AT#XBIND?
  *  AT#XBIND=? TEST command not supported
  */
-static int handle_at_bind(const char *at_cmd, size_t param_offset)
+static int handle_at_bind(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;
-	char *at_param = (char *)at_cmd + param_offset;
-	char ip[TCPIP_MAX_URL];
-	int size = TCPIP_MAX_URL;
 	u16_t port;
 
-	if (*(at_param) == '=') {
-		at_param++;
-		if (*(at_param) == '?') {
-			return err;
-		}
-		err = at_parser_params_from_str(at_cmd, NULL, &m_param_list);
-		if (err < 0) {
-			return err;
-		};
-		if (at_params_valid_count_get(&m_param_list) < 3) {
+	if (client.sock < 0) {
+		LOG_ERR("Socket not opened yet");
+		return err;
+	}
+
+	switch (cmd_type) {
+	case AT_CMD_TYPE_SET_COMMAND:
+		if (at_params_valid_count_get(&m_param_list) < 2) {
 			return -EINVAL;
 		}
-		err = at_params_string_get(&m_param_list, 1, ip, &size);
+		err = at_params_short_get(&m_param_list, 1, &port);
 		if (err < 0) {
 			return err;
 		};
-		ip[size] = '\0';
-		err = at_params_short_get(&m_param_list, 2, &port);
-		if (err < 0) {
-			return err;
-		};
-		err = do_bind(ip, port);
+		err = do_bind(port);
+		break;
+
+	default:
+		break;
 	}
 
 	return err;
@@ -554,10 +526,9 @@ static int handle_at_bind(const char *at_cmd, size_t param_offset)
  *  AT#XTCPCONN?
  *  AT#XTCPCONN=? TEST command not supported
  */
-static int handle_at_tcp_conn(const char *at_cmd, size_t param_offset)
+static int handle_at_tcp_conn(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;
-	char *at_param = (char *)at_cmd + param_offset;
 	char url[TCPIP_MAX_URL];
 	int size = TCPIP_MAX_URL;
 	u16_t port;
@@ -567,15 +538,8 @@ static int handle_at_tcp_conn(const char *at_cmd, size_t param_offset)
 		return err;
 	}
 
-	if (*(at_param) == '=') {
-		at_param++;
-		if (*(at_param) == '?') {
-			return err;
-		}
-		err = at_parser_params_from_str(at_cmd, NULL, &m_param_list);
-		if (err < 0) {
-			return err;
-		};
+	switch (cmd_type) {
+	case AT_CMD_TYPE_SET_COMMAND:
 		if (at_params_valid_count_get(&m_param_list) < 3) {
 			return -EINVAL;
 		}
@@ -589,13 +553,19 @@ static int handle_at_tcp_conn(const char *at_cmd, size_t param_offset)
 			return err;
 		};
 		err = do_tcp_connect(url, port);
-	} else if (*(at_param) == '?') {
+		break;
+
+	case AT_CMD_TYPE_READ_COMMAND:
 		if (client.connected) {
 			client.callback("+XTCPCONN: 1\r\n");
 		} else {
 			client.callback("+XTCPCONN: 0\r\n");
 		}
 		err = 0;
+		break;
+
+	default:
+		break;
 	}
 
 	return err;
@@ -606,10 +576,9 @@ static int handle_at_tcp_conn(const char *at_cmd, size_t param_offset)
  *  AT#XTCPSEND? READ command not supported
  *  AT#XTCPSEND=? TEST command not supported
  */
-static int handle_at_tcp_send(const char *at_cmd, size_t param_offset)
+static int handle_at_tcp_send(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;
-	char *at_param = (char *)at_cmd + param_offset;
 	char data[NET_IPV4_MTU];
 	int size = NET_IPV4_MTU;
 
@@ -618,15 +587,8 @@ static int handle_at_tcp_send(const char *at_cmd, size_t param_offset)
 		return err;
 	}
 
-	if (*(at_param) == '=') {
-		at_param++;
-		if (*(at_param) == '?') {
-			return err;
-		}
-		err = at_parser_params_from_str(at_cmd, NULL, &m_param_list);
-		if (err < 0) {
-			return err;
-		};
+	switch (cmd_type) {
+	case AT_CMD_TYPE_SET_COMMAND:
 		if (at_params_valid_count_get(&m_param_list) < 2) {
 			return -EINVAL;
 		}
@@ -636,20 +598,23 @@ static int handle_at_tcp_send(const char *at_cmd, size_t param_offset)
 		};
 		data[size] = '\0';
 		err = do_tcp_send(data);
+		break;
+
+	default:
+		break;
 	}
 
 	return err;
 }
 
 /**@brief handle AT#XTCPRECV commands
- *  AT#XTCPRECV=<length>
+ *  AT#XTCPRECV=<length>,<timeout>
  *  AT#XTCPRECV? READ command not supported
  *  AT#XTCPRECV=? TEST command not supported
  */
-static int handle_at_tcp_recv(const char *at_cmd, size_t param_offset)
+static int handle_at_tcp_recv(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;
-	char *at_param = (char *)at_cmd + param_offset;
 	u16_t length, time;
 
 	if (!client.connected) {
@@ -657,15 +622,8 @@ static int handle_at_tcp_recv(const char *at_cmd, size_t param_offset)
 		return err;
 	}
 
-	if (*(at_param) == '=') {
-		at_param++;
-		if (*(at_param) == '?') {
-			return err;
-		}
-		err = at_parser_params_from_str(at_cmd, NULL, &m_param_list);
-		if (err < 0) {
-			return err;
-		};
+	switch (cmd_type) {
+	case AT_CMD_TYPE_SET_COMMAND:
 		if (at_params_valid_count_get(&m_param_list) < 3) {
 			return -EINVAL;
 		}
@@ -678,6 +636,10 @@ static int handle_at_tcp_recv(const char *at_cmd, size_t param_offset)
 			return err;
 		};
 		err = do_tcp_receive(length, time);
+		break;
+
+	default:
+		break;
 	}
 
 	return err;
@@ -688,10 +650,9 @@ static int handle_at_tcp_recv(const char *at_cmd, size_t param_offset)
  *  AT#XUDPSENDTO? READ command not supported
  *  AT#XUDPSENDTO=? TEST command not supported
  */
-static int handle_at_udp_sendto(const char *at_cmd, size_t param_offset)
+static int handle_at_udp_sendto(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;
-	char *at_param = (char *)at_cmd + param_offset;
 	char url[TCPIP_MAX_URL];
 	u16_t port;
 	char data[NET_IPV4_MTU];
@@ -705,15 +666,8 @@ static int handle_at_udp_sendto(const char *at_cmd, size_t param_offset)
 		return err;
 	}
 
-	if (*(at_param) == '=') {
-		at_param++;
-		if (*(at_param) == '?') {
-			return err;
-		}
-		err = at_parser_params_from_str(at_cmd, NULL, &m_param_list);
-		if (err < 0) {
-			return err;
-		};
+	switch (cmd_type) {
+	case AT_CMD_TYPE_SET_COMMAND:
 		if (at_params_valid_count_get(&m_param_list) < 4) {
 			return -EINVAL;
 		}
@@ -734,20 +688,23 @@ static int handle_at_udp_sendto(const char *at_cmd, size_t param_offset)
 		};
 		data[size] = '\0';
 		err = do_udp_sendto(url, port, data);
+		break;
+
+	default:
+		break;
 	}
 
 	return err;
 }
 
 /**@brief handle AT#XUDPRECVFROM commands
- *  AT#XUDPRECVFROM=<url>,<port>,<length>
+ *  AT#XUDPRECVFROM=<url>,<port>,<length>,<timeout>
  *  AT#XUDPRECVFROM? READ command not supported
  *  AT#XUDPRECVFROM=? TEST command not supported
  */
-static int handle_at_udp_recvfrom(const char *at_cmd, size_t param_offset)
+static int handle_at_udp_recvfrom(enum at_cmd_type cmd_type)
 {
 	int err = -EINVAL;
-	char *at_param = (char *)at_cmd + param_offset;
 	char url[TCPIP_MAX_URL];
 	int size = TCPIP_MAX_URL;
 	u16_t port, length, time;
@@ -760,15 +717,8 @@ static int handle_at_udp_recvfrom(const char *at_cmd, size_t param_offset)
 		return err;
 	}
 
-	if (*(at_param) == '=') {
-		at_param++;
-		if (*(at_param) == '?') {
-			return err;
-		}
-		err = at_parser_params_from_str(at_cmd, NULL, &m_param_list);
-		if (err < 0) {
-			return err;
-		};
+	switch (cmd_type) {
+	case AT_CMD_TYPE_SET_COMMAND:
 		if (at_params_valid_count_get(&m_param_list) < 5) {
 			return -EINVAL;
 		}
@@ -790,6 +740,10 @@ static int handle_at_udp_recvfrom(const char *at_cmd, size_t param_offset)
 			return err;
 		};
 		err = do_udp_recvfrom(url, port, length, time);
+		break;
+
+	default:
+		break;
 	}
 
 	return err;
@@ -797,22 +751,24 @@ static int handle_at_udp_recvfrom(const char *at_cmd, size_t param_offset)
 
 /**@brief API to handle TCP/IP AT commands
  */
-int slm_at_tcpip_parse(const u8_t *param, u8_t length)
+int slm_at_tcpip_parse(const char *at_cmd)
 {
 	int ret = -ENOTSUP;
-
-	ARG_UNUSED(length);
+	enum at_cmd_type type;
 
 	for (int i = 0; i < AT_TCPIP_MAX; i++) {
-		u8_t cmd_len = strlen(m_at_list[i].string_upper);
+		u8_t cmd_len = strlen(m_tcpip_at_list[i].string);
 
-		if (strncmp(param, m_at_list[i].string_upper,
-			cmd_len) == 0) {
-			ret = m_at_list[i].handler(param, cmd_len);
-			break;
-		} else if (strncmp(param, m_at_list[i].string_lower,
-			cmd_len) == 0) {
-			ret = m_at_list[i].handler(param, cmd_len);
+		if (slm_at_cmd_cmp(at_cmd, m_tcpip_at_list[i].string,
+			cmd_len)) {
+			ret = at_parser_params_from_str(at_cmd, NULL,
+						&m_param_list);
+			if (ret < 0) {
+				LOG_ERR("Failed to parse AT command %d", ret);
+				return -EINVAL;
+			}
+			type = at_parser_cmd_type_get(at_cmd);
+			ret = m_tcpip_at_list[i].handler(type);
 			break;
 		}
 	}

--- a/samples/nrf9160/serial_lte_modem/src/slm_at_tcpip.h
+++ b/samples/nrf9160/serial_lte_modem/src/slm_at_tcpip.h
@@ -19,13 +19,12 @@
 /**
  * @brief TCP/IP AT command parser.
  *
- * @param at_cmd  AT command string.
- * @param param   Length of string.
+ * @param at_cmd AT command string.
  *
  * @retval 0 If the operation was successful.
  *           Otherwise, a (negative) error code is returned.
  */
-int slm_at_tcpip_parse(const u8_t *at_cmd, u8_t length);
+int slm_at_tcpip_parse(const char *at_cmd);
 
 /**
  * @brief Initialize TCP/IP AT command parser.


### PR DESCRIPTION
Adapt to new at_cmd_parser lib, see [PR#1587](https://github.com/NordicPlayground/fw-nrfconnect-nrf/pull/1587)
Adapt to nrx v2.0.0 (NRF_POWER related)
TCPIP #XBIND now requires no local IP address
GPS now reports Time To First Fix (TTFT)

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>