### PR TITLE
net: lib: zzhc: fixed filter for MODEL.

### DIFF
--- a/subsys/net/lib/zzhc/zzhc_internal.h
+++ b/subsys/net/lib/zzhc/zzhc_internal.h
@@ -111,17 +111,6 @@ struct zzhc {
 /**@brief Free. */
 #define zzhc_free(ptr)                          k_free(ptr)
 
-/**@brief Read chip-revision from FICR.
- *
- * This function request reading of FICR register 0x00FF0134.
- *
- * @param i   Pointer to 4-byte integer buffer for storage of FICR value.
- *
- * @return 0 on success, non-zero on failure.
- *
- */
-int zzhc_read_chip_rev(u32_t *i);
-
 /**@brief Save ICCID to file.
  *
  * The function saves ICCID to non-volatile storage.

--- a/subsys/net/lib/zzhc/zzhc_port.c
+++ b/subsys/net/lib/zzhc/zzhc_port.c
@@ -9,7 +9,6 @@ LOG_MODULE_REGISTER(zzhc_port, CONFIG_ZZHC_LOG_LEVEL);
 
 #include <zephyr.h>
 #include <base64.h>
-#include <secure_services.h>
 #include <json.h>
 #include <at_cmd_parser/at_cmd_parser.h>
 #include "zzhc_internal.h"
@@ -39,13 +38,6 @@ static const struct json_obj_descr rsp_desc[] = {
 	JSON_OBJ_DESCR_PRIM_NAMED(struct rsp_obj, "resultDesc", res_desc,
 		JSON_TOK_STRING),
 };
-
-int zzhc_read_chip_rev(u32_t *i)
-{
-	u32_t ficr_addr = NRF_FICR_S_BASE + FICR_REV_OFFSET;
-
-	return spm_request_read(i, ficr_addr, sizeof(u32_t));
-}
 
 int zzhc_load_iccid(char *iccid_buf, int buf_len)
 {


### PR DESCRIPTION
MODEL should not consist of underscore, and should contain English
characters, arabic numbers, +, - and (space).

Signed-off-by: PK Chan <pak.kee.chan@nordicsemi.no>