### PR TITLE
sample: serial_lte_modem Enable sleep for power saving

### DIFF
--- a/samples/nrf9160/serial_lte_modem/README.rst
+++ b/samples/nrf9160/serial_lte_modem/README.rst
@@ -9,6 +9,7 @@ An nRF9160 DK is used as the host, while the client can be simulated using eithe
 This sample is an enhancement to the :ref:`at_client_sample` sample.
 It provides the following features:
 
+ * Support for generic proprietary AT commands
  * Support for TCP/IP proprietary AT commands
  * Support for UDP proprietary AT commands
  * Support for GPS proprietary AT commands
@@ -53,7 +54,8 @@ Terminal serial configuration:
 External MCU configuration
 ==========================
 
-To work with external MCU (nRF52), you must set the configuration option ``CONFIG_SLM_CONNECT_UART_2``.
+To work with the external MCU (nRF52), you must set the configuration options ``CONFIG_SLM_GPIO_WAKEUP`` and ``CONFIG_SLM_CONNECT_UART_2``.
+
 The pin interconnection between nRF91 and nRF52 is presented in the following table:
 
 .. list-table::
@@ -69,7 +71,7 @@ The pin interconnection between nRF91 and nRF52 is presented in the following ta
    * - UART CTS P0.7
      - UART RTS P0.12
    * - UART RTS P0.5
-     - UART RTS P0.13
+     - UART CTS P0.13
    * - GPIO OUT P0.27
      - GPIO IN P0.31
 
@@ -86,6 +88,14 @@ UART configuration:
     * Operation mode: IRQ
 
 Note that the GPIO output level on nRF91 side should be 3 V.
+
+Generic commands
+****************
+
+The following proprietary generic AT commands are used in this sample:
+
+* AT#XSLMVER
+* AT#XSLEEP (only for external MCU configuration)
 
 TCP/IP AT commands
 ******************
@@ -105,6 +115,8 @@ UDP AT commands
 
 The following proprietary UDP AT commands are used in this sample:
 
+* AT#XSOCKET=<op>[,<type>]
+* AT#XSOCKET?
 * AT#XUDPSENDTO=<url>,<port>,<data>
 * AT#XUDPRECVFROM=<url>,<port>,<length>,<timeout>
 
@@ -112,7 +124,6 @@ GPS AT Commands
 ***************
 
 The following proprietary GPS AT commands are used in this sample:
-
 
 * AT#XGPSRUN=<op>[,<mask>]
 * AT#XGPSRUN?
@@ -154,8 +165,7 @@ This application uses the following |NCS| libraries and drivers:
     * ``nrf/drivers/at_cmd``
     * ``nrf/lib/bsd_lib``
     * ``nrf/lib/at_cmd_parser``
-    * nRF BSD Socket
-    * Zephyr BSD socket
+    * ``nrf/lib/at_notif``
 
 In addition, it uses the Secure Partition Manager sample:
 

--- a/samples/nrf9160/serial_lte_modem/prj.conf
+++ b/samples/nrf9160/serial_lte_modem/prj.conf
@@ -40,10 +40,19 @@ CONFIG_HEAP_MEM_POOL_SIZE=16384
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=8192
 
 # AT_CMD
+# Enable AT_CMD debug for details
+#
 #CONFIG_AT_CMD_LOG_LEVEL_DBG=y
 
+# Device power management
+# Not ready for nRF91 in Zephyr yet
+#CONFIG_DEVICE_POWER_MANAGEMENT=y
+
 # Application-specific
-CONFIG_SLM_AT_MODE=y
 CONFIG_SLM_TCPIP_AT_MODE=y
 CONFIG_SLM_GPS_AT_MODE=y
 CONFIG_SLM_LOG_LEVEL_INF=y
+# Use UART_2 when working with external MCU
+#CONFIG_SLM_CONNECT_UART_2=y
+# Enable GPIO wakeup when working with external MCU
+#CONFIG_SLM_GPIO_WAKEUP=y

--- a/samples/nrf9160/serial_lte_modem/src/main.c
+++ b/samples/nrf9160/serial_lte_modem/src/main.c
@@ -36,7 +36,6 @@ void start_execute(void)
 	int err;
 
 	LOG_INF("Serial LTE Modem");
-#if defined(CONFIG_SLM_AT_MODE)
 	err = slm_at_host_init();
 	if (err != 0) {
 		LOG_ERR("Failed to init at_host: %d", err);
@@ -49,10 +48,34 @@ void start_execute(void)
 		LOG_ERR("Failed to init AT Parser: %d", err);
 		return;
 	}
-#endif
 }
 
 #ifdef CONFIG_SLM_GPIO_WAKEUP
+void enter_sleep(void)
+{
+	/*
+	 * Due to errata 4, Always configure PIN_CNF[n].INPUT before
+	 *  PIN_CNF[n].SENSE.
+	 */
+	nrf_gpio_cfg_input(CONFIG_SLM_MODEM_WAKEUP_PIN,
+		NRF_GPIO_PIN_PULLUP);
+	nrf_gpio_cfg_sense_set(CONFIG_SLM_MODEM_WAKEUP_PIN,
+		NRF_GPIO_PIN_SENSE_LOW);
+
+	/*
+	 * The LTE modem also needs to be stopped by issuing a command
+	 * through the modem API, before entering System OFF mode.
+	 * Once the command is issued, one should wait for the modem
+	 * to respond that it actually has stopped as there may be a
+	 * delay until modem is disconnected from the network.
+	 * Refer to https://infocenter.nordicsemi.com/topic/ps_nrf9160/
+	 * pmu.html?cp=2_0_0_4_0_0_1#system_off_mode
+	 */
+	lte_lc_power_off();	/* Gracefully shutdown the modem.*/
+	bsd_shutdown();		/* Gracefully shutdown the BSD library*/
+	nrf_regulators_system_off(NRF_REGULATORS_NS);
+}
+
 void main(void)
 {
 	u32_t rr = nrf_power_resetreas_get(NRF_POWER_NS);
@@ -63,27 +86,7 @@ void main(void)
 		start_execute();
 	} else {
 		LOG_INF("Sleep");
-		/*
-		 * Due to errata 4, Always configure PIN_CNF[n].INPUT before
-		 *  PIN_CNF[n].SENSE.
-		 */
-		nrf_gpio_cfg_input(CONFIG_SLM_MODEM_WAKEUP_PIN,
-			NRF_GPIO_PIN_PULLUP);
-		nrf_gpio_cfg_sense_set(CONFIG_SLM_MODEM_WAKEUP_PIN,
-			NRF_GPIO_PIN_SENSE_LOW);
-
-		/*
-		 * The LTE modem also needs to be stopped by issuing a command
-		 * through the modem API, before entering System OFF mode.
-		 * Once the command is issued, one should wait for the modem
-		 * to respond that it actually has stopped as there may be a
-		 * delay until modem is disconnected from the network.
-		 * Refer to https://infocenter.nordicsemi.com/topic/ps_nrf9160/
-		 * pmu.html?cp=2_0_0_4_0_0_1#system_off_mode
-		 */
-		lte_lc_power_off();	/* Gracefully shutdown the modem.*/
-		bsd_shutdown();		/* Gracefully shutdown the BSD library*/
-		nrf_regulators_system_off(NRF_REGULATORS_NS);
+		enter_sleep();
 	}
 }
 #else

--- a/samples/nrf9160/serial_lte_modem/src/slm_at_gps.c
+++ b/samples/nrf9160/serial_lte_modem/src/slm_at_gps.c
@@ -346,3 +346,16 @@ int slm_at_gps_init(at_cmd_handler_t callback)
 
 	return 0;
 }
+
+/**@brief API to uninitialize GPS AT commands handler
+ */
+int slm_at_gps_uninit(void)
+{
+	if (gps_thread_id != NULL) {
+		do_gps_stop();
+		k_thread_abort(gps_thread_id);
+		gps_thread_id = NULL;
+	}
+
+	return 0;
+}

--- a/samples/nrf9160/serial_lte_modem/src/slm_at_gps.h
+++ b/samples/nrf9160/serial_lte_modem/src/slm_at_gps.h
@@ -36,6 +36,14 @@ int slm_at_gps_parse(const char *at_cmd);
  */
 int slm_at_gps_init(at_cmd_handler_t callback);
 
+/**
+ * @brief Uninitialize GPS AT command parser.
+ *
+ * @retval 0 If the operation was successful.
+ *           Otherwise, a (negative) error code is returned.
+ */
+int slm_at_gps_uninit(void);
+
 /** @} */
 
 #endif /* SLM_AT_GPS_ */

--- a/samples/nrf9160/serial_lte_modem/src/slm_at_tcpip.c
+++ b/samples/nrf9160/serial_lte_modem/src/slm_at_tcpip.c
@@ -790,3 +790,10 @@ int slm_at_tcpip_init(at_cmd_handler_t callback)
 	client.callback = callback;
 	return 0;
 }
+
+/**@brief API to uninitialize TCP/IP AT commands handler
+ */
+int slm_at_tcpip_uninit(void)
+{
+	return do_socket_close(0);
+}

--- a/samples/nrf9160/serial_lte_modem/src/slm_at_tcpip.h
+++ b/samples/nrf9160/serial_lte_modem/src/slm_at_tcpip.h
@@ -35,6 +35,14 @@ int slm_at_tcpip_parse(const char *at_cmd);
  *           Otherwise, a (negative) error code is returned.
  */
 int slm_at_tcpip_init(at_cmd_handler_t callback);
+
+/**
+ * @brief Uninitialize TCP/IP AT command parser.
+ *
+ * @retval 0 If the operation was successful.
+ *           Otherwise, a (negative) error code is returned.
+ */
+int slm_at_tcpip_uninit(void);
 /** @} */
 
 #endif /* SLM_AT_TCPIP_ */


### PR DESCRIPTION
Enable power saving by entering sleep via new AT#XSLEEP.
Wakeup is the same way as start sequence, i.e. by GPIO.
For customer request [JIRA NCSIDB-34](https://projecttools.nordicsemi.no/jira/browse/NCSIDB-34)

CONFIG_DEVICE_POWER_MANAGEMENT is not set as Zephyr is not ready
for nRF91 device power management yet.

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>