### PR TITLE
scripts: remove NCS internals from requirements.txt

### DIFF
--- a/scripts/requirements-extra.txt
+++ b/scripts/requirements-extra.txt
@@ -1,0 +1,2 @@
+pygit2>=0.26.0
+editdistance>=0.5.0

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -3,5 +3,3 @@ sphinxcontrib-mscgen>=0.5
 ecdsa
 intelhex
 nrfutil
-pygit2>=0.26.0
-editdistance>=0.5.0

--- a/scripts/west_commands/ncs_west_helpers.py
+++ b/scripts/west_commands/ncs_west_helpers.py
@@ -13,9 +13,15 @@ from collections import OrderedDict
 from pathlib import PurePath
 import re
 import textwrap
+import sys
 
-import editdistance
-import pygit2
+try:
+    import editdistance
+    import pygit2
+except ImportError:
+    sys.exit("Can't import extra dependencies needed for NCS west extensions.\n"
+             "Please install packages in nrf/scripts/requirements-extra.txt "
+             "with pip3.")
 from west import log
 
 __all__ = [


### PR DESCRIPTION
The editdistance and pygit2 dependencies are only needed by
maintainers for the internal ncs-loot and ncs-compare west extension
commands.

They're also causing installation problems for Windows users, as e.g.
editdistance is a C extension which is not currently available in
wheel form on Windows + Python 3.8.

Let's move them out to their own requirements file to make this
problem go away. This has the side benefit of making the installation
footprint for regular users smaller.
