### PR TITLE
partition_manager: allow empty pm.yml

### DIFF
--- a/scripts/partition_manager.py
+++ b/scripts/partition_manager.py
@@ -435,6 +435,8 @@ def load_reqs(reqs, input_config):
         if path.exists(ymlpath):
             with open(ymlpath, 'r') as f:
                 loaded_reqs = yaml.safe_load(f)
+                if loaded_reqs is None:
+                    continue
                 for key in loaded_reqs.keys():
                     if key in reqs.keys() and loaded_reqs[key] != reqs[key]:
                         raise RuntimeError("Conflicting configuration found for '{}' value for key '{}' differs."


### PR DESCRIPTION
yaml.safe_load(stream) returns None if no documents are found within stream.
Add check for this when reading pm.yml files.

Signed-off-by: Audun Korneliussen <audun.korneliussen@nordicsemi.no>