### PR TITLE
nrf53: spm: Don't enable SPM_SERVICE_RNG on nrf53

### DIFF
--- a/subsys/spm/Kconfig
+++ b/subsys/spm/Kconfig
@@ -53,6 +53,10 @@ config SPM_SERVICE_RNG
 	default y
 	select NORDIC_SECURITY_BACKEND
 	select FLOAT
+
+# NORDIC_SECURITY_BACKEND is not supported on 53 yet
+	depends on ! SOC_NRF5340_CPUAPP
+
 	help
 	  The Non-Secure Firmware is not allowed to use the crypto hardware.
 	  This service allows it to request random numbers from the SPM.


### PR DESCRIPTION
SPM_SERVICE_RNG uses NORDIC_SECURITY_BACKEND, but
NORDIC_SECURITY_BACKEND is not supported on nrf53 yet.

To prevent users from accidentally enabling something that is not
supported we add a dependency in Kconfig.

This, along with some other patches up for review, allows us to run
SPM on nrf53.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>