### PR TITLE
bluetooth: controller: Fix implicit function declaration

### DIFF
--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -80,15 +80,22 @@ BUILD_ASSERT(!IS_ENABLED(CONFIG_BT_PERIPHERAL) ||
 
 static u8_t ble_controller_mempool[MEMPOOL_SIZE];
 
+#if IS_ENABLED(CONFIG_BT_CTLR_ASSERT_HANDLER)
+extern void bt_ctlr_assert_handle(char *file, u32_t line);
+
 void blectlr_assertion_handler(const char *const file, const u32_t line)
 {
-#ifdef CONFIG_BT_CTLR_ASSERT_HANDLER
-	bt_ctlr_assert_handle(file, line);
-#else
+	bt_ctlr_assert_handle((char *) file, line);
+}
+
+#else /* !IS_ENABLED(CONFIG_BT_CTLR_ASSERT_HANDLER) */
+void blectlr_assertion_handler(const char *const file, const u32_t line)
+{
 	BT_ERR("BleCtlr ASSERT: %s, %d", log_strdup(file), line);
 	k_oops();
-#endif
 }
+#endif /* IS_ENABLED(CONFIG_BT_CTLR_ASSERT_HANDLER) */
+
 
 static int cmd_handle(struct net_buf *cmd)
 {


### PR DESCRIPTION
When CONFIG_BT_CTLR_ASSERT_HANDLER is defined, some samples expect
bt_ctlr_assert_handle() to be declared. This function is defined in
subsys/bluetooth/controller/hal/debug.h for Zephyr LL's, but this header
should not be used by BT_LL_NRFXLIB.