### PR TITLE
sample: lwm2m_client: Fix modem_info failure

### DIFF
--- a/lib/modem_info/Kconfig
+++ b/lib/modem_info/Kconfig
@@ -33,6 +33,15 @@ config MODEM_INFO_ADD_NETWORK
 	  Add the network information to the returned
 	  device JSON object.
 
+config MODEM_INFO_ADD_DATE_TIME
+	bool "Read the real-time clock value from the modem"
+	depends on MODEM_INFO_ADD_NETWORK
+	default y
+	help
+	  Inlcude the real-time clock value read from the modem in the network
+	  information. Note, that if no time information is available in the
+	  network, the modem info readout might fail.
+
 config MODEM_INFO_ADD_SIM
 	bool "Read the SIM card information from the modem"
 	default y

--- a/lib/modem_info/modem_info_params.c
+++ b/lib/modem_info/modem_info_params.c
@@ -144,7 +144,10 @@ int modem_info_params_get(struct modem_param_info *modem)
 		ret += modem_data_get(&modem->network.lte_mode);
 		ret += modem_data_get(&modem->network.nbiot_mode);
 		ret += modem_data_get(&modem->network.gps_mode);
-		ret += modem_data_get(&modem->network.date_time);
+
+		if (IS_ENABLED(CONFIG_MODEM_INFO_ADD_DATE_TIME)) {
+			ret += modem_data_get(&modem->network.date_time);
+		}
 
 		ret += mcc_mnc_parse(&modem->network.current_operator,
 				&modem->network.mcc,

--- a/samples/nrf9160/lwm2m_client/prj.conf
+++ b/samples/nrf9160/lwm2m_client/prj.conf
@@ -89,6 +89,7 @@ CONFIG_BSD_LIBRARY=y
 
 # Modem info
 CONFIG_MODEM_INFO=y
+CONFIG_MODEM_INFO_ADD_DATE_TIME=n
 
 # Library for buttons and LEDs
 CONFIG_DK_LIBRARY=y


### PR DESCRIPTION
modem_info module issues `AT+CCLK?` command, which has proven to fail
if sent to early after establishing a LTE connection. Fix the issue by
adding small delay before running the modem_info_params_get function.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>