### PR TITLE
tree-wide: Replace #include <misc/*.h> since all files have been moved

### DIFF
--- a/applications/asset_tracker/src/env_sensors/bsec.c
+++ b/applications/asset_tracker/src/env_sensors/bsec.c
@@ -9,7 +9,7 @@
 #include <atomic.h>
 #include <spinlock.h>
 #include <settings/settings.h>
-#include <misc/byteorder.h>
+#include <sys/byteorder.h>
 #include <i2c.h>
 #include "bsec_integration.h"
 #include "env_sensors.h"

--- a/applications/asset_tracker/src/gps_controller/gps_controller.c
+++ b/applications/asset_tracker/src/gps_controller/gps_controller.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr.h>
-#include <misc/util.h>
+#include <sys/util.h>
 #include <drivers/gps.h>
 #include <lte_lc.h>
 

--- a/applications/asset_tracker/src/main.c
+++ b/applications/asset_tracker/src/main.c
@@ -11,7 +11,7 @@
 #include <drivers/gps.h>
 #include <sensor.h>
 #include <console.h>
-#include <misc/reboot.h>
+#include <power/reboot.h>
 #include <logging/log_ctrl.h>
 #if defined(CONFIG_BSD_LIBRARY)
 #include <net/bsdlib.h>

--- a/applications/asset_tracker/src/ui/nmos.c
+++ b/applications/asset_tracker/src/ui/nmos.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr.h>
-#include <misc/util.h>
+#include <sys/util.h>
 #include <gpio.h>
 #include <pwm.h>
 

--- a/applications/nrf_desktop/configuration/common/key_id.h
+++ b/applications/nrf_desktop/configuration/common/key_id.h
@@ -8,7 +8,7 @@
 #define _KEY_ID_H_
 
 #include <zephyr/types.h>
-#include <misc/util.h>
+#include <sys/util.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/applications/nrf_desktop/configuration/common/led_effect.h
+++ b/applications/nrf_desktop/configuration/common/led_effect.h
@@ -14,7 +14,7 @@
  */
 
 #include <zephyr/types.h>
-#include <misc/util.h>
+#include <sys/util.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/applications/nrf_desktop/src/events/ble_event.c
+++ b/applications/nrf_desktop/src/events/ble_event.c
@@ -5,7 +5,7 @@
  */
 
 #include <assert.h>
-#include <misc/util.h>
+#include <sys/util.h>
 #include <stdio.h>
 
 #include "ble_event.h"

--- a/applications/nrf_desktop/src/events/module_state_event.c
+++ b/applications/nrf_desktop/src/events/module_state_event.c
@@ -6,7 +6,7 @@
 
 #include <stdio.h>
 #include <assert.h>
-#include <misc/util.h>
+#include <sys/util.h>
 
 #include "module_state_event.h"
 

--- a/applications/nrf_desktop/src/events/usb_event.c
+++ b/applications/nrf_desktop/src/events/usb_event.c
@@ -5,7 +5,7 @@
  */
 
 #include <assert.h>
-#include <misc/util.h>
+#include <sys/util.h>
 #include <stdio.h>
 
 #include "usb_event.h"

--- a/applications/nrf_desktop/src/hw_interface/buttons.c
+++ b/applications/nrf_desktop/src/hw_interface/buttons.c
@@ -10,7 +10,7 @@
 #include <soc.h>
 #include <device.h>
 #include <gpio.h>
-#include <misc/util.h>
+#include <sys/util.h>
 
 #include "key_id.h"
 #include "gpio_pins.h"

--- a/applications/nrf_desktop/src/hw_interface/motion_sensor.c
+++ b/applications/nrf_desktop/src/hw_interface/motion_sensor.c
@@ -7,7 +7,7 @@
 #include <zephyr.h>
 #include <atomic.h>
 #include <spinlock.h>
-#include <misc/byteorder.h>
+#include <sys/byteorder.h>
 
 #include <device.h>
 #include <sensor.h>

--- a/applications/nrf_desktop/src/modules/ble_discovery.c
+++ b/applications/nrf_desktop/src/modules/ble_discovery.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */
 
-#include <misc/byteorder.h>
+#include <sys/byteorder.h>
 #include <zephyr/types.h>
 
 #include <bluetooth/bluetooth.h>

--- a/applications/nrf_desktop/src/modules/ble_qos.c
+++ b/applications/nrf_desktop/src/modules/ble_qos.c
@@ -10,7 +10,7 @@
 #include <zephyr/types.h>
 #include <device.h>
 #include <drivers/uart.h>
-#include <misc/byteorder.h>
+#include <sys/byteorder.h>
 
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/conn.h>

--- a/applications/nrf_desktop/src/modules/ble_state.c
+++ b/applications/nrf_desktop/src/modules/ble_state.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/types.h>
-#include <misc/reboot.h>
+#include <power/reboot.h>
 
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/conn.h>

--- a/applications/nrf_desktop/src/modules/dfu.c
+++ b/applications/nrf_desktop/src/modules/dfu.c
@@ -7,7 +7,7 @@
 #include <inttypes.h>
 
 #include <zephyr/types.h>
-#include <misc/byteorder.h>
+#include <sys/byteorder.h>
 #include <flash_map.h>
 #include <pm_config.h>
 #include <dfu/mcuboot.h>

--- a/applications/nrf_desktop/src/modules/fn_keys.c
+++ b/applications/nrf_desktop/src/modules/fn_keys.c
@@ -6,7 +6,7 @@
 
 #include <sys/types.h>
 #include <kernel.h>
-#include <misc/util.h>
+#include <sys/util.h>
 #include <settings/settings.h>
 
 #define MODULE fn_keys

--- a/applications/nrf_desktop/src/modules/hid_forward.c
+++ b/applications/nrf_desktop/src/modules/hid_forward.c
@@ -5,11 +5,11 @@
  */
 
 #include <zephyr/types.h>
-#include <misc/slist.h>
+#include <sys/slist.h>
 
 #include <bluetooth/services/hids_c.h>
 #include <bluetooth/conn.h>
-#include <misc/byteorder.h>
+#include <sys/byteorder.h>
 
 #define MODULE hid_forward
 #include "module_state_event.h"

--- a/applications/nrf_desktop/src/modules/hid_state.c
+++ b/applications/nrf_desktop/src/modules/hid_state.c
@@ -14,8 +14,8 @@
 #include <sys/types.h>
 
 #include <zephyr/types.h>
-#include <misc/slist.h>
-#include <misc/util.h>
+#include <sys/slist.h>
+#include <sys/util.h>
 
 #include "button_event.h"
 #include "motion_event.h"

--- a/applications/nrf_desktop/src/modules/hids.c
+++ b/applications/nrf_desktop/src/modules/hids.c
@@ -9,7 +9,7 @@
 
 #include <zephyr.h>
 #include <zephyr/types.h>
-#include <misc/byteorder.h>
+#include <sys/byteorder.h>
 
 #include <bluetooth/services/hids.h>
 

--- a/applications/nrf_desktop/src/modules/led_stream.c
+++ b/applications/nrf_desktop/src/modules/led_stream.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr.h>
-#include <misc/byteorder.h>
+#include <sys/byteorder.h>
 
 #define MODULE led_stream
 #include "module_state_event.h"

--- a/applications/nrf_desktop/src/modules/usb_state.c
+++ b/applications/nrf_desktop/src/modules/usb_state.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/types.h>
-#include <misc/byteorder.h>
+#include <sys/byteorder.h>
 
 #include <usb/usb_device.h>
 #include <usb/usb_common.h>

--- a/applications/nrf_desktop/src/util/config_channel.c
+++ b/applications/nrf_desktop/src/util/config_channel.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
  */
 
-#include <misc/byteorder.h>
+#include <sys/byteorder.h>
 #include <errno.h>
 
 #include "hid_report_desc.h"

--- a/drivers/bt_ll_nrfxlib/flash/flash_ll_nrfxlib.c
+++ b/drivers/bt_ll_nrfxlib/flash/flash_ll_nrfxlib.c
@@ -10,7 +10,7 @@
 #include <device.h>
 #include <soc.h>
 #include <flash.h>
-#include <misc/util.h>
+#include <sys/util.h>
 
 #include <nrfx_nvmc.h>
 

--- a/drivers/sensor/bh1749/bh1749.c
+++ b/drivers/sensor/bh1749/bh1749.c
@@ -7,8 +7,8 @@
 #include <device.h>
 #include <sensor.h>
 #include <i2c.h>
-#include <misc/__assert.h>
-#include <misc/byteorder.h>
+#include <sys/__assert.h>
+#include <sys/byteorder.h>
 #include <init.h>
 #include <kernel.h>
 #include <string.h>

--- a/drivers/sensor/bh1749/bh1749_trigger.c
+++ b/drivers/sensor/bh1749/bh1749_trigger.c
@@ -7,7 +7,7 @@
 #include <device.h>
 #include <gpio.h>
 #include <i2c.h>
-#include <misc/util.h>
+#include <sys/util.h>
 #include <kernel.h>
 #include <sensor.h>
 #include "bh1749.h"

--- a/drivers/sensor/paw3212/paw3212.c
+++ b/drivers/sensor/paw3212/paw3212.c
@@ -10,7 +10,7 @@
 #include <device.h>
 #include <spi.h>
 #include <gpio.h>
-#include <misc/byteorder.h>
+#include <sys/byteorder.h>
 #include <sensor/paw3212.h>
 
 #include <logging/log.h>

--- a/drivers/sensor/pmw3360/pmw3360.c
+++ b/drivers/sensor/pmw3360/pmw3360.c
@@ -10,7 +10,7 @@
 #include <device.h>
 #include <spi.h>
 #include <gpio.h>
-#include <misc/byteorder.h>
+#include <sys/byteorder.h>
 #include <sensor/pmw3360.h>
 
 #include <logging/log.h>

--- a/include/bluetooth/conn_ctx.h
+++ b/include/bluetooth/conn_ctx.h
@@ -15,7 +15,7 @@
 #define BT_CONN_CTX_H_
 
 #include <zephyr.h>
-#include <misc/__assert.h>
+#include <sys/__assert.h>
 #include <bluetooth/conn.h>
 
 #ifdef __cplusplus

--- a/include/bluetooth/scan.h
+++ b/include/bluetooth/scan.h
@@ -26,7 +26,7 @@
 #define BT_SCAN_H_
 
 #include <zephyr/types.h>
-#include <misc/slist.h>
+#include <sys/slist.h>
 #include <bluetooth/hci.h>
 #include <bluetooth/uuid.h>
 #include <bluetooth/conn.h>

--- a/include/event_manager.h
+++ b/include/event_manager.h
@@ -21,8 +21,8 @@
 
 #include <zephyr.h>
 #include <zephyr/types.h>
-#include <misc/reboot.h>
-#include <misc/__assert.h>
+#include <power/reboot.h>
+#include <sys/__assert.h>
 #include <logging/log_ctrl.h>
 
 #include <event_manager_priv.h>

--- a/include/nrf_esb.h
+++ b/include/nrf_esb.h
@@ -7,7 +7,7 @@
 #define __NRF_ESB_H
 
 #include <errno.h>
-#include <misc/util.h>
+#include <sys/util.h>
 #include <nrf.h>
 #include <stdbool.h>
 #include <zephyr/types.h>

--- a/include/profiler.h
+++ b/include/profiler.h
@@ -16,8 +16,8 @@
 
 
 #include <zephyr/types.h>
-#include <misc/util.h>
-#include <misc/__assert.h>
+#include <sys/util.h>
+#include <sys/__assert.h>
 
 #ifndef CONFIG_MAX_NUMBER_OF_CUSTOM_EVENTS
 /** Maximum number of custom events. */

--- a/lib/adp536x/adp536x.c
+++ b/lib/adp536x/adp536x.c
@@ -7,7 +7,7 @@
 #include <zephyr.h>
 #include <device.h>
 #include <i2c.h>
-#include <misc/util.h>
+#include <sys/util.h>
 
 #define ADP536X_I2C_ADDR				0x46
 

--- a/lib/at_notif/at_notif.c
+++ b/lib/at_notif/at_notif.c
@@ -10,7 +10,7 @@
 #include <init.h>
 #include <at_cmd.h>
 #include <at_notif.h>
-#include <misc/slist.h>
+#include <sys/slist.h>
 
 LOG_MODULE_REGISTER(at_notif, CONFIG_AT_NOTIF_LOG_LEVEL);
 

--- a/lib/bin/lwm2m_carrier/os/lwm2m_os.c
+++ b/lib/bin/lwm2m_carrier/os/lwm2m_os.c
@@ -18,8 +18,8 @@
 #include <lte_lc.h>
 #include <net/bsdlib.h>
 #include <net/download_client.h>
-#include <misc/reboot.h>
-#include <misc/util.h>
+#include <power/reboot.h>
+#include <sys/util.h>
 #include <toolchain.h>
 #include <nvs/nvs.h>
 #include <logging/log.h>

--- a/lib/dk_buttons_and_leds/dk_buttons_and_leds.c
+++ b/lib/dk_buttons_and_leds/dk_buttons_and_leds.c
@@ -8,7 +8,7 @@
 #include <soc.h>
 #include <device.h>
 #include <gpio.h>
-#include <misc/util.h>
+#include <sys/util.h>
 #include <logging/log.h>
 #include <nrfx.h>
 #include <dk_buttons_and_leds.h>

--- a/lib/flash_patch/flash_patch.c
+++ b/lib/flash_patch/flash_patch.c
@@ -5,7 +5,7 @@
  */
 
 #include <nrf.h>
-#include <misc/reboot.h>
+#include <power/reboot.h>
 #include <init.h>
 
 #ifdef CONFIG_DISABLE_FLASH_PATCH

--- a/lib/fprotect/fprotect_bprot.c
+++ b/lib/fprotect/fprotect_bprot.c
@@ -18,7 +18,7 @@
 #else
 	#error Either NRF_BPROT or NRF_MPU must be available to use this file.
 #endif
-#include <misc/util.h>
+#include <sys/util.h>
 #include <errno.h>
 
  /* The number of CONFIG registers present in the chip. */

--- a/lib/st25r3911b/st25r3911b_common.c
+++ b/lib/st25r3911b/st25r3911b_common.c
@@ -5,7 +5,7 @@
  */
 
 #include <kernel.h>
-#include <misc/byteorder.h>
+#include <sys/byteorder.h>
 #include <device.h>
 #include <soc.h>
 #include <gpio.h>

--- a/lib/st25r3911b/st25r3911b_nfca.c
+++ b/lib/st25r3911b/st25r3911b_nfca.c
@@ -6,8 +6,8 @@
 #include <kernel.h>
 #include <stdbool.h>
 #include <assert.h>
-#include <misc/util.h>
-#include <misc/byteorder.h>
+#include <sys/util.h>
+#include <sys/byteorder.h>
 #include <string.h>
 #include <logging/log.h>
 #include <st25r3911b_nfca.h>

--- a/lib/st25r3911b/st25r3911b_spi.h
+++ b/lib/st25r3911b/st25r3911b_spi.h
@@ -9,7 +9,7 @@
 
 #include <stddef.h>
 #include <zephyr/types.h>
-#include <misc/util.h>
+#include <sys/util.h>
 
 /**
  * @file

--- a/samples/bluetooth/central_bas/src/main.c
+++ b/samples/bluetooth/central_bas/src/main.c
@@ -13,7 +13,7 @@
 #include <inttypes.h>
 #include <errno.h>
 #include <zephyr.h>
-#include <misc/printk.h>
+#include <sys/printk.h>
 
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/hci.h>

--- a/samples/bluetooth/central_dfu_smp/src/main.c
+++ b/samples/bluetooth/central_dfu_smp/src/main.c
@@ -10,7 +10,7 @@
 #include <stddef.h>
 #include <errno.h>
 #include <zephyr.h>
-#include <misc/printk.h>
+#include <sys/printk.h>
 
 #include <cbor.h>
 #include <bluetooth/bluetooth.h>
@@ -19,7 +19,7 @@
 #include <bluetooth/uuid.h>
 #include <bluetooth/gatt.h>
 #include <bluetooth/gatt_dm.h>
-#include <misc/byteorder.h>
+#include <sys/byteorder.h>
 #include <bluetooth/scan.h>
 #include <bluetooth/services/dfu_smp_c.h>
 #include <dk_buttons_and_leds.h>

--- a/samples/bluetooth/central_hids/README.rst
+++ b/samples/bluetooth/central_hids/README.rst
@@ -166,10 +166,10 @@ This sample uses the following |NCS| libraries:
 
 In addition, it uses the following Zephyr libraries:
 
-* ``include/misc/byteorder.h``
+* ``include/sys/byteorder.h``
 * ``include/zephyr/types.h``
 * ``lib/libc/minimal/include/errno.h``
-* ``include/misc/printk.h``
+* ``include/sys/printk.h``
 * :ref:`zephyr:bluetooth_api`:
 
   * ``include/bluetooth/bluetooth.h``

--- a/samples/bluetooth/central_hids/src/main.c
+++ b/samples/bluetooth/central_hids/src/main.c
@@ -10,7 +10,7 @@
 #include <stddef.h>
 #include <errno.h>
 #include <zephyr.h>
-#include <misc/printk.h>
+#include <sys/printk.h>
 
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/hci.h>
@@ -18,7 +18,7 @@
 #include <bluetooth/uuid.h>
 #include <bluetooth/gatt.h>
 #include <bluetooth/gatt_dm.h>
-#include <misc/byteorder.h>
+#include <sys/byteorder.h>
 #include <bluetooth/scan.h>
 #include <bluetooth/services/hids_c.h>
 #include <dk_buttons_and_leds.h>

--- a/samples/bluetooth/central_uart/src/main.c
+++ b/samples/bluetooth/central_uart/src/main.c
@@ -10,8 +10,8 @@
 
 #include <errno.h>
 #include <zephyr.h>
-#include <misc/byteorder.h>
-#include <misc/printk.h>
+#include <sys/byteorder.h>
+#include <sys/printk.h>
 
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/hci.h>

--- a/samples/bluetooth/llpm/README.rst
+++ b/samples/bluetooth/llpm/README.rst
@@ -282,7 +282,7 @@ In addition, it uses the following Zephyr libraries:
 
   * :file:`include/kernel.h`
 
-* :file:`include/misc/printk.h`
+* :file:`include/sys/printk.h`
 * :file:`include/zephyr/types.h`
 * :ref:`zephyr:bluetooth_api`:
 

--- a/samples/bluetooth/llpm/src/main.c
+++ b/samples/bluetooth/llpm/src/main.c
@@ -6,7 +6,7 @@
 
 #include <console.h>
 #include <string.h>
-#include <misc/printk.h>
+#include <sys/printk.h>
 #include <zephyr/types.h>
 
 #include <bluetooth/bluetooth.h>

--- a/samples/bluetooth/peripheral_gatt_dm/README.rst
+++ b/samples/bluetooth/peripheral_gatt_dm/README.rst
@@ -53,8 +53,8 @@ In addition, it uses the following Zephyr libraries:
 
 * ``include/zephyr/types.h``
 * ``lib/libc/minimal/include/errno.h``
-* ``include/misc/printk.h``
-* ``include/misc/byteorder.h``
+* ``include/sys/printk.h``
+* ``include/sys/byteorder.h``
 * :ref:`zephyr:bluetooth_api`:
 
   * ``include/bluetooth/bluetooth.h``

--- a/samples/bluetooth/peripheral_gatt_dm/src/main.c
+++ b/samples/bluetooth/peripheral_gatt_dm/src/main.c
@@ -8,8 +8,8 @@
 #include <stddef.h>
 #include <string.h>
 #include <errno.h>
-#include <misc/printk.h>
-#include <misc/byteorder.h>
+#include <sys/printk.h>
+#include <sys/byteorder.h>
 #include <zephyr.h>
 #include <gpio.h>
 #include <soc.h>

--- a/samples/bluetooth/peripheral_hids_keyboard/README.rst
+++ b/samples/bluetooth/peripheral_hids_keyboard/README.rst
@@ -192,8 +192,8 @@ When the `NFC_OOB_PAIRING` feature is enabled, it also uses the Type 2 Tag libra
 The sample uses the following Zephyr libraries:
 
 * ``include/zephyr/types.h``
-* ``include/misc/printk.h``
-* ``include/misc/byteorder.h``
+* ``include/sys/printk.h``
+* ``include/sys/byteorder.h``
 * :ref:`GPIO Interface <zephyr:api_peripherals>`
 * :ref:`zephyr:settings`
 * :ref:`zephyr:bluetooth_api`:

--- a/samples/bluetooth/peripheral_hids_keyboard/src/main.c
+++ b/samples/bluetooth/peripheral_hids_keyboard/src/main.c
@@ -8,8 +8,8 @@
 #include <stddef.h>
 #include <string.h>
 #include <errno.h>
-#include <misc/printk.h>
-#include <misc/byteorder.h>
+#include <sys/printk.h>
+#include <sys/byteorder.h>
 #include <zephyr.h>
 #include <gpio.h>
 #include <soc.h>

--- a/samples/bluetooth/peripheral_hids_mouse/README.rst
+++ b/samples/bluetooth/peripheral_hids_mouse/README.rst
@@ -127,8 +127,8 @@ In addition, it uses the following Zephyr libraries:
 * ``include/zephyr/types.h``
 * ``lib/libc/minimal/include/assert.h``
 * ``lib/libc/minimal/include/errno.h``
-* ``include/misc/printk.h``
-* ``include/misc/byteorder.h``
+* ``include/sys/printk.h``
+* ``include/sys/byteorder.h``
 * :ref:`GPIO Interface <zephyr:api_peripherals>`
 * :ref:`zephyr:settings`
 * :ref:`zephyr:bluetooth_api`:

--- a/samples/bluetooth/peripheral_hids_mouse/src/main.c
+++ b/samples/bluetooth/peripheral_hids_mouse/src/main.c
@@ -8,8 +8,8 @@
 #include <stddef.h>
 #include <string.h>
 #include <errno.h>
-#include <misc/printk.h>
-#include <misc/byteorder.h>
+#include <sys/printk.h>
+#include <sys/byteorder.h>
 #include <zephyr.h>
 #include <gpio.h>
 #include <soc.h>

--- a/samples/bluetooth/peripheral_lbs/README.rst
+++ b/samples/bluetooth/peripheral_lbs/README.rst
@@ -97,8 +97,8 @@ In addition, it uses the following Zephyr libraries:
 
 * ``include/zephyr/types.h``
 * ``lib/libc/minimal/include/errno.h``
-* ``include/misc/printk.h``
-* ``include/misc/byteorder.h``
+* ``include/sys/printk.h``
+* ``include/sys/byteorder.h``
 * :ref:`GPIO Interface <zephyr:api_peripherals>`
 * :ref:`zephyr:bluetooth_api`:
 

--- a/samples/bluetooth/peripheral_lbs/src/main.c
+++ b/samples/bluetooth/peripheral_lbs/src/main.c
@@ -8,8 +8,8 @@
 #include <stddef.h>
 #include <string.h>
 #include <errno.h>
-#include <misc/printk.h>
-#include <misc/byteorder.h>
+#include <sys/printk.h>
+#include <sys/byteorder.h>
 #include <zephyr.h>
 #include <gpio.h>
 #include <soc.h>

--- a/samples/bluetooth/throughput/README.rst
+++ b/samples/bluetooth/throughput/README.rst
@@ -208,7 +208,7 @@ In addition, it uses the following Zephyr libraries:
 
   * ``include/kernel.h``
 
-* ``include/misc/printk.h``
+* ``include/sys/printk.h``
 * ``include/zephyr/types.h``
 * :ref:`zephyr:bluetooth_api`:
 

--- a/samples/bluetooth/throughput/src/main.c
+++ b/samples/bluetooth/throughput/src/main.c
@@ -6,7 +6,7 @@
 
 #include <kernel.h>
 #include <console.h>
-#include <misc/printk.h>
+#include <sys/printk.h>
 #include <string.h>
 #include <zephyr/types.h>
 

--- a/samples/bootloader/src/main.c
+++ b/samples/bootloader/src/main.c
@@ -7,8 +7,8 @@
 #include <zephyr/types.h>
 #include <errno.h>
 #include <toolchain.h>
-#include <misc/util.h>
-#include <misc/printk.h>
+#include <sys/util.h>
+#include <sys/printk.h>
 #include <nrf.h>
 #include <pm_config.h>
 #include <bl_validation.h>

--- a/samples/mpsl/timeslot/README.rst
+++ b/samples/mpsl/timeslot/README.rst
@@ -66,5 +66,5 @@ In addition, it uses the following Zephyr libraries:
   * :file:`include/kernel.h`
   * :file:`include/irq.h`
 
-* :file:`include/misc/printk.h`
+* :file:`include/sys/printk.h`
 * :file:`include/zephyr/types.h`

--- a/samples/mpsl/timeslot/src/main.c
+++ b/samples/mpsl/timeslot/src/main.c
@@ -7,7 +7,7 @@
 #include <kernel.h>
 #include <console.h>
 #include <string.h>
-#include <misc/printk.h>
+#include <sys/printk.h>
 #include <zephyr/types.h>
 #include <irq.h>
 

--- a/samples/nfc/record_text/README.rst
+++ b/samples/nfc/record_text/README.rst
@@ -64,5 +64,5 @@ The sample uses the following Zephyr libraries:
 
 * ``include/zephyr.h``
 * ``include/device.h``
-* ``include/misc/reboot.h``
+* ``include/power/reboot.h``
 * :ref:`GPIO Interface <zephyr:api_peripherals>`

--- a/samples/nfc/record_text/src/main.c
+++ b/samples/nfc/record_text/src/main.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr.h>
-#include <misc/reboot.h>
+#include <power/reboot.h>
 
 #include <nfc_t2t_lib.h>
 #include <nfc/ndef/nfc_ndef_msg.h>

--- a/samples/nfc/tag_reader/README.rst
+++ b/samples/nfc/tag_reader/README.rst
@@ -69,4 +69,4 @@ This sample uses the following |NCS| libraries:
 In addition, it uses the following Zephyr libraries:
 
 * ``include/zephyr/types.h``
-* ``include/misc/printk.h``
+* ``include/sys/printk.h``

--- a/samples/nfc/tag_reader/src/main.c
+++ b/samples/nfc/tag_reader/src/main.c
@@ -11,7 +11,7 @@
 #include <stdbool.h>
 #include <string.h>
 #include <zephyr.h>
-#include <misc/printk.h>
+#include <sys/printk.h>
 #include <st25r3911b_nfca.h>
 #include <nfc/ndef/msg_parser.h>
 #include <nfc/t2t/parser.h>

--- a/samples/nfc/tnep_tag/README.rst
+++ b/samples/nfc/tnep_tag/README.rst
@@ -67,4 +67,4 @@ This sample uses the following |NCS| libraries:
 
 In addition, it uses the following Zephyr libraries:
 
-* ``include/misc/until.h``
+* ``include/sys/until.h``

--- a/samples/nfc/tnep_tag/src/main.c
+++ b/samples/nfc/tnep_tag/src/main.c
@@ -6,7 +6,7 @@
 #include <stdbool.h>
 #include <string.h>
 #include <zephyr.h>
-#include <misc/util.h>
+#include <sys/util.h>
 
 #include <dk_buttons_and_leds.h>
 

--- a/samples/nrf9160/aws_fota/src/main.c
+++ b/samples/nrf9160/aws_fota/src/main.c
@@ -15,7 +15,7 @@
 #include <net/bsdlib.h>
 #include <net/aws_fota.h>
 #include <dfu/mcuboot.h>
-#include <misc/reboot.h>
+#include <power/reboot.h>
 
 #if defined(CONFIG_USE_NRF_CLOUD)
 #define NRF_CLOUD_SECURITY_TAG 16842753

--- a/samples/nrf9160/lte_ble_gateway/src/alarm.c
+++ b/samples/nrf9160/lte_ble_gateway/src/alarm.c
@@ -5,7 +5,7 @@
  */
 #include <string.h>
 #include <stdbool.h>
-#include <misc/printk.h>
+#include <sys/printk.h>
 #include <nrf_cloud.h>
 
 #include "alarm.h"

--- a/samples/nrf9160/lte_ble_gateway/src/ble.c
+++ b/samples/nrf9160/lte_ble_gateway/src/ble.c
@@ -12,7 +12,7 @@
 #include <bluetooth/scan.h>
 
 #include <dk_buttons_and_leds.h>
-#include <misc/byteorder.h>
+#include <sys/byteorder.h>
 
 #include <nrf_cloud.h>
 #include "aggregator.h"

--- a/samples/nrf9160/lte_ble_gateway/src/main.c
+++ b/samples/nrf9160/lte_ble_gateway/src/main.c
@@ -13,7 +13,7 @@
 #include <nrf_cloud.h>
 #include <dk_buttons_and_leds.h>
 #include <lte_lc.h>
-#include <misc/reboot.h>
+#include <power/reboot.h>
 #include <net/bsdlib.h>
 
 #include "aggregator.h"

--- a/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_device.c
+++ b/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_device.c
@@ -7,7 +7,7 @@
 #include <zephyr.h>
 #include <version.h>
 #include <logging/log_ctrl.h>
-#include <misc/reboot.h>
+#include <power/reboot.h>
 #include <net/lwm2m.h>
 #include "pm_config.h"
 #include "lwm2m_client.h"

--- a/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_firmware.c
+++ b/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_firmware.c
@@ -10,7 +10,7 @@
 #include <dfu/mcuboot.h>
 #include <dfu/flash_img.h>
 #include <logging/log_ctrl.h>
-#include <misc/reboot.h>
+#include <power/reboot.h>
 #include <net/lwm2m.h>
 
 #include "settings.h"

--- a/samples/nrf9160/secure_services/src/main.c
+++ b/samples/nrf9160/secure_services/src/main.c
@@ -5,8 +5,8 @@
  */
 
 #include <zephyr.h>
-#include <misc/printk.h>
-#include <misc/reboot.h>
+#include <sys/printk.h>
+#include <power/reboot.h>
 #include <secure_services.h>
 #include <kernel.h>
 #include <pm_config.h>

--- a/samples/sensor/bh1749/src/main.c
+++ b/samples/sensor/bh1749/src/main.c
@@ -9,7 +9,7 @@
 #include <device.h>
 #include <sensor.h>
 #include <stdio.h>
-#include <misc/__assert.h>
+#include <sys/__assert.h>
 
 #define THRESHOLD_UPPER                 50
 #define THRESHOLD_LOWER                 0

--- a/subsys/bluetooth/controller/crypto.c
+++ b/subsys/bluetooth/controller/crypto.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/types.h>
-#include <misc/byteorder.h>
+#include <sys/byteorder.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <soc.h>

--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -9,7 +9,7 @@
 #include <irq.h>
 #include <kernel.h>
 #include <soc.h>
-#include <misc/byteorder.h>
+#include <sys/byteorder.h>
 #include <stdbool.h>
 
 #include <ble_controller.h>

--- a/subsys/bluetooth/scan.c
+++ b/subsys/bluetooth/scan.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr.h>
-#include <misc/byteorder.h>
+#include <sys/byteorder.h>
 #include <string.h>
 #include <bluetooth/scan.h>
 

--- a/subsys/bluetooth/services/hids.c
+++ b/subsys/bluetooth/services/hids.c
@@ -6,7 +6,7 @@
 
 #include <assert.h>
 #include <errno.h>
-#include <misc/byteorder.h>
+#include <sys/byteorder.h>
 #include <stddef.h>
 #include <string.h>
 #include <zephyr.h>

--- a/subsys/bluetooth/services/latency.c
+++ b/subsys/bluetooth/services/latency.c
@@ -5,7 +5,7 @@
  */
 
 #include <string.h>
-#include <misc/printk.h>
+#include <sys/printk.h>
 #include <zephyr/types.h>
 #include <logging/log.h>
 

--- a/subsys/bluetooth/services/latency_c.c
+++ b/subsys/bluetooth/services/latency_c.c
@@ -5,7 +5,7 @@
  */
 
 #include <string.h>
-#include <misc/printk.h>
+#include <sys/printk.h>
 #include <zephyr/types.h>
 #include <logging/log.h>
 

--- a/subsys/bluetooth/services/lbs.c
+++ b/subsys/bluetooth/services/lbs.c
@@ -12,8 +12,8 @@
 #include <stddef.h>
 #include <string.h>
 #include <errno.h>
-#include <misc/printk.h>
-#include <misc/byteorder.h>
+#include <sys/printk.h>
+#include <sys/byteorder.h>
 #include <zephyr.h>
 
 #include <bluetooth/bluetooth.h>

--- a/subsys/bluetooth/services/throughput.c
+++ b/subsys/bluetooth/services/throughput.c
@@ -5,7 +5,7 @@
  */
 
 #include <kernel.h>
-#include <misc/printk.h>
+#include <sys/printk.h>
 #include <string.h>
 #include <zephyr/types.h>
 

--- a/subsys/bootloader/bl_crypto/bl_crypto_cc310_common.c
+++ b/subsys/bootloader/bl_crypto/bl_crypto_cc310_common.c
@@ -6,7 +6,7 @@
 
 #include <errno.h>
 #include <zephyr/types.h>
-#include <misc/util.h>
+#include <sys/util.h>
 #include <toolchain.h>
 #include <nrf.h>
 #include <nrf_cc310_bl_init.h>

--- a/subsys/bootloader/bl_crypto/bl_crypto_cc310_hash.c
+++ b/subsys/bootloader/bl_crypto/bl_crypto_cc310_hash.c
@@ -6,7 +6,7 @@
 
 #include <zephyr/types.h>
 #include <linker/sections.h>
-#include <misc/util.h>
+#include <sys/util.h>
 #include <errno.h>
 #include <nrf_cc310_bl_hash_sha256.h>
 #include <generated_dts_board.h>

--- a/subsys/bootloader/bl_validation/bl_validation.c
+++ b/subsys/bootloader/bl_validation/bl_validation.c
@@ -7,7 +7,7 @@
 #include <bl_validation.h>
 #include <zephyr/types.h>
 #include <errno.h>
-#include <misc/printk.h>
+#include <sys/printk.h>
 #include <fw_info.h>
 #include <bl_crypto.h>
 #include <provision.h>

--- a/subsys/enhanced_shockburst/nrf_esb.c
+++ b/subsys/enhanced_shockburst/nrf_esb.c
@@ -5,7 +5,7 @@
  */
 #include <errno.h>
 #include <irq.h>
-#include <misc/byteorder.h>
+#include <sys/byteorder.h>
 #include <nrf.h>
 #include <nrf_esb.h>
 #include <stddef.h>

--- a/subsys/event_manager/event_manager.c
+++ b/subsys/event_manager/event_manager.c
@@ -7,7 +7,7 @@
 #include <stdio.h>
 #include <zephyr.h>
 #include <spinlock.h>
-#include <misc/slist.h>
+#include <sys/slist.h>
 #include <event_manager.h>
 #include <logging/log.h>
 

--- a/subsys/net/lib/aws_fota/src/aws_fota_json.c
+++ b/subsys/net/lib/aws_fota/src/aws_fota_json.c
@@ -7,7 +7,7 @@
 #include <zephyr.h>
 #include <string.h>
 #include <json.h>
-#include <misc/util.h>
+#include <sys/util.h>
 #include <net/aws_jobs.h>
 
 #include "aws_fota_json.h"

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
@@ -12,7 +12,7 @@
 #include <net/mqtt.h>
 #include <net/socket.h>
 #include <logging/log.h>
-#include <misc/util.h>
+#include <sys/util.h>
 
 #if defined(CONFIG_BSD_LIBRARY)
 #include <nrf_socket.h>

--- a/subsys/nfc/ndef/nfc_ndef_msg.c
+++ b/subsys/nfc/ndef/nfc_ndef_msg.c
@@ -5,8 +5,8 @@
  */
 
 #include <nfc/ndef/nfc_ndef_msg.h>
-#include <misc/byteorder.h>
-#include <misc/util.h>
+#include <sys/byteorder.h>
+#include <sys/util.h>
 #include <errno.h>
 
 /* Resolve the value of record location flags of the NFC NDEF record

--- a/subsys/nfc/ndef/nfc_ndef_record.c
+++ b/subsys/nfc/ndef/nfc_ndef_record.c
@@ -7,7 +7,7 @@
 #include <string.h>
 #include <errno.h>
 #include <nfc/ndef/nfc_ndef_record.h>
-#include <misc/byteorder.h>
+#include <sys/byteorder.h>
 
 /* Sum of sizes of fields: TNF-flags, Type Length, Payload Length in long
  * NDEF record.

--- a/subsys/nfc/ndef/record_parser.c
+++ b/subsys/nfc/ndef/record_parser.c
@@ -7,8 +7,8 @@
 #include <stdbool.h>
 #include <errno.h>
 #include <logging/log.h>
-#include <misc/util.h>
-#include <misc/byteorder.h>
+#include <sys/util.h>
+#include <sys/byteorder.h>
 #include <nfc/ndef/record_parser.h>
 
 LOG_MODULE_DECLARE(nfc_ndef_parser);

--- a/subsys/nfc/ndef/tnep_rec.c
+++ b/subsys/nfc/ndef/tnep_rec.c
@@ -6,7 +6,7 @@
 
 #include <zephyr.h>
 #include <string.h>
-#include <misc/byteorder.h>
+#include <sys/byteorder.h>
 #include <nfc/ndef/tnep_rec.h>
 
 #define NFC_NDEF_TNEP_STATUS_SIZE 1

--- a/subsys/nfc/t2t/parser.c
+++ b/subsys/nfc/t2t/parser.c
@@ -5,7 +5,7 @@
  */
 #include <stdbool.h>
 #include <errno.h>
-#include <misc/byteorder.h>
+#include <sys/byteorder.h>
 #include <logging/log.h>
 #include <nfc/t2t/parser.h>
 

--- a/subsys/profiler/profiler_nordic.c
+++ b/subsys/profiler/profiler_nordic.c
@@ -6,9 +6,9 @@
 
 #include <stdio.h>
 #include <kernel_structs.h>
-#include <misc/printk.h>
-#include <misc/util.h>
-#include <misc/byteorder.h>
+#include <sys/printk.h>
+#include <sys/util.h>
+#include <sys/byteorder.h>
 #include <zephyr.h>
 #include <SEGGER_RTT.h>
 #include <profiler.h>

--- a/subsys/spm/secure_services.c
+++ b/subsys/spm/secure_services.c
@@ -6,8 +6,8 @@
 #include <zephyr.h>
 #include <errno.h>
 #include <cortex_m/tz.h>
-#include <misc/reboot.h>
-#include <misc/util.h>
+#include <power/reboot.h>
+#include <sys/util.h>
 #include <autoconf.h>
 #include <secure_services.h>
 #include <string.h>

--- a/subsys/spm/spm.c
+++ b/subsys/spm/spm.c
@@ -5,8 +5,8 @@
  */
 
 #include <zephyr.h>
-#include <misc/printk.h>
-#include <misc/util.h>
+#include <sys/printk.h>
+#include <sys/util.h>
 #include <linker/linker-defs.h>
 #include <device.h>
 #include <gpio.h>

--- a/subsys/spm/spm_internal.h
+++ b/subsys/spm/spm_internal.h
@@ -9,7 +9,7 @@
 
 #include <zephyr.h>
 #include <nrfx.h>
-#include <misc/util.h>
+#include <sys/util.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/tests/subsys/bluetooth/gatt_dm/mock/gatt_discover_mock.c
+++ b/tests/subsys/bluetooth/gatt_dm/mock/gatt_discover_mock.c
@@ -9,7 +9,7 @@
 #include <bluetooth/uuid.h>
 #include <kernel.h>
 #include <ztest.h>
-#include <misc/util.h>
+#include <sys/util.h>
 
 
 /* Settings of the discover mock */

--- a/tests/subsys/bluetooth/gatt_dm/src/main.c
+++ b/tests/subsys/bluetooth/gatt_dm/src/main.c
@@ -6,7 +6,7 @@
 #include <ztest.h>
 #include <kernel.h>
 #include <stddef.h>
-#include <misc/util.h>
+#include <sys/util.h>
 #include <bluetooth/uuid.h>
 #include <bluetooth/gatt_dm.h>
 #include "../mock/gatt_discover_mock.h"

--- a/tests/unity/example_test/src/example_test.h
+++ b/tests/unity/example_test/src/example_test.h
@@ -6,7 +6,7 @@
 #ifndef EXAMPLE_TEST_H_
 #define EXAMPLE_TEST_H_
 
-#include <misc/util.h>
+#include <sys/util.h>
 #include <stdbool.h>
 
 /* This header shows how to handle testing of compile time options in a single

--- a/tests/unity/example_test/src/uut/uut.c
+++ b/tests/unity/example_test/src/uut/uut.c
@@ -5,7 +5,7 @@
  */
 #include <uut.h>
 #include <foo/foo.h>
-#include <misc/util.h>
+#include <sys/util.h>
 #include <stddef.h>
 
 int uut_init(void *handle)


### PR DESCRIPTION
Replace misc/reboot.h with power/reboot, and all other misc/* with sys/*

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>