### PR TITLE
subsys: bluetooth: bas_c: Changed notifications disabled log.

### DIFF
--- a/subsys/bluetooth/services/bas_c.c
+++ b/subsys/bluetooth/services/bas_c.c
@@ -39,7 +39,7 @@ static u8_t notify_process(struct bt_conn *conn,
 
 	bas_c = CONTAINER_OF(params, struct bt_gatt_bas_c, notify_params);
 	if (!data || !length) {
-		LOG_ERR("NULL notification received.");
+		LOG_INF("Notifications disabled.");
 		if (bas_c->notify_cb) {
 			bas_c->notify_cb(bas_c, BT_GATT_BAS_VAL_INVALID);
 		}


### PR DESCRIPTION
Fixing NCSDK-3894 raised by verification. Changed log level from ERR to INF as NULL notifications just inform the subscription has stopped.