### PR TITLE
fw_info: ld: Replace a temphack in zephyr with an nrf patch

### DIFF
--- a/subsys/fw_info/CMakeLists.txt
+++ b/subsys/fw_info/CMakeLists.txt
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 if (CONFIG_FW_INFO OR CONFIG_IS_SECURE_BOOTLOADER)
+  zephyr_linker_sources(RODATA ext_abis.ld)
+
   zephyr_library()
   zephyr_library_sources(fw_info.c)
 endif ()

--- a/subsys/fw_info/ext_abis.ld
+++ b/subsys/fw_info/ext_abis.ld
@@ -1,0 +1,4 @@
+. = ALIGN(4);
+_ext_abis_start = .;
+KEEP(*(.ext_abis))
+_ext_abis_size = ABSOLUTE((. - _ext_abis_start) / 4);

--- a/west.yml
+++ b/west.yml
@@ -36,7 +36,7 @@ manifest:
     - name: zephyr
       repo-path: fw-nrfconnect-zephyr
       west-commands: scripts/west-commands.yml
-      revision: f2d732b7fa5d57f49d731271cdb60d6176793e31
+      revision: 9a0a85cf67602e4fa5b0c6d7cef2c5e58ca4ac34
     - name: nffs
       revision: bc62a2fa9d98ddb5d633c932ea199bc68e10f194
       path: modules/fs/nffs


### PR DESCRIPTION
Use zephyr_linker_sources to avoid patching in Zephyr.

zephyr PR : https://github.com/NordicPlayground/fw-nrfconnect-zephyr/pull/251

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>