### PR TITLE
Introduce fprotect block size and conditional alignment

### DIFF
--- a/lib/fprotect/Kconfig
+++ b/lib/fprotect/Kconfig
@@ -10,3 +10,13 @@ config FPROTECT
 	help
 	  Use hardware peripherals (BPROT, ACL, or SPU) to write-protect
 	  regions of flash until next reset.
+
+if FPROTECT
+config FPROTECT_BLOCK_SIZE
+	int "Block size of fprotect"
+	default 32768 if SOC_NRF9160
+	default 16384 if SOC_NRF5340_CPUAPP
+	default $(dt_int_val,DT_SOC_NV_FLASH_1000000_ERASE_BLOCK_SIZE) if SOC_NRF5340_CPUNET
+	default $(dt_int_val,DT_SOC_NV_FLASH_0_ERASE_BLOCK_SIZE)
+endif
+

--- a/lib/fprotect/fprotect_acl.c
+++ b/lib/fprotect/fprotect_acl.c
@@ -12,6 +12,9 @@ int fprotect_area(u32_t start, size_t length)
 {
 	static u32_t region_idx;
 
+	assert(nrf_ficr_codepagesize_get(NRF_FICR) ==
+			CONFIG_FPROTECT_BLOCK_SIZE);
+
 	if (region_idx >= ACL_REGIONS_COUNT) {
 		return -ENOSPC;
 	}

--- a/lib/fprotect/fprotect_bprot.c
+++ b/lib/fprotect/fprotect_bprot.c
@@ -40,6 +40,8 @@ int fprotect_area(u32_t start, size_t length)
 	u32_t block_end   = (start + length) / BPROT_REGIONS_SIZE;
 	u32_t block_mask[BPROT_CONFIGS_NUM] = {0};
 
+	BUILD_ASSERT(BPROT_REGIONS_SIZE == CONFIG_FPROTECT_BLOCK_SIZE);
+
 	if ((start % BPROT_REGIONS_SIZE) ||
 	    (length % BPROT_REGIONS_SIZE) ||
 	    (block_end > BPROT_REGIONS_NUM) ||

--- a/lib/fprotect/fprotect_spu.c
+++ b/lib/fprotect/fprotect_spu.c
@@ -9,18 +9,16 @@
 #include <hal/nrf_spu.h>
 #include <errno.h>
 
-#define SPU_LOCK_REGION_SIZE (32 * 1024)
-
 int fprotect_area(u32_t start, size_t length)
 {
-	if (start % SPU_LOCK_REGION_SIZE != 0 ||
-		length % SPU_LOCK_REGION_SIZE != 0) {
+	if (start % CONFIG_FPROTECT_BLOCK_SIZE != 0 ||
+		length % CONFIG_FPROTECT_BLOCK_SIZE != 0) {
 		return -EINVAL;
 	}
 
-	for (u32_t i = 0; i < length / SPU_LOCK_REGION_SIZE; i++) {
+	for (u32_t i = 0; i < length / CONFIG_FPROTECT_BLOCK_SIZE; i++) {
 		nrf_spu_flashregion_set(NRF_SPU_S,
-				(start / SPU_LOCK_REGION_SIZE) + i,
+				(start / CONFIG_FPROTECT_BLOCK_SIZE) + i,
 				true,
 				NRF_SPU_MEM_PERM_EXECUTE |
 				NRF_SPU_MEM_PERM_READ,

--- a/samples/bootloader/pm.yml
+++ b/samples/bootloader/pm.yml
@@ -13,7 +13,7 @@ s0_pad:
   share_size: mcuboot_pad
   placement:
     after: b0
-    align: {start: DT_FLASH_ERASE_BLOCK_SIZE}
+    align: {start: CONFIG_FPROTECT_BLOCK_SIZE}
 
 s0_image:
   # S0 spans over the image booted by B0
@@ -33,7 +33,9 @@ s1_pad:
 s1_image:
   # This partition will only exist if mcuboot exists.
   share_size: mcuboot
-  placement: {after: s1_pad}
+  placement:
+    after: s1_pad
+    align: {end: CONFIG_FPROTECT_BLOCK_SIZE}
 
 s1:
   # Partition which contains the whole S1 partition.


### PR DESCRIPTION
Introduce concept of conditional alignment, which only sets alignment requirement if the CONFIG option is set (in practice).

Use this feature to conditionally align partitions which are to be protected by fprotect.

One topic to discuss, do we need a separate kconfig option for enabling protection of given partitions? In addition to enabling FPROTECT module.