### PR TITLE
applications: nrf_desktop: Allow to stay on when idle

### DIFF
--- a/applications/nrf_desktop/src/modules/Kconfig.power_manager
+++ b/applications/nrf_desktop/src/modules/Kconfig.power_manager
@@ -24,6 +24,14 @@ config DESKTOP_POWER_MANAGER_CONSTLAT
 	  interrupts. This reduces interrupt propagation time but increases
 	  power consumption.
 
+config DESKTOP_POWER_MANAGER_STAY_ON
+	bool "Stay on while no connections"
+	help
+	  If disabled the device will switch SoC to OFF mode after power
+	  manager timeout is done. If enabled the device will stay on
+	  but remain idle. If the device is connected it will always stay on
+	  and maintain the connection, regardless of the setting.
+
 config DESKTOP_POWER_MANAGER_TIMEOUT
 	int "Power down timeout [s]"
 	default 120

--- a/applications/nrf_desktop/src/modules/power_manager.c
+++ b/applications/nrf_desktop/src/modules/power_manager.c
@@ -143,7 +143,8 @@ static bool event_handler(const struct event_header *eh)
 
 			profiler_term();
 
-			if (connection_count > 0) {
+			if (IS_ENABLED(CONFIG_DESKTOP_POWER_MANAGER_STAY_ON) ||
+			    (connection_count > 0)) {
 				/* Connection is active, keep OS alive. */
 				power_state = POWER_STATE_SUSPENDED;
 				LOG_WRN("System suspended");
@@ -208,7 +209,8 @@ static bool event_handler(const struct event_header *eh)
 		}
 
 		if (!usb_connected && (connection_count == 0) &&
-		    (power_state == POWER_STATE_SUSPENDED)) {
+		    (power_state == POWER_STATE_SUSPENDED) &&
+		    !IS_ENABLED(CONFIG_DESKTOP_POWER_MANAGER_STAY_ON)) {
 			/* Last peer disconnected during standby.
 			 * Turn system off.
 			 */


### PR DESCRIPTION
Allow the device to stay on even if there are no active connections.
If disabled the device will switch SoC to off mode.

Jira:DESK-776

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>