### PR TITLE
net: lib: aws_fota: Allow resumption of IN_PROGRESS jobs

### DIFF
--- a/subsys/net/lib/aws_fota/include/aws_fota_json.h
+++ b/subsys/net/lib/aws_fota/include/aws_fota_json.h
@@ -27,12 +27,57 @@ extern "C" {
  */
 #define STATUS_MAX_LEN (12)
 
-int aws_fota_parse_notify_next_document(char *job_document,
-		u32_t payload_len, char *job_id_buf, char *hostname_buf,
-		char *file_path_buf);
+/**
+ * @brief The bit set when the status field in a job execution object is
+ * decoded.
+ */
+#define UPDATE_JOB_EXECUTION_STATUS_DECODED_BIT 1
+/**
+ * @brief The bit set when the Execution Description object is decoded.
+ */
+#define EXECUTION_OBJ_DECODED_BIT 2
 
-int aws_fota_parse_update_job_exec_state_rsp(char *update_rsp_document,
-		size_t payload_len, char *status);
+/**
+ * @brief Parse a given AWS IoT DescribeJobExecution response JSON object.
+ *	  More information on this object can be found at https://docs.aws.amazon.com/iot/latest/developerguide/jobs-api.html#mqtt-describejobexecution
+ *
+ * @param[in] job_document  JSON formated string of an AWS IoT
+ *			    DescribeJobExecution response.
+ * @param[in] payload_len  The length of the provided string.
+ * @param[out] job_id_buf  Output buffer for the "jobId" field from the
+ *			   JobExecution data type.
+ * @param[out] hostname_buf  Output buffer for the "host" field from the Job
+ *			     Document
+ * @param[out] file_path_buf  Output buffer for the "file" field from the Job
+ *			      Document
+ * @param[out] version_number  Version number from the Job Execution data type.
+ *
+ * @return 0 if the Job Execution object is empty, 1 if Job Execution object was
+ *	     correctly decoded, otherwise a negative error code is returned
+ *	     identicating reason of failure.
+ **/
+int aws_fota_parse_DescribeJobExecution_rsp(char *job_document,
+					    u32_t payload_len,
+					    char *job_id_buf,
+					    char *hostname_buf,
+					    char *file_path_buf,
+					    int *version_number);
+
+/**
+ * @brief Parse a Job Execution accepted response object. Returned by a call to
+ *	  https://docs.aws.amazon.com/iot/latest/developerguide/jobs-api.html#mqtt-updatejobexecution
+ *
+ * @param[in] job_document  JSON formated string of an AWS IoT Job execution
+ *			    update response.
+ * @param[in] payload_len  The length of the provided string.
+ * @param[out] status  String with the AWS Job status after an update.
+
+ * @return 0 for an successful parsing or a negative error code identicating
+ *	   reason of failure.
+ */
+int aws_fota_parse_UpdateJobExecution_rsp(char *update_rsp_document,
+					  size_t payload_len,
+					  char *status);
 
 #ifdef __cplusplus
 }

--- a/subsys/net/lib/aws_fota/src/aws_fota_json.c
+++ b/subsys/net/lib/aws_fota/src/aws_fota_json.c
@@ -25,21 +25,6 @@ struct job_document_obj {
 	struct location_obj location;
 };
 
-struct execution_obj {
-	const char *job_id;
-	const char *status;
-	int queued_at;
-	int last_update_at;
-	int version_number;
-	int execution_number;
-	struct job_document_obj job_document;
-};
-
-struct notify_next_obj {
-	int timestamp;
-	struct execution_obj execution;
-};
-
 struct status_details_obj {
 	const char *next_state;
 };
@@ -50,6 +35,23 @@ struct execution_state_obj {
 	int version_number;
 };
 
+struct execution_obj {
+	const char *job_id;
+	const char *status;
+	struct status_details_obj status_details;
+	int queued_at;
+	int last_update_at;
+	int version_number;
+	int execution_number;
+	struct job_document_obj job_document;
+};
+
+struct desc_job_execution_obj {
+	const char *client_token;
+	int timestamp;
+	struct execution_obj execution;
+};
+
 static const struct json_obj_descr location_obj_descr[] = {
 	JSON_OBJ_DESCR_PRIM(struct location_obj, protocol, JSON_TOK_STRING),
 	JSON_OBJ_DESCR_PRIM(struct location_obj, host, JSON_TOK_STRING),
@@ -57,59 +59,45 @@ static const struct json_obj_descr location_obj_descr[] = {
 };
 
 static const struct json_obj_descr job_document_obj_descr[] = {
-	JSON_OBJ_DESCR_PRIM(struct job_document_obj,
-			    operation,
+	JSON_OBJ_DESCR_PRIM(struct job_document_obj, operation,
 			    JSON_TOK_STRING),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct job_document_obj,
-				  "fwversion",
-				  fw_version,
-				  JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct job_document_obj, "fwversion",
+				  fw_version, JSON_TOK_STRING),
 	JSON_OBJ_DESCR_PRIM(struct job_document_obj, size, JSON_TOK_NUMBER),
-	JSON_OBJ_DESCR_OBJECT(struct job_document_obj,
-			      location,
+	JSON_OBJ_DESCR_OBJECT(struct job_document_obj, location,
 			      location_obj_descr),
 };
 
+static const struct json_obj_descr status_details_obj_descr[] = {
+	JSON_OBJ_DESCR_PRIM_NAMED(struct status_details_obj, "nextState",
+				  next_state, JSON_TOK_STRING),
+};
+
 static const struct json_obj_descr execution_obj_descr[] = {
-	JSON_OBJ_DESCR_PRIM_NAMED(struct execution_obj,
-				  "jobId",
-				  job_id,
+	JSON_OBJ_DESCR_PRIM_NAMED(struct execution_obj, "jobId", job_id,
 				  JSON_TOK_STRING),
 	JSON_OBJ_DESCR_PRIM(struct execution_obj, status, JSON_TOK_STRING),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct execution_obj,
-				  "queuedAt",
-				  queued_at,
+	JSON_OBJ_DESCR_OBJECT_NAMED(struct execution_obj, "statusDetails",
+				    status_details, status_details_obj_descr),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct execution_obj, "queuedAt", queued_at,
 				  JSON_TOK_NUMBER),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct execution_obj,
-				  "lastUpdatedAt",
-				  last_update_at,
-				  JSON_TOK_NUMBER),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct execution_obj,
-				  "versionNumber",
-				  version_number,
-				  JSON_TOK_NUMBER),
-	JSON_OBJ_DESCR_PRIM_NAMED(struct execution_obj,
-				  "executionNumber",
-				  execution_number,
-				  JSON_TOK_NUMBER),
-	JSON_OBJ_DESCR_OBJECT_NAMED(struct execution_obj,
-				    "jobDocument",
-				    job_document,
-				    job_document_obj_descr),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct execution_obj, "lastUpdatedAt",
+				  last_update_at, JSON_TOK_NUMBER),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct execution_obj, "versionNumber",
+				  version_number, JSON_TOK_NUMBER),
+	JSON_OBJ_DESCR_PRIM_NAMED(struct execution_obj, "executionNumber",
+				  execution_number, JSON_TOK_NUMBER),
+	JSON_OBJ_DESCR_OBJECT_NAMED(struct execution_obj, "jobDocument",
+				    job_document, job_document_obj_descr),
 };
 
-static const struct json_obj_descr notify_next_obj_descr[] = {
-	JSON_OBJ_DESCR_PRIM(struct notify_next_obj, timestamp, JSON_TOK_NUMBER),
-	JSON_OBJ_DESCR_OBJECT(struct notify_next_obj,
-			      execution,
+static const struct json_obj_descr desc_job_execution_obj_descr[] = {
+	JSON_OBJ_DESCR_PRIM_NAMED(struct desc_job_execution_obj, "clientToken",
+				  client_token, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_PRIM(struct desc_job_execution_obj, timestamp,
+			    JSON_TOK_NUMBER),
+	JSON_OBJ_DESCR_OBJECT(struct desc_job_execution_obj, execution,
 			      execution_obj_descr),
-};
-
-static const struct json_obj_descr status_details_obj_descr[] = {
-	JSON_OBJ_DESCR_PRIM_NAMED(struct status_details_obj,
-				  "nextState",
-				  next_state,
-				  JSON_TOK_STRING),
 };
 
 struct update_rsp_obj {
@@ -122,20 +110,14 @@ struct update_rsp_obj {
 
 static const struct json_obj_descr update_job_exec_stat_rsp_descr[] = {
 	JSON_OBJ_DESCR_PRIM_NAMED(struct update_rsp_obj, "status",
-			status, JSON_TOK_STRING),
-
-	JSON_OBJ_DESCR_OBJECT_NAMED(struct update_rsp_obj,
-				    "statusDetails",
-				    status_details,
-				    status_details_obj_descr),
-
+				  status, JSON_TOK_STRING),
+	JSON_OBJ_DESCR_OBJECT_NAMED(struct update_rsp_obj, "statusDetails",
+				    status_details, status_details_obj_descr),
 	JSON_OBJ_DESCR_PRIM_NAMED(struct update_rsp_obj, "expectedVersion",
-			expected_version, JSON_TOK_STRING),
-
+				  expected_version, JSON_TOK_STRING),
 	JSON_OBJ_DESCR_PRIM(struct update_rsp_obj, timestamp, JSON_TOK_NUMBER),
-
 	JSON_OBJ_DESCR_PRIM_NAMED(struct update_rsp_obj, "clientToken",
-			client_token, JSON_TOK_STRING),
+				  client_token, JSON_TOK_STRING),
 };
 
 /**@brief Copy max maxlen bytes from src to dst. Insert null-terminator.
@@ -150,54 +132,92 @@ static void strncpy_nullterm(char *dst, const char *src, size_t maxlen)
 	}
 }
 
-int aws_fota_parse_update_job_exec_state_rsp(char *update_rsp_document,
-		size_t payload_len, char *status)
+int aws_fota_parse_UpdateJobExecution_rsp(char *update_rsp_document,
+					  size_t payload_len, char *status)
 {
+	if (update_rsp_document == NULL || status == NULL) {
+		return -EINVAL;
+	}
+
 	struct update_rsp_obj rsp;
 
 	int ret = json_obj_parse(update_rsp_document, payload_len,
 			update_job_exec_stat_rsp_descr,
 			ARRAY_SIZE(update_job_exec_stat_rsp_descr), &rsp);
 
-	/* Check if the status field(1st field) of the object has been parsed */
-	if (ret & 0x01) {
-		strncpy_nullterm(status, rsp.status, STATUS_MAX_LEN);
+	if (ret < 0) {
+		return ret;
 	}
 
-	return ret;
+	/* Check if the status field(1st field) of the object has been parsed */
+	if (ret & BIT(UPDATE_JOB_EXECUTION_STATUS_DECODED_BIT)) {
+		strncpy_nullterm(status, rsp.status, STATUS_MAX_LEN);
+	} else {
+		return -ENODATA;
+	}
+
+	return 0;
 }
 
-int aws_fota_parse_notify_next_document(char *job_document,
-		u32_t payload_len, char *job_id_buf, char *hostname_buf,
-		char *file_path_buf)
+int aws_fota_parse_DescribeJobExecution_rsp(char *job_document,
+					   u32_t payload_len,
+					   char *job_id_buf,
+					   char *hostname_buf,
+					   char *file_path_buf,
+					   int *version_number)
 {
-	struct notify_next_obj job;
-	struct job_document_obj *job_doc_obj;
-
-	int ret = json_obj_parse(job_document,
-				 payload_len,
-				 notify_next_obj_descr,
-				 ARRAY_SIZE(notify_next_obj_descr),
-				 &job);
-	job_doc_obj = &job.execution.job_document;
-
-	/* Check if the execution field of the object has been parsed */
-	if (ret & 0x02) {
-		if (job.execution.job_id != 0) {
-			strncpy_nullterm(job_id_buf, job.execution.job_id,
-				      AWS_JOBS_JOB_ID_MAX_LEN);
-		}
-		if (job_doc_obj->location.host != 0) {
-			strncpy_nullterm(hostname_buf,
-					 job_doc_obj->location.host,
-					 CONFIG_AWS_FOTA_HOSTNAME_MAX_LEN);
-		}
-		if (job_doc_obj->location.path != 0) {
-			strncpy_nullterm(file_path_buf,
-					 job_doc_obj->location.path,
-					  CONFIG_AWS_FOTA_FILE_PATH_MAX_LEN);
-		}
-
+	if (job_document == NULL
+	    || job_id_buf == NULL
+	    || hostname_buf == NULL
+	    || file_path_buf == NULL
+	    || version_number == NULL) {
+		return -EINVAL;
 	}
-	return ret;
+
+	struct desc_job_execution_obj root_obj;
+	struct job_document_obj *job_doc_obj;
+	struct execution_obj *exec_obj;
+
+	int ret = json_obj_parse(job_document, payload_len,
+				 desc_job_execution_obj_descr,
+				 ARRAY_SIZE(desc_job_execution_obj_descr),
+				 &root_obj);
+
+	if (ret < 0) {
+		return ret;
+	}
+
+	if (!(ret & BIT(EXECUTION_OBJ_DECODED_BIT))) {
+		/* No execution object in JSON */
+		return 0;
+	}
+
+	/* Check if the execution field of the object has been parsed. This
+	 * test is currently non-functional as Zephyr's JSON parser does not
+	 * populate fields as NULL in nested structure if the field in the
+	 * nested structure is not found.
+	 */
+	exec_obj = &root_obj.execution;
+	job_doc_obj = &exec_obj->job_document;
+	if (exec_obj->job_id != 0
+	    && exec_obj->version_number != 0
+	    && job_doc_obj->location.host != 0
+	    && job_doc_obj->location.path != 0) {
+		strncpy_nullterm(job_id_buf, exec_obj->job_id,
+				AWS_JOBS_JOB_ID_MAX_LEN);
+		*version_number = exec_obj->version_number;
+		strncpy_nullterm(hostname_buf,
+				job_doc_obj->location.host,
+				CONFIG_AWS_FOTA_HOSTNAME_MAX_LEN);
+		strncpy_nullterm(file_path_buf,
+				job_doc_obj->location.path,
+				CONFIG_AWS_FOTA_FILE_PATH_MAX_LEN);
+	} else {
+		/* A field was not decoded correctly which means we are missing
+		 * data.
+		 */
+		return -ENODATA;
+	}
+
+	return 1;
 }

--- a/tests/subsys/net/lib/aws_fota/aws_fota_json/src/main.c
+++ b/tests/subsys/net/lib/aws_fota/aws_fota_json/src/main.c
@@ -9,8 +9,9 @@
 #include <ztest.h>
 #include <aws_fota_json.h>
 
-static void test_notify_next(void)
+static void test_parse_job_execution(void)
 {
+	int expected_version_number = 1;
 	char expected_job_id[] = "9b5caac6-3e8a-45dd-9273-c1b995762f4a";
 	char expected_hostname[] = "fota-update-bucket.s3.eu-central-1.amazonaws.com";
 	char expected_file_path[] = "/update.bin?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAWXEL53DXIU7W72AE%2F20190606%2Feu-central-1%2Fs3%2Faws4_request&X-Amz-Date=20190606T081505Z&X-Amz-Expires=604800&X-Amz-Signature=913e00b97efe5565a901df4ff0b87e4878a406941d711f59d45915035989adcc&X-Amz-SignedHeaders=host";
@@ -20,16 +21,53 @@ static void test_notify_next(void)
 	char job_id[100];
 	char hostname[100];
 	char file_path[1000];
+	int version_number;
 
 	/* Memset to ensure correct null-termination */
 	memset(job_id, 0xff, sizeof(job_id));
 	memset(hostname, 0xff, sizeof(hostname));
 	memset(file_path, 0xff, sizeof(file_path));
 
-	ret = aws_fota_parse_notify_next_document(encoded, sizeof(encoded) - 1,
-			job_id, hostname, file_path);
+	ret = aws_fota_parse_DescribeJobExecution_rsp(encoded,
+						      sizeof(encoded) - 1,
+						      job_id, hostname,
+						      file_path,
+						      &version_number);
 
+	zassert_equal(ret, 1, NULL);
 	zassert_true(!strcmp(job_id, expected_job_id), NULL);
+	zassert_equal(version_number, expected_version_number, NULL);
+	zassert_true(!strcmp(hostname, expected_hostname), NULL);
+	zassert_true(!strcmp(file_path, expected_file_path), NULL);
+}
+
+static void test_parse_job_execution_missing_field(void)
+{
+	char expected_job_id[] = "9b5caac6-3e8a-45dd-9273-c1b995762f4a";
+	char expected_hostname[] = "fota-update-bucket.s3.eu-central-1.amazonaws.com";
+	char expected_file_path[] = "/update.bin?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAWXEL53DXIU7W72AE%2F20190606%2Feu-central-1%2Fs3%2Faws4_request&X-Amz-Date=20190606T081505Z&X-Amz-Expires=604800&X-Amz-Signature=913e00b97efe5565a901df4ff0b87e4878a406941d711f59d45915035989adcc&X-Amz-SignedHeaders=host";
+
+	int ret;
+	char job_id[100];
+	char hostname[100];
+	char file_path[1000];
+	int version_number;
+
+	char encoded[] = "{\"timestamp\":1559808907,\"execution\":{\"status\":\"QUEUED\",\"queuedAt\":1559808906,\"lastUpdatedAt\":1559808906,\"versionNumber\":1,\"executionNumber\":1,\"jobDocument\":{\"operation\":\"app_fw_update\",\"fwversion\":\"2\",\"size\":181124,\"location\":{\"protocol\":\"https:\",\"host\":\"fota-update-bucket.s3.eu-central-1.amazonaws.com\",\"path\":\"/update.bin?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAWXEL53DXIU7W72AE%2F20190606%2Feu-central-1%2Fs3%2Faws4_request&X-Amz-Date=20190606T081505Z&X-Amz-Expires=604800&X-Amz-Signature=913e00b97efe5565a901df4ff0b87e4878a406941d711f59d45915035989adcc&X-Amz-SignedHeaders=host\"}}}}";
+/* Memset to ensure correct null-termination */
+	memset(job_id, 0xff, sizeof(job_id));
+	memset(hostname, 0xff, sizeof(hostname));
+	memset(file_path, 0xff, sizeof(file_path));
+
+	ret = aws_fota_parse_DescribeJobExecution_rsp(encoded,
+						      sizeof(encoded) - 1,
+						      job_id, hostname,
+						      file_path,
+						      &version_number);
+
+	zassert_equal(ret, -ENODATA, NULL);
+	zassert_true(!strcmp(job_id, expected_job_id), NULL);
+	zassert_equal(version_number, 1, NULL);
 	zassert_true(!strcmp(hostname, expected_hostname), NULL);
 	zassert_true(!strcmp(file_path, expected_file_path), NULL);
 }
@@ -46,7 +84,7 @@ static void test_update_job_longer_than_max(void)
 
 	memset(status, 0xff, sizeof(status));
 
-	ret = aws_fota_parse_update_job_exec_state_rsp(encoded,
+	ret = aws_fota_parse_UpdateJobExecution_rsp(encoded,
 			sizeof(encoded) - 1, status);
 	zassert_true(!strcmp(status, expected_status), NULL);
 }
@@ -59,12 +97,16 @@ static void test_timestamp_only(void)
 	char hostname[100];
 	char file_path[100];
 	char encoded[] = "{\"timestamp\":1559808907}";
+	int version_number;
 
-	ret = aws_fota_parse_notify_next_document(encoded, sizeof(encoded) - 1,
-			job_id, hostname, file_path);
+	ret = aws_fota_parse_DescribeJobExecution_rsp(encoded,
+						      sizeof(encoded) - 1,
+						      job_id,
+						      hostname,
+						      file_path,
+						      &version_number);
 
-	zassert_equal(ret, 1,
-		     "Timestamp decoded correctly");
+	zassert_equal(ret, 0, "Timestamp decoded correctly");
 }
 
 static void test_update_job_exec_rsp_minimal(void)
@@ -73,11 +115,12 @@ static void test_update_job_exec_rsp_minimal(void)
 	char status[100];
 	int ret;
 
-	ret = aws_fota_parse_update_job_exec_state_rsp(encoded,
-			sizeof(encoded) - 1, status);
+	ret = aws_fota_parse_UpdateJobExecution_rsp(encoded,
+						    sizeof(encoded) - 1,
+						    status);
 
 	/* Only two last fields are set */
-	zassert_equal(ret, 0b11000, "All fields decoded correctly");
+	zassert_equal(ret, -ENODATA, "All fields decoded correctly");
 }
 
 static void test_update_job_exec_rsp(void)
@@ -89,8 +132,9 @@ static void test_update_job_exec_rsp(void)
 
 	memset(status, 0xff, sizeof(status));
 
-	ret = aws_fota_parse_update_job_exec_state_rsp(encoded,
-			sizeof(encoded) - 1, status);
+	ret = aws_fota_parse_UpdateJobExecution_rsp(encoded,
+						    sizeof(encoded) - 1,
+						    status);
 	zassert_true(!strcmp(status, expected_status), NULL);
 }
 
@@ -102,7 +146,7 @@ void test_main(void)
 			 ztest_unit_test(test_update_job_exec_rsp),
 			 ztest_unit_test(test_update_job_longer_than_max),
 			 ztest_unit_test(test_timestamp_only),
-			 ztest_unit_test(test_notify_next)
+			 ztest_unit_test(test_parse_job_execution)
 			 );
 
 	ztest_run_test_suite(lib_json_test);


### PR DESCRIPTION
* Improved parsing of the JSON object of a Job so that it can decode
more types of Job Execution objects.
* Allow an `IN_PROGRESS` job to be picked up and resumed by the device.
* Refactor parts of the `aws_fota.c` to make each function more
readable.
* Added unit test for parsing out the document version number
* Added parsing of document version number used for updating the job
document.

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>