### PR TITLE
samples: event_manager: Remove unexisting event subscription

### DIFF
--- a/samples/event_manager/src/modules/controller.c
+++ b/samples/event_manager/src/modules/controller.c
@@ -9,7 +9,6 @@
 #include "measurement_event.h"
 #include "control_event.h"
 #include "ack_event.h"
-#include "config_event.h"
 
 #define VALUE2_THRESH 15
 #define MODULE controller

--- a/samples/event_manager/src/modules/sensor_simulated.c
+++ b/samples/event_manager/src/modules/sensor_simulated.c
@@ -86,6 +86,5 @@ static bool event_handler(const struct event_header *eh)
 }
 
 EVENT_LISTENER(MODULE, event_handler);
-EVENT_SUBSCRIBE(MODULE, module_state_event);
 EVENT_SUBSCRIBE(MODULE, control_event);
 EVENT_SUBSCRIBE(MODULE, config_event);


### PR DESCRIPTION
Change removes unexisting event subscription and unused include.