### PR TITLE
kconfig: add "Bootloader" menu

### DIFF
--- a/subsys/Kconfig
+++ b/subsys/Kconfig
@@ -7,10 +7,6 @@
 
 rsource "bootloader/Kconfig"
 
-rsource "bootloader/bl_crypto/Kconfig"
-
-rsource "bootloader/bl_validation/Kconfig"
-
 rsource "bluetooth/Kconfig"
 
 rsource "dfu/Kconfig"

--- a/subsys/bootloader/Kconfig
+++ b/subsys/bootloader/Kconfig
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
+menu "Bootloader"
+
 config MCUBOOT_BUILD_S1_VARIANT
 	# This can not depend on BOOTLOADER_MCUBOOT, or SECURE_BOOT as this
 	# option has to be set when building MCUBoot itself. Instead an error
@@ -31,7 +33,6 @@ config SB_PRIVATE_KEY_PROVIDED
 	  Hidden config specifying whether the build system has access to the
 	  private key used for signing, and will use it to perform signing and
 	  create the public key for the provision page.
-
 
 choice SB_SIGNING
 	prompt "Firmware signing method"
@@ -106,7 +107,6 @@ config SB_DEBUG_SIGNATURE_PUBLIC_KEY_LAST
 	  first. This is meant to be used for testing looping through the
 	  public keys.
 
-
 endif # SECURE_BOOT
 
 menuconfig IS_SECURE_BOOTLOADER
@@ -153,3 +153,8 @@ config SB_BPROT_IN_DEBUG
 
 endif # SECURE_BOOT_DEBUG
 endif # IS_SECURE_BOOTLOADER
+
+rsource "bl_crypto/Kconfig"
+rsource "bl_validation/Kconfig"
+
+endmenu

--- a/subsys/dfu/Kconfig
+++ b/subsys/dfu/Kconfig
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
+menu "DFU"
+
 menuconfig DFU_TARGET
 	bool "Device Firmware Upgrade target API"
 
@@ -42,3 +44,5 @@ module-str=Device Firmware Upgrade
 source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
 
 endif # DFU_TARGET
+
+endmenu

--- a/subsys/spm/Kconfig
+++ b/subsys/spm/Kconfig
@@ -213,8 +213,6 @@ config SPM_NRF_DPPIC_PERM_MASK
 
 endif # IS_SPM
 
-endmenu
-
 # Set new default name for the veneers file.
 
 if ARM_FIRMWARE_USES_SECURE_ENTRY_FUNCS
@@ -228,3 +226,5 @@ config ARM_ENTRY_VENEERS_LIB_NAME
 	string "Entry Veneers symbol file"
 	default "libspmsecureentries.a"
 endif
+
+endmenu # SPM


### PR DESCRIPTION
Add a "Bootloader" menu to avoid cluttering the top-level
Kconfig menu with bootloader-related entries.