### PR TITLE
cmake: multi_image: expose childrens shared vars to parent

### DIFF
--- a/cmake/multi_image.cmake
+++ b/cmake/multi_image.cmake
@@ -151,6 +151,16 @@ function(add_child_image_from_source name sourcedir)
     RESULT_VARIABLE ret
     )
 
+  if (IMAGE_NAME)
+    # Expose your childrens secrets to your parent
+    set_property(
+      TARGET         zephyr_property_target
+      APPEND_STRING
+      PROPERTY       shared_vars
+      "include(${CMAKE_BINARY_DIR}/${name}/shared_vars.cmake)\n"
+      )
+  endif()
+
   set_property(DIRECTORY APPEND PROPERTY
     CMAKE_CONFIGURE_DEPENDS
     ${CMAKE_BINARY_DIR}/${name}/zephyr/.config


### PR DESCRIPTION
Enable arbitrary depth family-tree by exposing the childrens
shared vars to your parent.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>