### PR TITLE
doc: Fix pylint warnings that fail CI

### DIFF
--- a/doc/mcuboot/conf.py
+++ b/doc/mcuboot/conf.py
@@ -152,5 +152,5 @@ intersphinx_mapping = {
 }
 
 def setup(app):
-   app.add_stylesheet("css/common.css")
-   app.add_stylesheet("css/mcuboot.css")
+    app.add_stylesheet("css/common.css")
+    app.add_stylesheet("css/mcuboot.css")

--- a/doc/nrf/conf.py
+++ b/doc/nrf/conf.py
@@ -190,5 +190,5 @@ rst_epilog = """
 """
 
 def setup(app):
-   app.add_stylesheet("css/common.css")
-   app.add_stylesheet("css/nrf.css")
+    app.add_stylesheet("css/common.css")
+    app.add_stylesheet("css/nrf.css")

--- a/doc/nrfxlib/conf.py
+++ b/doc/nrfxlib/conf.py
@@ -151,5 +151,5 @@ cpp_id_attributes = ['__syscall', '__syscall_inline', '__deprecated',
     '__DEPRECATED_MACRO', 'FUNC_NORETURN' ]
 
 def setup(app):
-   app.add_stylesheet("css/common.css")
-   app.add_stylesheet("css/nrfxlib.css")
+    app.add_stylesheet("css/common.css")
+    app.add_stylesheet("css/nrfxlib.css")

--- a/doc/zephyr/conf.py
+++ b/doc/zephyr/conf.py
@@ -108,7 +108,7 @@ try:
             extraversion = val
         if version_major and version_minor and patchlevel and extraversion:
             break
-except:
+except Exception:
     pass
 finally:
     if version_major and version_minor and patchlevel and extraversion is not None :
@@ -183,7 +183,7 @@ html_theme = "zephyr"
 html_theme_path = ['{}/doc/themes'.format(NRF_BASE)]
 html_favicon = '{}/doc/static/images/favicon.ico'.format(NRF_BASE)
 
-if tags.has('release'):
+if tags.has('release'):  # pylint: disable=undefined-variable
     is_release = True
     docs_title = 'Docs / %s' %(version)
 else:
@@ -320,6 +320,6 @@ linkcheck_workers = 10
 linkcheck_anchors = False
 
 def setup(app):
-   app.add_stylesheet("zephyr-custom.css")
-   app.add_stylesheet("css/zephyr.css")
-   app.add_stylesheet("css/common.css")
+    app.add_stylesheet("zephyr-custom.css")
+    app.add_stylesheet("css/zephyr.css")
+    app.add_stylesheet("css/common.css")


### PR DESCRIPTION
pylint warnings now cause failures in CI. Fix some bad indentation, a
bare 'except:' ('except Exception:' avoids catching Ctrl-C and the
like), and suppress an unused-variable warning about a 'tags' variable
that gets created by Sphinx.