### PR TITLE
nRF Cloud: handle device config in shadow

### DIFF
--- a/applications/asset_tracker/src/cloud_codec/cloud_codec.c
+++ b/applications/asset_tracker/src/cloud_codec/cloud_codec.c
@@ -582,6 +582,79 @@ static int cloud_search_cmd(cJSON *root_obj)
 	return 0;
 }
 
+static int cloud_search_config(cJSON * const root_obj)
+{
+	struct cmd const *const group = &group_cfg_set;
+	cJSON *state_obj = NULL;
+	cJSON *config_obj = NULL;
+
+	if (root_obj == NULL) {
+		return -EINVAL;
+	}
+
+	/* A delta update will have state */
+	state_obj = cJSON_GetObjectItem(root_obj, "state");
+	config_obj = cJSON_DetachItemFromObject(
+		state_obj ? state_obj : root_obj, "config");
+
+	if (config_obj == NULL) {
+		return 0;
+	}
+
+	/* Search all channels */
+	for (size_t ch = 0; ch < group->num_children; ++ch) {
+		struct cloud_command found_config_item = {
+				.group = CLOUD_CMD_GROUP_CFG_SET
+			};
+
+		cJSON *channel_obj = json_object_decode(
+			config_obj,
+			channel_type_str[group->children[ch].channel]);
+
+		if (channel_obj == NULL) {
+			continue;
+		}
+
+		struct cmd *chan = &group->children[ch];
+		found_config_item.channel = chan->channel;
+
+		/* Search channel's config types */
+		for (size_t type = 0; type < chan->num_children; ++type) {
+			int ret = cloud_cmd_parse_type(&chan->children[type],
+						   channel_obj,
+						   &found_config_item);
+
+			if (ret != 0) {
+				if (ret != -ENOENT) {
+					printk("[%s:%d] Unhandled cfg format for %s, error %d\n",
+					       __func__, __LINE__,
+					       channel_type_str[chan->channel],
+					       ret);
+				}
+				continue;
+			}
+
+			printk("[%s:%d] Found cfg item %s, %s\n", __func__,
+			       __LINE__,
+			       channel_type_str[found_config_item.channel],
+			       cmd_type_str[found_config_item.type]);
+
+			/* Handle cfg commands */
+			(void)cloud_cmd_handle_sensor_set_chan_cfg(
+				&found_config_item);
+
+			if (cloud_command_cb) {
+				cloud_command_cb(&found_config_item);
+			}
+		}
+	}
+
+	/* Config was detached, must be deleted */
+	cJSON_Delete(config_obj);
+
+	return 0;
+}
+
 int cloud_decode_command(char const *input)
 {
 	cJSON *root_obj = NULL;
@@ -597,6 +670,8 @@ int cloud_decode_command(char const *input)
 	}
 
 	cloud_search_cmd(root_obj);
+
+	cloud_search_config(root_obj);
 
 	cJSON_Delete(root_obj);
 
@@ -796,20 +871,11 @@ static int cloud_cmd_handle_sensor_set_chan_cfg(struct cloud_command const *cons
 	}
 
 	switch (cmd->type) {
-	case CLOUD_CMD_INTERVAL:
-		if (cmd->data.sv.state == CLOUD_CMD_STATE_UNDEFINED) {
-			/* Undefined means a valid value was set, so enable */
-			err = cloud_set_chan_cfg_item(
-				cmd->channel,
-				SENSOR_CHAN_CFG_ITEM_TYPE_SEND_ENABLE,
-				true);
-
-		} else {
-			err = cloud_set_chan_cfg_item(
-				cmd->channel,
-				SENSOR_CHAN_CFG_ITEM_TYPE_SEND_ENABLE,
-				(cmd->data.sv.state == CLOUD_CMD_STATE_TRUE));
-		}
+	case CLOUD_CMD_ENABLE:
+		err = cloud_set_chan_cfg_item(
+			cmd->channel,
+			SENSOR_CHAN_CFG_ITEM_TYPE_SEND_ENABLE,
+			(cmd->data.sv.state == CLOUD_CMD_STATE_TRUE));
 		break;
 	case CLOUD_CMD_THRESHOLD_HIGH:
 		if (cmd->data.sv.state == CLOUD_CMD_STATE_UNDEFINED) {

--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_codec.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_codec.h
@@ -7,6 +7,8 @@
 #ifndef NRF_CLOUD_CODEC_H__
 #define NRF_CLOUD_CODEC_H__
 
+#include <stdbool.h>
+
 #include <nrf_cloud.h>
 #include "nrf_cloud_fsm.h"
 
@@ -37,6 +39,11 @@ int nrf_cloud_decode_data_endpoint(const struct nrf_cloud_data *input,
 
 /** @brief Encodes state information. */
 int nrf_cloud_encode_state(u32_t reported_state, struct nrf_cloud_data *output);
+
+/** @brief Search input for config and encode response if necessary. */
+int nrf_cloud_encode_config_response(struct nrf_cloud_data const *const input,
+				     struct nrf_cloud_data *const output,
+				     bool *const has_config);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
New config items come in on desired deltas.
The device clears the config from desired and adds config to reported
section.
Existing config items come in on the (trimmed) reported shadow.

Signed-off-by: Justin Morton <justin.morton@nordicsemi.no>