### PR TITLE
spm: allow user to define veneer lib

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -6,6 +6,16 @@
 
 if (CONFIG_SPM)
   add_child_image(spm ${CMAKE_CURRENT_LIST_DIR}/nrf9160/spm)
+
+  if (CONFIG_ARM_FIRMWARE_USES_SECURE_ENTRY_FUNCS AND
+      NOT CONFIG_SPM_BUILD_STRATEGY_FROM_SOURCE AND
+      NOT EXISTS ${CONFIG_ARM_ENTRY_VENEERS_LIB_NAME})
+    message(WARNING "NOTE: SPM is not built from source, and the firmware use secure "
+      "entry functions. However, the configured library file is not found.
+      Ensure that the configuration 'ARM_ENTRY_VENEERS_LIB_NAME'
+      points to the .a file (default 'spm/libspmsecureentries.a')
+      generated alongside the flashed or merged SPM hex file")
+  endif()
 endif()
 
 if (CONFIG_SECURE_BOOT)

--- a/subsys/spm/Kconfig
+++ b/subsys/spm/Kconfig
@@ -215,12 +215,12 @@ endmenu
 
 if ARM_FIRMWARE_USES_SECURE_ENTRY_FUNCS
 config ARM_ENTRY_VENEERS_LIB_NAME
-	string
+	string "Entry Veneers symbol file"
 	default "spm/libspmsecureentries.a"
 endif
 
 if ARM_FIRMWARE_HAS_SECURE_ENTRY_FUNCS
 config ARM_ENTRY_VENEERS_LIB_NAME
-	string
+	string "Entry Veneers symbol file"
 	default "libspmsecureentries.a"
 endif


### PR DESCRIPTION
When spm is not built from source, it is necessary for the user
to define the veneer lib name.

Also print a note in cmake to help the user realize this.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>