### PR TITLE
applications: asset_tracker: AT commands from nRF Cloud

### DIFF
--- a/applications/asset_tracker/src/cloud_codec/cloud_codec.c
+++ b/applications/asset_tracker/src/cloud_codec/cloud_codec.c
@@ -8,6 +8,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <ctype.h>
 #include <zephyr.h>
 #include <zephyr/types.h>
 #include <net/cloud.h>
@@ -165,7 +166,16 @@ static CMD_NEW_GROUP(group_data, CLOUD_CMD_GROUP_DATA, CMD_ARRAY(
 	)
 );
 
-struct cmd *cmd_groups[] = {&group_cfg_set, &group_get, &group_data};
+static CMD_NEW_GROUP(group_command, CLOUD_CMD_GROUP_COMMAND, CMD_ARRAY(
+		CMD_NEW_CHAN(CLOUD_CHANNEL_MODEM, CMD_ARRAY(
+			CMD_NEW_TYPE(CLOUD_CMD_DATA_STRING)
+			)
+		),
+	)
+);
+
+struct cmd *cmd_groups[] = { &group_cfg_set, &group_get, &group_data,
+			      &group_command };
 static cloud_cmd_cb_t cloud_command_cb;
 struct cloud_command cmd_parsed;
 
@@ -189,6 +199,7 @@ static const char *const channel_type_str[] = {
 	[CLOUD_CHANNEL_LIGHT_BLUE] = CLOUD_CHANNEL_STR_LIGHT_BLUE,
 	[CLOUD_CHANNEL_LIGHT_IR] = CLOUD_CHANNEL_STR_LIGHT_IR,
 	[CLOUD_CHANNEL_ASSISTED_GPS] = CLOUD_CHANNEL_STR_ASSISTED_GPS,
+	[CLOUD_CHANNEL_MODEM] = CLOUD_CHANNEL_STR_MODEM,
 };
 BUILD_ASSERT(ARRAY_SIZE(channel_type_str) == CLOUD_CHANNEL__TOTAL);
 
@@ -203,6 +214,7 @@ static const char *const cmd_group_str[] = {
 	[CLOUD_CMD_GROUP_OK] = CLOUD_CMD_GROUP_STR_OK,
 	[CLOUD_CMD_GROUP_CFG_SET] = CLOUD_CMD_GROUP_STR_CFG_SET,
 	[CLOUD_CMD_GROUP_CFG_GET] = CLOUD_CMD_GROUP_STR_CFG_GET,
+	[CLOUD_CMD_GROUP_COMMAND] = CLOUD_CMD_GROUP_STR_COMMAND,
 };
 BUILD_ASSERT(ARRAY_SIZE(cmd_group_str) == CLOUD_CMD_GROUP__TOTAL);
 
@@ -214,6 +226,7 @@ static const char *const cmd_type_str[] = {
 	[CLOUD_CMD_INTERVAL] = CLOUD_CMD_TYPE_STR_INTERVAL,
 	[CLOUD_CMD_COLOR] = CLOUD_CMD_TYPE_STR_COLOR,
 	[CLOUD_CMD_MODEM_PARAM] = CLOUD_CMD_TYPE_STR_MODEM_PARAM,
+	[CLOUD_CMD_DATA_STRING] = CLOUD_CMD_TYPE_STR_DATA_STRING,
 };
 BUILD_ASSERT(ARRAY_SIZE(cmd_type_str) == CLOUD_CMD__TOTAL);
 
@@ -278,12 +291,14 @@ static bool json_value_string_compare(cJSON *obj, const char *const str)
 }
 
 int cloud_encode_data(const struct cloud_channel_data *channel,
+		      const enum cloud_cmd_group group,
 		      struct cloud_msg *output)
 {
 	int ret;
 
 	if (channel == NULL || channel->data.buf == NULL ||
-	    channel->data.len == 0 || output == NULL) {
+	    channel->data.len == 0 || output == NULL ||
+	    group >= CLOUD_CMD_GROUP__TOTAL) {
 		return -EINVAL;
 	}
 
@@ -296,8 +311,7 @@ int cloud_encode_data(const struct cloud_channel_data *channel,
 	ret = json_add_str(root_obj, CMD_CHAN_KEY_STR,
 			   channel_type_str[channel->type]);
 	ret += json_add_str(root_obj, CMD_DATA_TYPE_KEY_STR, channel->data.buf);
-	ret += json_add_str(root_obj, CMD_GROUP_KEY_STR,
-			    CLOUD_CMD_GROUP_STR_DATA);
+	ret += json_add_str(root_obj, CMD_GROUP_KEY_STR, cmd_group_str[group]);
 	if (ret != 0) {
 		cJSON_Delete(root_obj);
 		return -ENOMEM;
@@ -328,6 +342,8 @@ int cloud_encode_digital_twin_data(const struct cloud_channel_data *channel,
 	cJSON *root_obj = cJSON_CreateObject();
 	cJSON *state_obj = cJSON_CreateObject();
 	cJSON *reported_obj = cJSON_CreateObject();
+	char dev_str[] = CLOUD_CHANNEL_STR_DEVICE_INFO;
+	const char *channel_type;
 
 	if (root_obj == NULL || state_obj == NULL || reported_obj == NULL) {
 		cJSON_Delete(root_obj);
@@ -350,11 +366,19 @@ int cloud_encode_digital_twin_data(const struct cloud_channel_data *channel,
 			 * silently as it's not a functionally critical error.
 			 */
 		} else {
-			ret += json_add_obj(reported_obj, "DEVICE", dummy_obj);
+			ret += json_add_obj(reported_obj, dev_str, dummy_obj);
 		}
+
+		/* Convert to lowercase for shadow */
+		for (int i = 0; dev_str[i]; ++i) {
+			dev_str[i] = tolower(dev_str[i]);
+		}
+		channel_type = dev_str;
+	} else {
+		channel_type = channel_type_str[channel->type];
 	}
 
-	ret += json_add_obj(reported_obj, channel_type_str[channel->type],
+	ret += json_add_obj(reported_obj, channel_type,
 			   (cJSON *)channel->data.buf);
 	ret += json_add_obj(state_obj, "reported", reported_obj);
 	ret += json_add_obj(root_obj, "state", state_obj);
@@ -390,11 +414,10 @@ static int cloud_decode_modem_params(cJSON *const data_obj,
 	}
 
 	blob = json_object_decode(data_obj, MODEM_PARAM_BLOB_KEY_STR);
-	params->blob = cJSON_IsString(blob) ? blob->valuestring : NULL;
+	params->blob = cJSON_GetStringValue(blob);
 
 	checksum = json_object_decode(data_obj, MODEM_PARAM_CHECKSUM_KEY_STR);
-	params->checksum =
-		cJSON_IsString(checksum) ? checksum->valuestring : NULL;
+	params->checksum = cJSON_GetStringValue(checksum);
 
 	return (((params->blob == NULL) || (params->checksum == NULL)) ?
 			-ESRCH : 0);
@@ -412,11 +435,14 @@ static int cloud_cmd_parse_type(const struct cmd *const type_cmd,
 	}
 
 	if (type_obj != NULL) {
-		decoded_obj = json_object_decode(type_obj,
-						 cmd_type_str[type_cmd->type]);
+		/* Data string type does not require additional decoding */
+		if (type_cmd->type != CLOUD_CMD_DATA_STRING) {
+			decoded_obj = json_object_decode(type_obj,
+					cmd_type_str[type_cmd->type]);
 
-		if (!decoded_obj) {
-			return -ENOENT; /* Command not found */
+			if (!decoded_obj) {
+				return -ENOENT; /* Command not found */
+			}
 		}
 
 		switch (type_cmd->type) {
@@ -453,13 +479,13 @@ static int cloud_cmd_parse_type(const struct cmd *const type_cmd,
 			break;
 		}
 		case CLOUD_CMD_COLOR: {
-			if (!cJSON_IsString(decoded_obj) ||
-				!decoded_obj->valuestring) {
+			if (cJSON_GetStringValue(decoded_obj) == NULL) {
 				return -ESRCH;
 			}
 
 			parsed_cmd->data.sv.value = (double)strtol(
-				decoded_obj->valuestring, NULL, 16);
+				cJSON_GetStringValue(decoded_obj), NULL, 16);
+
 			break;
 		}
 		case CLOUD_CMD_MODEM_PARAM: {
@@ -472,6 +498,13 @@ static int cloud_cmd_parse_type(const struct cmd *const type_cmd,
 
 			break;
 		}
+		case CLOUD_CMD_DATA_STRING:
+			parsed_cmd->data.data_string =
+				cJSON_GetStringValue(type_obj);
+			if (parsed_cmd->data.data_string == NULL) {
+				return -ESRCH;
+			}
+			break;
 		case CLOUD_CMD_EMPTY:
 		default: {
 			return -ENOTSUP;
@@ -646,7 +679,7 @@ int cloud_encode_env_sensors_data(const env_sensor_data_t *sensor_data,
 	cloud_sensor.data.buf = buf;
 	cloud_sensor.data.len = len;
 
-	return cloud_encode_data(&cloud_sensor, output);
+	return cloud_encode_data(&cloud_sensor, CLOUD_CMD_GROUP_DATA, output);
 }
 
 int cloud_encode_motion_data(const motion_data_t *motion_data,
@@ -672,7 +705,7 @@ int cloud_encode_motion_data(const motion_data_t *motion_data,
 
 	cloud_sensor.data.len = sizeof(cloud_sensor.data.buf) - 1;
 
-	return cloud_encode_data(&cloud_sensor, output);
+	return cloud_encode_data(&cloud_sensor, CLOUD_CMD_GROUP_DATA, output);
 
 }
 #if CONFIG_LIGHT_SENSOR
@@ -719,7 +752,7 @@ int cloud_encode_light_sensor_data(const struct light_sensor_data *sensor_data,
 	cloud_sensor.data.len = len;
 	cloud_sensor.type = CLOUD_CHANNEL_LIGHT_SENSOR;
 
-	return cloud_encode_data(&cloud_sensor, output);
+	return cloud_encode_data(&cloud_sensor, CLOUD_CMD_GROUP_DATA, output);
 }
 #endif /* CONFIG_LIGHT_SENSOR */
 

--- a/applications/asset_tracker/src/cloud_codec/cloud_codec.h
+++ b/applications/asset_tracker/src/cloud_codec/cloud_codec.h
@@ -62,6 +62,8 @@ enum cloud_channel {
 	CLOUD_CHANNEL_LIGHT_IR,
 	/** The assisted GPS channel. */
 	CLOUD_CHANNEL_ASSISTED_GPS,
+	/** The modem channel. */
+	CLOUD_CHANNEL_MODEM,
 
 	CLOUD_CHANNEL__TOTAL
 };
@@ -74,10 +76,7 @@ enum cloud_channel {
 #define CLOUD_CHANNEL_STR_AIR_PRESS "AIR_PRESS"
 #define CLOUD_CHANNEL_STR_AIR_QUAL "AIR_QUAL"
 #define CLOUD_CHANNEL_STR_LTE_LINK_RSRP "RSRP"
-/* The "device" is intended for the shadow, which expects its objects
- * to have lowercase keys.
- */
-#define CLOUD_CHANNEL_STR_DEVICE_INFO "device"
+#define CLOUD_CHANNEL_STR_DEVICE_INFO "DEVICE"
 #define CLOUD_CHANNEL_STR_LIGHT_SENSOR "LIGHT"
 #define CLOUD_CHANNEL_STR_LIGHT_RED "LIGHT_RED"
 #define CLOUD_CHANNEL_STR_LIGHT_GREEN "LIGHT_GREEN"
@@ -85,6 +84,7 @@ enum cloud_channel {
 #define CLOUD_CHANNEL_STR_LIGHT_IR "LIGHT_IR"
 #define CLOUD_CHANNEL_STR_ASSISTED_GPS "AGPS"
 #define CLOUD_CHANNEL_STR_RGB_LED "LED"
+#define CLOUD_CHANNEL_STR_MODEM "MODEM"
 
 struct cloud_data {
 	char *buf;
@@ -114,6 +114,7 @@ enum cloud_cmd_group {
 	CLOUD_CMD_GROUP_OK,
 	CLOUD_CMD_GROUP_CFG_SET,
 	CLOUD_CMD_GROUP_CFG_GET,
+	CLOUD_CMD_GROUP_COMMAND,
 
 	CLOUD_CMD_GROUP__TOTAL
 };
@@ -128,6 +129,7 @@ enum cloud_cmd_group {
 #define CLOUD_CMD_GROUP_STR_OK "OK"
 #define CLOUD_CMD_GROUP_STR_CFG_SET "CFG_SET"
 #define CLOUD_CMD_GROUP_STR_CFG_GET "CFG_GET"
+#define CLOUD_CMD_GROUP_STR_COMMAND "CMD"
 
 enum cloud_cmd_type {
 	CLOUD_CMD_EMPTY,
@@ -137,6 +139,7 @@ enum cloud_cmd_type {
 	CLOUD_CMD_INTERVAL,
 	CLOUD_CMD_COLOR,
 	CLOUD_CMD_MODEM_PARAM,
+	CLOUD_CMD_DATA_STRING,
 
 	CLOUD_CMD__TOTAL
 };
@@ -154,6 +157,8 @@ enum cloud_cmd_state {
 #define CLOUD_CMD_TYPE_STR_INTERVAL "interval"
 #define CLOUD_CMD_TYPE_STR_COLOR "color"
 #define CLOUD_CMD_TYPE_STR_MODEM_PARAM "modemParams"
+#define CLOUD_CMD_TYPE_STR_DATA_STRING "data_string"
+
 
 #define MODEM_PARAM_BLOB_KEY_STR "blob"
 #define MODEM_PARAM_CHECKSUM_KEY_STR "checksum"
@@ -177,6 +182,7 @@ struct cloud_command {
 	union {
 		struct cloud_command_state_value sv;
 		struct cloud_command_modem_params mp;
+		char *data_string;
 	} data;
 };
 
@@ -186,12 +192,13 @@ typedef void (*cloud_cmd_cb_t)(struct cloud_command *cmd);
  * @brief Encode cloud data.
  *
  * @param channel The cloud channel type.
+ * @param group The channel data's group.
  * @param output Pointer to the cloud data output.
  *
  * @return 0 if the operation was successful, otherwise a (negative) error code.
  */
 int cloud_encode_data(const struct cloud_channel_data *channel,
-		      struct cloud_msg *output);
+	const enum cloud_cmd_group group, struct cloud_msg *output);
 
 /**
  * @brief Decode cloud data.


### PR DESCRIPTION
Implemented receving modem AT commands from the cloud
and returning the modem's response.

Signed-off-by: Justin Morton <justin.morton@nordicsemi.no>