### PR TITLE
manifest: Update zephyr to include PR 258

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -36,7 +36,7 @@ manifest:
     - name: zephyr
       repo-path: fw-nrfconnect-zephyr
       west-commands: scripts/west-commands.yml
-      revision: eb4e78d449a37114da70439366e9134e574d9144
+      revision: pull/258/head
     - name: nffs
       revision: bc62a2fa9d98ddb5d633c932ea199bc68e10f194
       path: modules/fs/nffs


### PR DESCRIPTION
Update zephyr to include PR 258. This will test whether the commit
that is being reverted in 258 is needed.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>