### PR TITLE
fw_info: Change structure member names to remove firmware_* prefix

### DIFF
--- a/include/fw_info.h
+++ b/include/fw_info.h
@@ -55,13 +55,13 @@ struct __packed fw_info {
 	u32_t magic[MAGIC_LEN_WORDS];
 
 	/* Size of the firmware image code. */
-	u32_t firmware_size;
+	u32_t size;
 
 	/* Monotonically increasing version counter.*/
-	u32_t firmware_version;
+	u32_t version;
 
 	/* The address of the start (vector table) of the firmware. */
-	u32_t firmware_address;
+	u32_t address;
 
 	/* Where to place the getter for the EXT_API provided to this firmware.
 	 */
@@ -80,10 +80,10 @@ struct __packed fw_info {
 
 /* Static asserts to ensure compatibility */
 OFFSET_CHECK(struct fw_info, magic, 0);
-OFFSET_CHECK(struct fw_info, firmware_size, CONFIG_FW_INFO_MAGIC_LEN);
-OFFSET_CHECK(struct fw_info, firmware_version,
+OFFSET_CHECK(struct fw_info, size, CONFIG_FW_INFO_MAGIC_LEN);
+OFFSET_CHECK(struct fw_info, version,
 	(CONFIG_FW_INFO_MAGIC_LEN + 4));
-OFFSET_CHECK(struct fw_info, firmware_address,
+OFFSET_CHECK(struct fw_info, address,
 	(CONFIG_FW_INFO_MAGIC_LEN + 8));
 
 /** @endcond

--- a/samples/bootloader/src/main.c
+++ b/samples/bootloader/src/main.c
@@ -46,12 +46,12 @@ extern u32_t _vector_table_pointer;
 
 static void boot_from(const struct fw_info *fw_info)
 {
-	u32_t *vector_table = (u32_t *)fw_info->firmware_address;
+	u32_t *vector_table = (u32_t *)fw_info->address;
 
 	printk("Attempting to boot from address 0x%x.\n\r",
-		fw_info->firmware_address);
+		fw_info->address);
 
-	if (!bl_validate_firmware_local(fw_info->firmware_address,
+	if (!bl_validate_firmware_local(fw_info->address,
 					fw_info)) {
 		printk("Failed to validate!\n\r");
 		return;
@@ -75,7 +75,7 @@ static void boot_from(const struct fw_info *fw_info)
 		nvic->ICPR[i] = 0xFFFFFFFF;
 	}
 
-	printk("Booting (0x%x).\r\n", fw_info->firmware_address);
+	printk("Booting (0x%x).\r\n", fw_info->address);
 
 	uninit_used_peripherals();
 
@@ -97,7 +97,7 @@ static void boot_from(const struct fw_info *fw_info)
 	__DSB(); /* Force Memory Write before continuing */
 	__ISB(); /* Flush and refill pipeline with updated permissions */
 
-	VTOR = fw_info->firmware_address;
+	VTOR = fw_info->address;
 
 	fw_info_ext_api_provide(fw_info);
 
@@ -124,8 +124,7 @@ void main(void)
 	const struct fw_info *s0_info = fw_info_find(s0_addr);
 	const struct fw_info *s1_info = fw_info_find(s1_addr);
 
-	if (!s1_info || (s0_info->firmware_version >=
-			 s1_info->firmware_version)) {
+	if (!s1_info || (s0_info->version >= s1_info->version)) {
 		boot_from(s0_info);
 		boot_from(s1_info);
 	} else {

--- a/samples/nrf9160/secure_services/src/main.c
+++ b/samples/nrf9160/secure_services/src/main.c
@@ -57,7 +57,7 @@ void main(void)
 		printk("Could find firmware info (err: %d)\n", ret);
 	}
 
-	printk("App FW version: %d\n", info_app.firmware_version);
+	printk("App FW version: %d\n", info_app.version);
 
 #ifdef CONFIG_BOOTLOADER_MCUBOOT
 	const int num_bytes_to_read = PM_MCUBOOT_PAD_SIZE;

--- a/subsys/fw_info/fw_info.c
+++ b/subsys/fw_info/fw_info.c
@@ -43,9 +43,9 @@ int ext_api_getter(u32_t id, u32_t index, const struct fw_info_ext_api **out)
 __fw_info struct fw_info m_firmware_info =
 {
 	.magic = {FIRMWARE_INFO_MAGIC},
-	.firmware_size = (u32_t)&_flash_used,
-	.firmware_version = CONFIG_FW_INFO_FIRMWARE_VERSION,
-	.firmware_address = (u32_t)&_image_rom_start,
+	.size = (u32_t)&_flash_used,
+	.version = CONFIG_FW_INFO_FIRMWARE_VERSION,
+	.address = (u32_t)&_image_rom_start,
 	.ext_api_in = &ext_api_getter_in,
 	.ext_api_out = &ext_api_getter,
 };

--- a/subsys/net/lib/fota_download/src/fota_download.c
+++ b/subsys/net/lib/fota_download/src/fota_download.c
@@ -177,7 +177,7 @@ int fota_download_start(char *host, char *file)
 		return err;
 	}
 
-	bool s0_active = s0.firmware_version >= s1.firmware_version;
+	bool s0_active = s0.version >= s1.version;
 
 	err = dfu_ctx_mcuboot_set_b1_file(file, s0_active, &update);
 	if (err != 0) {

--- a/tests/subsys/net/lib/fota_download/src/main.c
+++ b/tests/subsys/net/lib/fota_download/src/main.c
@@ -84,9 +84,9 @@ int spm_firmware_info(u32_t fw_address, struct fw_info *info)
 	zassert_true(info != NULL, NULL);
 
 	if (fw_address == PM_S0_ADDRESS) {
-		info->firmware_version = s0_version;
+		info->version = s0_version;
 	} else if (fw_address == PM_S1_ADDRESS) {
-		info->firmware_version = s1_version;
+		info->version = s1_version;
 	} else {
 		zassert_true(false, "Unexpected address");
 	}


### PR DESCRIPTION
To make the naming more generic, not tied to code.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>