### PR TITLE
subsys: spm: Change default DPPIC permission mask

### DIFF
--- a/subsys/spm/Kconfig
+++ b/subsys/spm/Kconfig
@@ -199,7 +199,7 @@ config SPM_NRF_DPPIC_NS
 
 config SPM_NRF_DPPIC_PERM_MASK
 	hex "Set DPPIC PERM mask for Non-secure"
-	default 0x0000FFFF
+	default 0x00000000
 	depends on SPM_NRF_DPPIC_NS
 	help
 	  The input mask is a mirror of the permission bits set in


### PR DESCRIPTION
If DPPIC is configured as non-secure, the permission
mask is by default all set to secure mode.
This sets all to non-secure when DPPIC is non-secure:
https://infocenter.nordicsemi.com/topic/ps_nrf9160/spu.html?cp=2_0_0_5_14_5#register.DPPI-0-0.PERM