### PR TITLE
partition_manager: scripts: docs: ignore non-int values for alignment

### DIFF
--- a/scripts/partition_manager.py
+++ b/scripts/partition_manager.py
@@ -370,6 +370,11 @@ def get_required_offset(align, start, size, move_up):
     if len(align) != 1 or ('start' not in align and 'end' not in align):
         raise RuntimeError("Invalid alignment requirement {}".format(align))
 
+    # As Kconfig preprocessor options are used as values, we need to ignore any non-int value, as it indicates
+    # that there shall be no alignment.
+    if not isinstance(align['start' if 'start' in align else 'end'], int):
+        return 0
+
     end = start + size
     align_start = 'start' in align
 

--- a/scripts/partition_manager/partition_manager.rst
+++ b/scripts/partition_manager/partition_manager.rst
@@ -104,6 +104,10 @@ placement: dict
          Only one key can be specified.
          Partitions which directly or indirectly (through spans) share size with the ``app`` partitions can only be aligned if they are placed directly after the ``app`` partition.
 
+         If the value of the align dict is not interpreted as an integer type, the alignment requirement is discarded.
+         This can be used to have conditional alignment by using a Kconfig option preprocessor macro as the value for the align dict.
+         If the Kconfig value is not set, the macro will not be replaced by an integer, and the alignment requirement will be discarded.
+
 
 span: list OR dict: list
    If the value type is a list, this property lists which partitions this partition should span across.


### PR DESCRIPTION
To facilitate conditional alignment, ignore non-integer alignment values.

This is used to support direct use of Kconfig option names
as values for alignments. If the kconfig option is not set,
the alignment requirement is discarded.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>