### PR TITLE
multi image: support built-in CMake flags instead of proprietary

### DIFF
--- a/cmake/multi_image.cmake
+++ b/cmake/multi_image.cmake
@@ -87,6 +87,7 @@ function(add_child_image_from_source name sourcedir)
   list(APPEND
     SHARED_MULTI_IMAGE_VARIABLES
     CMAKE_BUILD_TYPE
+    CMAKE_VERBOSE_MAKEFILE
     BOARD_DIR
     ZEPHYR_MODULES
     ZEPHYR_EXTRA_MODULES
@@ -181,14 +182,20 @@ function(add_child_image_from_source name sourcedir)
   # Increase the scope of this variable to make it more available
   set(${name}_KERNEL_HEX_NAME ${${name}_KERNEL_HEX_NAME} CACHE STRING "" FORCE)
 
+  if(MULTI_IMAGE_DEBUG_MAKEFILE AND "${CMAKE_GENERATOR}" STREQUAL "Ninja")
+    set(multi_image_build_args "-d" "${MULTI_IMAGE_DEBUG_MAKEFILE}")
+  endif()
+  if(MULTI_IMAGE_DEBUG_MAKEFILE AND "${CMAKE_GENERATOR}" STREQUAL "Unix Makefiles")
+    set(multi_image_build_args "--debug=${MULTI_IMAGE_DEBUG_MAKEFILE}")
+  endif()
+
   include(ExternalProject)
   ExternalProject_Add(${name}_subimage
     SOURCE_DIR ${sourcedir}
     BINARY_DIR ${CMAKE_BINARY_DIR}/${name}
     BUILD_BYPRODUCTS ${${name}_BUILD_BYPRODUCTS} # Set by shared_vars.cmake
     CONFIGURE_COMMAND ""
-    BUILD_COMMAND ${CMAKE_MAKE_PROGRAM}
-    ${EXTRA_MULTI_IMAGE_BUILD_OPT} # E.g. -v
+    BUILD_COMMAND ${CMAKE_COMMAND} --build . -- ${multi_image_build_args}
     INSTALL_COMMAND ""
     BUILD_ALWAYS True
     )

--- a/doc/nrf/gs_modifying.rst
+++ b/doc/nrf/gs_modifying.rst
@@ -138,3 +138,18 @@ The documentation for each :ref:`configuration option <configuration_options>` a
 .. important::
    All changes to the :file:`.config` file are lost when you clean your build directory.
    You can save it to another location, but you must then manually copy it back to your build directory.
+
+.. _cmake_options:
+
+Providing CMake options
+***********************
+
+You can provide additional options for building your application to the CMake process, which can be useful, for example, to switch between different build scenarios.
+These options are specified when CMake is run, thus not during the actual build, but when configuring the build.
+
+If you work with SES, this configuration takes place when you open an |NCS| project, and you must therefore provide the CMake options before you open the project.
+To specify CMake options, click :guilabel:`Tools` > :guilabel:`Options`, select the :guilabel:`nRF Connect` tab, and specify a value for :guilabel:`Additional CMake options`.
+
+If you work on the command line, pass the additional options to the ``west build`` command.
+The options must be added after a ``--`` at the end of the command.
+See :ref:`zephyr:west-building-cmake-args` for more information.

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -187,6 +187,9 @@
 
 .. _`CMake documentation`: https://cmake.org/cmake/help/latest/
 
+.. _`VERBOSE`: https://cmake.org/cmake/help/latest/envvar/VERBOSE.html
+.. _`CMAKE_BUILD_PARALLEL_LEVEL`: https://cmake.org/cmake/help/latest/envvar/CMAKE_BUILD_PARALLEL_LEVEL.html
+
 .. _`AWS IoT Developer Guide`: https://docs.aws.amazon.com/iot/latest/developerguide/what-is-aws-iot.html
 .. _`AWS IoT MQTT`: https://docs.aws.amazon.com/iot/latest/developerguide/mqtt.html
 .. _`AWS IoT Developer Guide: Basic Policy Variables`: https://docs.aws.amazon.com/iot/latest/developerguide/basic-policy-variables.html

--- a/doc/nrf/ug_multi_image.rst
+++ b/doc/nrf/ug_multi_image.rst
@@ -168,8 +168,6 @@ For example, to change the ``CONF_FILE`` variable for the MCUboot image and the 
 You can extend the CMake command that is used to create the child images by adding flags to the CMake variable ``EXTRA_MULTI_IMAGE_CMAKE_ARGS``.
 For example, add ``--trace-expand`` to that variable to output more debug information.
 
-Similarly, you can modify the options for building the child image by adding them to the CMake variable ``EXTRA_MULTI_IMAGE_BUILD_OPT``.
-
 Child image targets
 ===================
 
@@ -181,6 +179,54 @@ This means that to run menuconfig, for example, you invoke the ``menuconfig`` ta
 
 You can also invoke any child target directly from its build directory.
 Child build directories are located at the root of the parent's build directory.
+
+Controlling the build process
+=============================
+
+The child image is built using CMake's build command ``cmake --build``.
+This mechanism allows additional control of the build process through CMake.
+
+CMake options
+-------------
+
+The following CMake options are propagated from the CMake command of the parent image to the CMake command of the child image:
+
+* ``CMAKE_BUILD_TYPE``
+* ``CMAKE_VERBOSE_MAKEFILE``
+
+You can add other CMake options to a specific child image in the same way as you can set `image-specific variables <Image-specific variables>`_.
+For example, add ``-Dmcuboot_CMAKE_VERBOSE_MAKEFILE`` to the parent's CMake command to build the ``mcuboot`` child image with verbose output.
+
+To enable additional debug information for the multi-image build command, set the CMake option ``MULTI_IMAGE_DEBUG_MAKEFILE`` to the desired debug mode.
+For example, add ``-DMULTI_IMAGE_DEBUG_MAKEFILE=explain`` to log the reasons why a command was executed.
+
+See :ref:`cmake_options` for instructions on how to specify these CMake options for the build.
+
+CMake environment variables
+---------------------------
+
+Unlike CMake options, CMake environment variables allow you to control the build process without re-invoking CMake.
+
+You can use the CMake environment variables `VERBOSE`_ and `CMAKE_BUILD_PARALLEL_LEVEL`_ to control the verbosity and the number of parallel jobs for a build.
+
+When using |SES|, you must set these environment variables before starting SES, and they will apply only to the build of the child images.
+On the command line, you must set them before invoking ``west``, and they will apply to both the parent image and the child images.
+For example, to build with verbose output and one parallel job, use the following commands (where *board_name* is the name of the board for which you are building):
+
+* Linux/macOS:
+
+     .. parsed-literal::
+        :class: highlight
+
+        $ VERBOSE=True CMAKE_BUILD_PARALLEL_LEVEL=1 west build -b *board_name*
+
+* Windows:
+
+     .. parsed-literal::
+        :class: highlight
+
+        > set VERBOSE=True && set CMAKE_BUILD_PARALLEL_LEVEL=1 && west build -b *board_name*
+
 
 Memory placement
 ****************


### PR DESCRIPTION
https://github.com/NordicPlayground/fw-nrfconnect-nrf/pull/1508 was merged in order to continue with Zephyr upmerge.

However, there was still a discussion ongoing regarding NCS specific CMake flags (`EXTRA_MULTI_IMAGE_BUILD_OPT`) vs. built-in support in CMake / make / ninja (`CMAKE_VERBOSE_MAKEFILE`).

This commit propose to use the built-in CMake flag `CMAKE_VERBOSE_MAKEFILE` to support setting verbosity on child images, as this is already a documented flag in CMake:
https://cmake.org/cmake/help/latest/variable/CMAKE_VERBOSE_MAKEFILE.html

This flag is supported both for `make` and `ninja` builds.

This allows users to use: 
`cmake -DCMAKE_VERBOSE_MAKEFILE=True` 
To increase verbosity on all child images

If user prefers to just increase verbosity on a single image, the following is of course also a possibility:
`ninja -C <path-to-child-image> -v` or `make -C <path-to-child-image> -v` 

As those options already exists as features in CMake / ninja / make, I suggest we follow existing CMake arguments.

