### PR TITLE
applications: nrf_desktop: Fix config channel forward bug

### DIFF
--- a/applications/nrf_desktop/src/modules/hid_forward.c
+++ b/applications/nrf_desktop/src/modules/hid_forward.c
@@ -480,6 +480,8 @@ static void handle_config_forward(const struct config_forward_event *event)
 	if (event->status == CONFIG_STATUS_FETCH) {
 		LOG_INF("Forwarding fetch request");
 		frame.status = CONFIG_STATUS_FETCH;
+	} else {
+		frame.status = CONFIG_STATUS_PENDING;
 	}
 
 	frame.recipient = event->recipient;


### PR DESCRIPTION
Change fixes config channel forwarding bug caused by uninitialized status field.