### PR TITLE
spm: make NRF_REGULATORS default non-secure

### DIFF
--- a/subsys/spm/Kconfig
+++ b/subsys/spm/Kconfig
@@ -190,7 +190,7 @@ config SPM_NRF_PWM3_NS
 
 config SPM_NRF_REGULATORS_NS
 	bool "Regulators is Non-Secure"
-	default n
+	default y
 
 config SPM_NRF_WDT_NS
 	bool "WDT is Non-Secure"


### PR DESCRIPTION
This is needed to run non-secure samples on nRF53.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>