### PR TITLE
net: lib: nrf_cloud: revert log severity

### DIFF
--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_fsm.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_fsm.c
@@ -213,7 +213,7 @@ static int state_ua_pin_complete(void)
 
 static int drop_event_handler(const struct nct_evt *nct_evt)
 {
-	LOG_ERR("Dropping FSM transition %d, current state %d", nct_evt->type,
+	LOG_DBG("Dropping FSM transition %d, current state %d", nct_evt->type,
 		nfsm_get_current_state());
 	return 0;
 }


### PR DESCRIPTION
Revert log severity to debug for dropped state transition log message.
TG91-133

Signed-off-by: Justin Morton <justin.morton@nordicsemi.no>