### PR TITLE
Bluetooth: LLPM: Change to using synchronous HCI command send

### DIFF
--- a/applications/nrf_desktop/src/modules/ble_qos.c
+++ b/applications/nrf_desktop/src/modules/ble_qos.c
@@ -474,9 +474,8 @@ static void enable_qos_reporting(void)
 	cmd_enable = net_buf_add(buf, sizeof(*cmd_enable));
 	cmd_enable->enable = 1;
 
-	err = bt_hci_cmd_send(
-		HCI_VS_OPCODE_CMD_QOS_CONN_EVENT_REPORT_ENABLE,
-		buf);
+	err = bt_hci_cmd_send_sync(
+		HCI_VS_OPCODE_CMD_QOS_CONN_EVENT_REPORT_ENABLE, buf, NULL);
 	if (err) {
 		LOG_ERR("Failed to enable HCI VS QoS");
 		return;

--- a/applications/nrf_desktop/src/modules/ble_state.c
+++ b/applications/nrf_desktop/src/modules/ble_state.c
@@ -268,10 +268,9 @@ static void bt_ready(int err)
 	p_cmd_enable = net_buf_add(buf, sizeof(*p_cmd_enable));
 	p_cmd_enable->enable = 1;
 
-	int hci_err = bt_hci_cmd_send(HCI_VS_OPCODE_CMD_LLPM_MODE_SET, buf);
-
-	if (hci_err) {
-		LOG_ERR("Error enabling LLPM (err:%" PRIu8 ")", hci_err);
+	err = bt_hci_cmd_send_sync(HCI_VS_OPCODE_CMD_LLPM_MODE_SET, buf, NULL);
+	if (err) {
+		LOG_ERR("Error enabling LLPM (err: %d)", err);
 	} else {
 		LOG_INF("LLPM enabled");
 	}

--- a/samples/bluetooth/llpm/src/main.c
+++ b/samples/bluetooth/llpm/src/main.c
@@ -226,7 +226,7 @@ static int enable_llpm_mode(void)
 	cmd_enable = net_buf_add(buf, sizeof(*cmd_enable));
 	cmd_enable->enable = true;
 
-	err = bt_hci_cmd_send(HCI_VS_OPCODE_CMD_LLPM_MODE_SET, buf);
+	err = bt_hci_cmd_send_sync(HCI_VS_OPCODE_CMD_LLPM_MODE_SET, buf, NULL);
 	if (err) {
 		printk("Error enabling LLPM %d\n", err);
 		return err;
@@ -317,8 +317,8 @@ static int enable_qos_conn_evt_report(void)
 	cmd_enable = net_buf_add(buf, sizeof(*cmd_enable));
 	cmd_enable->enable = true;
 
-	err = bt_hci_cmd_send(HCI_VS_OPCODE_CMD_QOS_CONN_EVENT_REPORT_ENABLE,
-			      buf);
+	err = bt_hci_cmd_send_sync(
+		HCI_VS_OPCODE_CMD_QOS_CONN_EVENT_REPORT_ENABLE, buf, NULL);
 	if (err) {
 		printk("Could not send command buffer (err %d)\n", err);
 		return err;


### PR DESCRIPTION
Change to using synchronous HCI command send since without it we would
not get the command complete event carrying the status. This means that
the command could fail without the application being notified.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>