### PR TITLE
west.yml: remove civetweb module

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -29,8 +29,6 @@ manifest:
       url-base: https://github.com/ThrowTheSwitch
     - name: armmbed
       url-base: https://github.com/ARMmbed
-    - name: civetweb
-      url-base: https://github.com/civetweb
 
   # The list of external projects for the nRF Connect SDK.
   #
@@ -92,10 +90,6 @@ manifest:
     # manager patchset. Please report any issues.
     #
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/scripts/partition_manager/partition_manager.html
-    - name: civetweb
-      path: modules/lib/civetweb
-      remote: civetweb
-      revision: 99129c5efc907ea613c4b73ccff07581feb58a7a
     - name: fatfs
       path: modules/fs/fatfs
       remote: zephyrproject


### PR DESCRIPTION
Hotfix for NCS installation on Windows using Git 2.24, which rejects
the clone of the civetweb repository due to its containing a tree with
a backslash (\) character.
