### PR TITLE
Add report back offset/progress to AWS Job document

### DIFF
--- a/include/net/fota_download.h
+++ b/include/net/fota_download.h
@@ -30,10 +30,22 @@ extern "C" {
  * @brief FOTA download event IDs.
  */
 enum fota_download_evt_id {
+	/** FOTA download progress report. */
+	FOTA_DOWNLOAD_EVT_PROGRESS,
 	/** FOTA download finished. */
 	FOTA_DOWNLOAD_EVT_FINISHED,
 	/** FOTA download error. */
 	FOTA_DOWNLOAD_EVT_ERROR,
+};
+
+/**
+ * @brief FOTA download event data.
+ */
+struct fota_download_evt {
+	enum fota_download_evt_id id;
+#ifdef CONFIG_FOTA_DOWNLOAD_PROGRESS_EVT
+	int offset;
+#endif
 };
 
 /**
@@ -42,7 +54,7 @@ enum fota_download_evt_id {
  * @param event_id Event ID.
  *
  */
-typedef void (*fota_download_callback_t)(enum fota_download_evt_id evt_id);
+typedef void (*fota_download_callback_t)(const struct fota_download_evt *evt);
 
 /**@brief Initialize the firmware over-the-air download library.
  *

--- a/subsys/dfu/src/dfu_target_modem.c
+++ b/subsys/dfu/src/dfu_target_modem.c
@@ -174,6 +174,7 @@ int dfu_target_modem_write(const void *const buf, size_t len)
 
 	sent = send(fd, buf, len, 0);
 	if (sent > 0) {
+		offset += len;
 		return 0;
 	}
 

--- a/subsys/net/lib/fota_download/Kconfig
+++ b/subsys/net/lib/fota_download/Kconfig
@@ -11,9 +11,13 @@ menuconfig FOTA_DOWNLOAD
 
 if (FOTA_DOWNLOAD)
 
-menuconfig FOTA_SOCKET_RETRIES
+config FOTA_SOCKET_RETRIES
 	int "Number of retries for socket-related download issues"
 	default 2
+
+config FOTA_DOWNLOAD_PROGRESS_EVT
+	bool "Emit progress event upon receiving a download fragment"
+	default y
 
 module=FOTA_DOWNLOAD
 module-dep=LOG


### PR DESCRIPTION
Working functionality to report back through MQTT the offset(progress) when downloading an firmware upgrade file back through the update job execution API. It is emitted through the `statusDetails` field in the JSON object.

```JSON
{
    "status":"IN_PROGRESS",
    "statusDetails": {
        "progress":"120"
    },
    "expectedVersion":"1",
    "clientToken":""
}
```

It's currently not the cleanest solution as it's using a state variable for synchronization to check whether an update to the `job execution` has been accepted combined with a wait state which `k_sleeps` to yield so that the MQTT client thread/Download thread is able to run.