### PR TITLE
samples: bluetooth: cleaned up platform whitelists.

### DIFF
--- a/samples/bluetooth/central_bas/sample.yaml
+++ b/samples/bluetooth/central_bas/sample.yaml
@@ -9,5 +9,5 @@ tests:
   test_build:
     build_only: true
     build_on_all: true
-    platform_whitelist: nrf51_pca10028 nrf52_pca10040 nrf52840_pca10056 nrf52810_pca10040
+    platform_whitelist: nrf51_pca10028 nrf52_pca10040 nrf52840_pca10056
     tags: bluetooth ci_build

--- a/samples/bluetooth/central_hids/sample.yaml
+++ b/samples/bluetooth/central_hids/sample.yaml
@@ -9,5 +9,5 @@ tests:
   test_build:
     build_only: true
     build_on_all: true
-    platform_whitelist: nrf51_pca10028 nrf52_pca10040 nrf52840_pca10056 nrf52810_pca10040
+    platform_whitelist: nrf51_pca10028 nrf52_pca10040 nrf52840_pca10056
     tags: bluetooth ci_build

--- a/samples/bluetooth/peripheral_uart/sample.yaml
+++ b/samples/bluetooth/peripheral_uart/sample.yaml
@@ -5,5 +5,5 @@ tests:
   test_build:
     build_only: true
     build_on_all: true
-    platform_whitelist: nrf51_pca10028 nrf52_pca10040 nrf52840_pca10056 nrf52810_pca10040
+    platform_whitelist: nrf51_pca10028 nrf52_pca10040 nrf52840_pca10056
     tags: bluetooth ci_build


### PR DESCRIPTION
Fixes NCSDK-3695. Removed nRF52810 targets from tests
(platform whitelist in sample.yaml files) for samples which don't fit this
device's RAM.