### PR TITLE
net: download_client: allow dynamic fragment size based on protocol

### DIFF
--- a/include/net/download_client.h
+++ b/include/net/download_client.h
@@ -120,6 +120,8 @@ struct download_client {
 	size_t file_size;
 	/** Download progress, number of bytes downloaded. */
 	size_t progress;
+	/** Fragment size being used for this download. */
+	size_t fragment_size;
 
 	/** Whether the HTTP header for
 	 * the current fragment has been processed.

--- a/include/net/download_client.rst
+++ b/include/net/download_client.rst
@@ -5,7 +5,8 @@ Download client
 
 The download client library can be used to download files from an HTTP or HTTPS server. It supports IPv4 and IPv6 protocols.
 
-The file is downloaded in fragments of configurable size (:option:`CONFIG_DOWNLOAD_CLIENT_MAX_FRAGMENT_SIZE`), that are returned to the application via events (:cpp:member:`DOWNLOAD_CLIENT_EVT_FRAGMENT`).
+The file is downloaded in fragments whose size can be configured independently for TLS and non-TLS connections (:option:`CONFIG_DOWNLOAD_CLIENT_MAX_TLS_FRAGMENT_SIZE` and :option:`CONFIG_DOWNLOAD_CLIENT_MAX_FRAGMENT_SIZE`).
+These fragments are returned to the application via events (:cpp:member:`DOWNLOAD_CLIENT_EVT_FRAGMENT`).
 
 The library can detect the size of the file that is downloaded and sends an event (:cpp:member:`DOWNLOAD_CLIENT_EVT_DONE`) to the application when the download has completed.
 
@@ -15,7 +16,7 @@ The application can then resume the download by calling the :cpp:func:`download_
 
 The download happens in a separate thread which can be paused and resumed.
 
-Make sure to configure :option:`CONFIG_DOWNLOAD_CLIENT_MAX_FRAGMENT_SIZE` in a way that suits your application.
+Make sure to configure the fragment size in a way that suits your application.
 A large fragment size requires more RAM, while a small fragment size results in more download requests, and thus a higher protocol overhead.
 If the size of the file being downloaded is larger than a hundred times the size of one fragment, the server might close the HTTP connection
 after the hundredth fragment has been transferred. The library is able to detect when the server has closed the HTTP connection

--- a/subsys/net/lib/download_client/Kconfig
+++ b/subsys/net/lib/download_client/Kconfig
@@ -10,16 +10,25 @@ menuconfig  DOWNLOAD_CLIENT
 if DOWNLOAD_CLIENT
 
 config DOWNLOAD_CLIENT_MAX_FRAGMENT_SIZE
-	int "Fragment size"
-	range 512 2048 if BSD_LIBRARY && DOWNLOAD_CLIENT_TLS
-	default 2048 if BSD_LIBRARY && DOWNLOAD_CLIENT_TLS
+	int "Non-TLS fragment size"
 	range 512 4096
 	default 4096
 	help
-	  Size of the data fragments reported to the application in each event.
-	  When using BSD library and TLS, the fragment can not exceed 2.3kB.
-	  When not using TLS, prefer a larger fragment size to reduce the
+	  Size of the data fragments reported to the application in each event
+	  when not using TLS. Use a larger fragment size to reduce the
 	  bandwidth overhead due to the HTTP headers.
+
+config DOWNLOAD_CLIENT_MAX_TLS_FRAGMENT_SIZE
+	int "TLS fragment size"
+	range 512 2048 if BSD_LIBRARY
+	default 2048 if BSD_LIBRARY
+	range 512 4096
+	default 4096
+	help
+	  Size of the data fragments reported to the application in each event
+	  when using TLS. Use a larger fragment size to reduce the
+	  bandwidth overhead due to the HTTP headers. When using the BSD library,
+	  the fragment cannot exceed 2.3 kB.
 
 config DOWNLOAD_CLIENT_MAX_RESPONSE_SIZE
 	int "Response size"


### PR DESCRIPTION
Previously, building with HTTPS support always forced the buffer and
fragment sizes down, even if the server you made the request from wasn't
using HTTPS.  This change adds support for parallel TLS and non-TLS
fragment sizes, and selects the size dynamically when starting the
download.

This reduces overhead, speeds up download times, and reduces the
opportunities for packet loss (fewer packets).

Signed-off-by: Justin Brzozoski <justin.brzozoski@signal-fire.com>