### PR TITLE
53 ns support

### DIFF
--- a/cmake/multi_image.cmake
+++ b/cmake/multi_image.cmake
@@ -30,13 +30,17 @@ function(image_board_selection board_in board_out)
   # images defined.
   # TODO: Allow multiple non-secure images by using Kconfig to set the
   # secure/non-secure property rather than using a separate board definition.
-  if(${board_in} STREQUAL nrf9160_pca10090ns)
-    set(${board_out} nrf9160_pca10090 PARENT_SCOPE)
-    message("Changed board to secure nrf9160_pca10090 (NOT NS)")
+  set(nonsecure_boards_with_ns_suffix
+    nrf9160_pca10090ns
+    nrf9160_pca20035ns
+    )
+  if(${board_in} IN_LIST nonsecure_boards_with_ns_suffix)
+    string(LENGTH ${board_in} len)
+    math(EXPR len_without_suffix "${len} - 2")
+    string(SUBSTRING ${board_in} 0 ${len_without_suffix} board_in_without_suffix)
 
-  elseif(${board_in} STREQUAL nrf9160_pca20035ns)
-    set(${board_out} nrf9160_pca20035 PARENT_SCOPE)
-    message("Changed board to secure nrf9160_pca20035 (NOT NS)")
+    set(${board_out} ${board_in_without_suffix} PARENT_SCOPE)
+    message("Changed board to secure ${board_in_without_suffix} (NOT NS)")
 
   elseif(${board_in} STREQUAL actinius_icarus_ns)
     set(${board_out} actinius_icarus PARENT_SCOPE)

--- a/cmake/multi_image.cmake
+++ b/cmake/multi_image.cmake
@@ -33,6 +33,7 @@ function(image_board_selection board_in board_out)
   set(nonsecure_boards_with_ns_suffix
     nrf9160_pca10090ns
     nrf9160_pca20035ns
+    nrf5340_dk_nrf5340_cpuappns
     )
   if(${board_in} IN_LIST nonsecure_boards_with_ns_suffix)
     string(LENGTH ${board_in} len)

--- a/subsys/fw_info/Kconfig
+++ b/subsys/fw_info/Kconfig
@@ -67,6 +67,7 @@ config FW_INFO_HARDWARE_ID
 	range 0 255
 	default 51 if SOC_SERIES_NRF51X
 	default 52 if SOC_SERIES_NRF52X
+	default 53 if SOC_SERIES_NRF53X
 	default 91 if SOC_SERIES_NRF91X
 	help
 	  Used to ensure binary compatibility.


### PR DESCRIPTION
Add an entry for 53 in the mechanism that changes the board from
secure to nonsecure.

Also add an entry for nrf53 in CONFIG_FW_INFO_HARDWARE_ID.

This is necessary for multi-image nrf53 nonsecure support.