### PR TITLE
cmake: bootloader: support building bootloader sample stand alone

### DIFF
--- a/subsys/bootloader/CMakeLists.txt
+++ b/subsys/bootloader/CMakeLists.txt
@@ -10,3 +10,12 @@ add_subdirectory_ifdef(CONFIG_SECURE_BOOT_CRYPTO bl_crypto)
 
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/fw_info_magic.cmake)
 zephyr_include_directories(include)
+
+if (NOT IMAGE_NAME)
+  message(WARNING "Building bootloader without associated application. "
+          "Dummy values will be used for partition configuration."
+          "The idiomatic way of including the immutable bootloader is to set "
+          "the configuration 'CONFIG_SECURE_BOOTLOADER=y' in your applications "
+          "'prj.conf'.")
+  zephyr_include_directories(include/dummy_values/)
+endif()

--- a/subsys/bootloader/include/dummy_values/pm_config.h
+++ b/subsys/bootloader/include/dummy_values/pm_config.h
@@ -1,0 +1,7 @@
+/* DUMMY FILE ONLY TO BE USED FOR TESTING */
+#ifndef PM_CONFIG_H__
+#define PM_CONFIG_H__
+#define PM_B0_ADDRESS 0x0
+#define PM_B0_SIZE 0x8000
+#define PM_PROVISION_ADDRESS 0x7000
+#endif /* PM_CONFIG_H__ */


### PR DESCRIPTION
Fix bug where the bootloader sample could not be build as a
stand alone application.

This is not the preferred way of building the bootloader,
so a warning is given when it is built this way.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>