### PR TITLE
scripts: hid_configurator: Add substep time verification

### DIFF
--- a/scripts/hid_configurator/led_stream.py
+++ b/scripts/hid_configurator/led_stream.py
@@ -169,6 +169,9 @@ class MusicLedStream():
                                    self.led_effects['SUBSTEP_CNT'])
             )
 
+            if step.substep_time < 0:
+                step.substep_time = 0
+
             self.led_effects['reminder'] = duration - \
                         (step.substep_count * step.substep_time / MS_PER_SEC)
 


### PR DESCRIPTION
Change adds substep time verification for LED effects (should not be lower than 0).