### PR TITLE
lib: at_host: Preserve CR and LF from serial

### DIFF
--- a/lib/at_host/Kconfig
+++ b/lib/at_host/Kconfig
@@ -42,7 +42,7 @@ config AT_HOST_UART_INIT_TIMEOUT
 
 choice
 	prompt "Termination Mode"
-	default CR_TERMINATION
+	default LF_TERMINATION
 	depends on AT_HOST_LIBRARY
 	help
 		Sets the termination ending from the serial terminal
@@ -51,6 +51,9 @@ choice
 		-  CR Termination
 		-  LF Termination
 		-  CR+LF Termination
+
+		WARNING! Some AT commands (like AT+CMGS) use CR internally.
+		Selecting CR Termination will render those commands unavailable.
 	config NULL_TERMINATION
 		bool "NULL Termination"
 	config CR_TERMINATION


### PR DESCRIPTION
Changes the serial parsing to preserve CR and LF, when they do not
terminate the message.

Fixes TG91-139.

The cr_state variable is no longer needed when the CR and LF symbols are recorded into the buffer, and has been removed.

Default termination is changed to LF, rather than CR. This is needed for SMS functionality, because the SMS AT command requires a CR in the middle. This will break clients that do not send LF. Clients that use LF or CR+LF (Including nRF Connect LTE Link Monitor) still work as expected.