### PR TITLE
boilerplate: include nrf's boilerplate.cmake in all NCS samples

### DIFF
--- a/applications/asset_tracker/CMakeLists.txt
+++ b/applications/asset_tracker/CMakeLists.txt
@@ -6,8 +6,7 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
-include(../../cmake/boilerplate.cmake)
-
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(asset_tracker)
 zephyr_compile_definitions(PROJECT_NAME=${PROJECT_NAME})

--- a/applications/nrf_desktop/CMakeLists.txt
+++ b/applications/nrf_desktop/CMakeLists.txt
@@ -23,7 +23,7 @@ if (NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/configuration/${BOARD}/app_${CMAKE_B
           "Please add file ${CMAKE_CURRENT_SOURCE_DIR}/configuration/${BOARD}/app_${CMAKE_BUILD_TYPE}.conf")
 endif()
 
-include(../../cmake/boilerplate.cmake)
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 
 if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/configuration/${BOARD}/dts.overlay")
   set(DTC_OVERLAY_FILE "${CMAKE_CURRENT_SOURCE_DIR}/configuration/${BOARD}/dts.overlay")

--- a/doc/nrf/ug_app_dev.rst
+++ b/doc/nrf/ug_app_dev.rst
@@ -36,7 +36,7 @@ You must be aware of these additions when you start writing your own application
 
   * The |NCS| provides an additional :file:`boilerplate.cmake` that must be included before Zephyr's in the :file:`CMakeLists.txt` file of your application::
 
-      include(path/to/nrf/cmake/boilerplate.cmake)
+      include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
       include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 
     Since the |NCS| does not require or provide an environment variable equivalent to :makevar:`ZEPHYR_BASE`, you can either create your own or locate the full path in your own :file:`CMakeLists.txt`.

--- a/samples/bluetooth/central_bas/CMakeLists.txt
+++ b/samples/bluetooth/central_bas/CMakeLists.txt
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 cmake_minimum_required(VERSION 3.8.2)
+
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/bluetooth/central_dfu_smp/CMakeLists.txt
+++ b/samples/bluetooth/central_dfu_smp/CMakeLists.txt
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 cmake_minimum_required(VERSION 3.8.2)
+
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/bluetooth/central_hids/CMakeLists.txt
+++ b/samples/bluetooth/central_hids/CMakeLists.txt
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 cmake_minimum_required(VERSION 3.8.2)
+
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/bluetooth/central_uart/CMakeLists.txt
+++ b/samples/bluetooth/central_uart/CMakeLists.txt
@@ -5,6 +5,7 @@
 #
 cmake_minimum_required(VERSION 3.8.2)
 
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(central_uart)
 

--- a/samples/bluetooth/llpm/CMakeLists.txt
+++ b/samples/bluetooth/llpm/CMakeLists.txt
@@ -5,6 +5,8 @@
 #
 
 cmake_minimum_required(VERSION 3.8.2)
+
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/bluetooth/mesh/light/CMakeLists.txt
+++ b/samples/bluetooth/mesh/light/CMakeLists.txt
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 cmake_minimum_required(VERSION 3.8.2)
+
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/bluetooth/mesh/light_switch/CMakeLists.txt
+++ b/samples/bluetooth/mesh/light_switch/CMakeLists.txt
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 cmake_minimum_required(VERSION 3.8.2)
+
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(mesh_light_switch)
 

--- a/samples/bluetooth/peripheral_gatt_dm/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_gatt_dm/CMakeLists.txt
@@ -5,6 +5,7 @@
 #
 cmake_minimum_required(VERSION 3.8)
 
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/bluetooth/peripheral_hids_keyboard/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_hids_keyboard/CMakeLists.txt
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 cmake_minimum_required(VERSION 3.8.2)
+
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/bluetooth/peripheral_hids_mouse/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_hids_mouse/CMakeLists.txt
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 cmake_minimum_required(VERSION 3.8.2)
+
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/bluetooth/peripheral_lbs/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_lbs/CMakeLists.txt
@@ -5,6 +5,7 @@
 #
 cmake_minimum_required(VERSION 3.8)
 
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/bluetooth/peripheral_uart/CMakeLists.txt
+++ b/samples/bluetooth/peripheral_uart/CMakeLists.txt
@@ -5,6 +5,7 @@
 #
 cmake_minimum_required(VERSION 3.8)
 
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/bluetooth/shell_bt_nus/CMakeLists.txt
+++ b/samples/bluetooth/shell_bt_nus/CMakeLists.txt
@@ -5,6 +5,7 @@
 #
 cmake_minimum_required(VERSION 3.8)
 
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/bluetooth/throughput/CMakeLists.txt
+++ b/samples/bluetooth/throughput/CMakeLists.txt
@@ -5,6 +5,8 @@
 #
 
 cmake_minimum_required(VERSION 3.8.2)
+
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/bootloader/CMakeLists.txt
+++ b/samples/bootloader/CMakeLists.txt
@@ -6,6 +6,7 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(bootloader)
 

--- a/samples/debug/ppi_trace/CMakeLists.txt
+++ b/samples/debug/ppi_trace/CMakeLists.txt
@@ -6,6 +6,7 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project("PPI trace sample")
 

--- a/samples/esb/prx/CMakeLists.txt
+++ b/samples/esb/prx/CMakeLists.txt
@@ -5,6 +5,7 @@
 #
 cmake_minimum_required(VERSION 3.8.2)
 
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/esb/ptx/CMakeLists.txt
+++ b/samples/esb/ptx/CMakeLists.txt
@@ -5,6 +5,7 @@
 #
 cmake_minimum_required(VERSION 3.8.2)
 
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/event_manager/CMakeLists.txt
+++ b/samples/event_manager/CMakeLists.txt
@@ -6,6 +6,7 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project("Event Manager sample")
 

--- a/samples/mpsl/timeslot/CMakeLists.txt
+++ b/samples/mpsl/timeslot/CMakeLists.txt
@@ -5,6 +5,7 @@
 #
 cmake_minimum_required(VERSION 3.8)
 
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/nfc/record_text/CMakeLists.txt
+++ b/samples/nfc/record_text/CMakeLists.txt
@@ -6,6 +6,7 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/nfc/tag_reader/CMakeLists.txt
+++ b/samples/nfc/tag_reader/CMakeLists.txt
@@ -12,8 +12,7 @@ set(NRF_SUPPORTED_BOARDS
   nrf52840_pca10056
   )
 
-include(../../../cmake/boilerplate.cmake)
-
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/nfc/tnep_tag/CMakeLists.txt
+++ b/samples/nfc/tnep_tag/CMakeLists.txt
@@ -11,7 +11,7 @@ set(NRF_SUPPORTED_BOARDS
   nrf52840_pca10056
   )
 
-include(../../../cmake/boilerplate.cmake)
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/nfc/writable_ndef_msg/CMakeLists.txt
+++ b/samples/nfc/writable_ndef_msg/CMakeLists.txt
@@ -6,6 +6,7 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/nrf9160/at_client/CMakeLists.txt
+++ b/samples/nrf9160/at_client/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
-include(../../../cmake/boilerplate.cmake)
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/nrf9160/aws_fota/CMakeLists.txt
+++ b/samples/nrf9160/aws_fota/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
-include(../../../cmake/boilerplate.cmake NO_POLICY_SCOPE)
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 if(CONFIG_PROVISION_CERTIFICATES)
   message(WARNING "

--- a/samples/nrf9160/coap_client/CMakeLists.txt
+++ b/samples/nrf9160/coap_client/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
-include(../../../cmake/boilerplate.cmake)
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(nrf-coap-client)
 

--- a/samples/nrf9160/gps/CMakeLists.txt
+++ b/samples/nrf9160/gps/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
-include(../../../cmake/boilerplate.cmake)
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(gps_socket_sample)
 

--- a/samples/nrf9160/http_application_update/CMakeLists.txt
+++ b/samples/nrf9160/http_application_update/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
-include(../../../cmake/boilerplate.cmake)
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(http_application_update)
 

--- a/samples/nrf9160/lte_ble_gateway/CMakeLists.txt
+++ b/samples/nrf9160/lte_ble_gateway/CMakeLists.txt
@@ -17,6 +17,7 @@ set(spm_CONF_FILE
   ${CMAKE_CURRENT_LIST_DIR}/child_secure_partition_manager.conf
   )
 
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(lte-ble-gateway)
 

--- a/samples/nrf9160/lwm2m_carrier/CMakeLists.txt
+++ b/samples/nrf9160/lwm2m_carrier/CMakeLists.txt
@@ -6,6 +6,7 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(lwm2m-carrier)
 

--- a/samples/nrf9160/lwm2m_client/CMakeLists.txt
+++ b/samples/nrf9160/lwm2m_client/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 cmake_minimum_required(VERSION 3.13.1)
 
-include(../../../cmake/boilerplate.cmake NO_POLICY_SCOPE)
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(lwm2m_client)
 zephyr_compile_definitions(PROJECT_NAME=${PROJECT_NAME})

--- a/samples/nrf9160/mqtt_simple/CMakeLists.txt
+++ b/samples/nrf9160/mqtt_simple/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
-include(../../../cmake/boilerplate.cmake NO_POLICY_SCOPE)
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(mqtt-simple)
 

--- a/samples/nrf9160/secure_services/CMakeLists.txt
+++ b/samples/nrf9160/secure_services/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
-include(../../../cmake/boilerplate.cmake)
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(secure_services)
 

--- a/samples/nrf9160/serial_lte_modem/CMakeLists.txt
+++ b/samples/nrf9160/serial_lte_modem/CMakeLists.txt
@@ -16,7 +16,7 @@ set(spm_CONF_FILE
   prj.conf
   ${CMAKE_CURRENT_LIST_DIR}/child_secure_partition_manager.conf
   )
-
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(serial_lte_modem)
 

--- a/samples/nrf9160/spm/CMakeLists.txt
+++ b/samples/nrf9160/spm/CMakeLists.txt
@@ -5,7 +5,7 @@
 #
 cmake_minimum_required(VERSION 3.8.2)
 
-include(../../../cmake/boilerplate.cmake)
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/samples/profiler/CMakeLists.txt
+++ b/samples/profiler/CMakeLists.txt
@@ -6,6 +6,7 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project("Profiler sample")
 

--- a/samples/sensor/bh1749/CMakeLists.txt
+++ b/samples/sensor/bh1749/CMakeLists.txt
@@ -1,6 +1,6 @@
-include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-
 cmake_minimum_required(VERSION 3.13.1)
+
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(bh1749)
 

--- a/samples/usb/usb_uart_bridge/CMakeLists.txt
+++ b/samples/usb/usb_uart_bridge/CMakeLists.txt
@@ -7,7 +7,6 @@
 cmake_minimum_required(VERSION 3.8.2)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
-
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/drivers/fprotect/negative/CMakeLists.txt
+++ b/tests/drivers/fprotect/negative/CMakeLists.txt
@@ -5,6 +5,8 @@
 #
 
 cmake_minimum_required(VERSION 3.8.2)
+
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/drivers/fprotect/positive/CMakeLists.txt
+++ b/tests/drivers/fprotect/positive/CMakeLists.txt
@@ -5,6 +5,8 @@
 #
 
 cmake_minimum_required(VERSION 3.8.2)
+
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/lib/at_cmd_parser/at_cmd_parser/CMakeLists.txt
+++ b/tests/lib/at_cmd_parser/at_cmd_parser/CMakeLists.txt
@@ -1,4 +1,6 @@
 cmake_minimum_required(VERSION 3.13.1)
+
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(at_cmd_parser)
 

--- a/tests/lib/at_cmd_parser/at_params/CMakeLists.txt
+++ b/tests/lib/at_cmd_parser/at_params/CMakeLists.txt
@@ -1,4 +1,6 @@
 cmake_minimum_required(VERSION 3.13.1)
+
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(at_cmd_parser)
 

--- a/tests/lib/at_cmd_parser/at_utils/CMakeLists.txt
+++ b/tests/lib/at_cmd_parser/at_utils/CMakeLists.txt
@@ -1,4 +1,6 @@
 cmake_minimum_required(VERSION 3.13.1)
+
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(at_cmd_parser)
 

--- a/tests/subsys/bluetooth/gatt_dm/CMakeLists.txt
+++ b/tests/subsys/bluetooth/gatt_dm/CMakeLists.txt
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 cmake_minimum_required(VERSION 3.8.2)
+
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/subsys/bootloader/bl_crypto/CMakeLists.txt
+++ b/tests/subsys/bootloader/bl_crypto/CMakeLists.txt
@@ -5,6 +5,8 @@
 #
 
 cmake_minimum_required(VERSION 3.8.2)
+
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/subsys/bootloader/bl_validation/CMakeLists.txt
+++ b/tests/subsys/bootloader/bl_validation/CMakeLists.txt
@@ -5,6 +5,8 @@
 #
 
 cmake_minimum_required(VERSION 3.8.2)
+
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
 

--- a/tests/subsys/dfu/dfu_target/mcuboot/CMakeLists.txt
+++ b/tests/subsys/dfu/dfu_target/mcuboot/CMakeLists.txt
@@ -5,6 +5,8 @@
 #
 
 cmake_minimum_required(VERSION 3.13.1)
+
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(dfu_target_test)
 

--- a/tests/subsys/dfu/dfu_target_mcuboot/CMakeLists.txt
+++ b/tests/subsys/dfu/dfu_target_mcuboot/CMakeLists.txt
@@ -5,6 +5,8 @@
 #
 
 cmake_minimum_required(VERSION 3.13.1)
+
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(json)
 

--- a/tests/subsys/event_manager/CMakeLists.txt
+++ b/tests/subsys/event_manager/CMakeLists.txt
@@ -6,6 +6,7 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project("Event Manager unit tests")
 

--- a/tests/subsys/net/lib/aws_fota/aws_fota_json/CMakeLists.txt
+++ b/tests/subsys/net/lib/aws_fota/aws_fota_json/CMakeLists.txt
@@ -5,6 +5,8 @@
 #
 
 cmake_minimum_required(VERSION 3.13.1)
+
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(json)
 

--- a/tests/subsys/net/lib/aws_jobs/CMakeLists.txt
+++ b/tests/subsys/net/lib/aws_jobs/CMakeLists.txt
@@ -5,6 +5,7 @@
 #
 
 cmake_minimum_required(VERSION 3.13.1)
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(json)
 

--- a/tests/subsys/net/lib/fota_download/CMakeLists.txt
+++ b/tests/subsys/net/lib/fota_download/CMakeLists.txt
@@ -5,6 +5,8 @@
 #
 
 cmake_minimum_required(VERSION 3.13.1)
+
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(fota_download)
 

--- a/tests/unity/example_test/CMakeLists.txt
+++ b/tests/unity/example_test/CMakeLists.txt
@@ -5,6 +5,8 @@
 #
 
 cmake_minimum_required(VERSION 3.13.1)
+
+include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(example_test)
 


### PR DESCRIPTION
Include nrf's boilerplate.cmake from all samples. This is a documented
requirement for NCS samples.

Also, include relatively to ZEPHYR_BASE instead of from the sample
itself so it is easier to copy it.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>