### PR TITLE
doc: zephyr: Fix conf.py to support tabs

### DIFF
--- a/doc/zephyr/conf.py
+++ b/doc/zephyr/conf.py
@@ -67,7 +67,8 @@ extensions = [
     'zephyr.application',
     'zephyr.html_redirects',
     'only.eager_only',
-    'zephyr.link-roles'
+    'zephyr.link-roles',
+    'sphinx_tabs.tabs'
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
After 7d3f2f6ce18f4939692c1594824f7c8695c098c9 was introduced to
upstream Zephyr, the Sphinx config requires tabs to be enabled. Enable
them in our own copy of it.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>