### PR TITLE
Bluetooth: gatt_dm: Handle out of memory failure cases

### DIFF
--- a/subsys/bluetooth/gatt_dm.c
+++ b/subsys/bluetooth/gatt_dm.c
@@ -283,8 +283,10 @@ static u8_t discovery_process_service(struct bt_gatt_dm *dm,
 
 	cur_attr->uuid = uuid_store(dm, attr->uuid);
 	service_val = user_data_store(dm, service_val, sizeof(*service_val));
-	service_val->uuid = uuid_store(dm, service_val->uuid);
-	cur_attr->user_data = service_val;
+	if (service_val) {
+		service_val->uuid = uuid_store(dm, service_val->uuid);
+		cur_attr->user_data = service_val;
+	}
 
 	if (!cur_attr->uuid || !service_val ||
 	    !service_val->uuid) {
@@ -376,8 +378,11 @@ static u8_t discovery_process_characteristic(
 
 	gatt_chrc = attr->user_data;
 	gatt_chrc = user_data_store(dm, gatt_chrc, sizeof(*gatt_chrc));
-	gatt_chrc->uuid = uuid_store(dm, gatt_chrc->uuid);
-	cur_attr->user_data = gatt_chrc;
+	if (gatt_chrc) {
+		gatt_chrc->uuid = uuid_store(dm, gatt_chrc->uuid);
+		cur_attr->user_data = gatt_chrc;
+	}
+
 	if (!gatt_chrc || !gatt_chrc->uuid) {
 		discovery_complete_error(dm, -ENOMEM);
 		return BT_GATT_ITER_STOP;


### PR DESCRIPTION
Fix cases where service or characteristic storage allocation failed but
continued to use the returned pointer before checking if it was actually
valid.

This resulted in MPU fault:
<err> bt_gatt_dm: Could not store ATT UUID.
<err> os: ***** MPU FAULT *****
<err> os:   Data Access Violation
<err> os:   MMFAR Address: 0x0
<err> os: Faulting instruction address (r15/pc): 0x00003cc0

Where 0x3cc0 is gatt_dm.c:379

Fixes: NCSDK-4051