### PR TITLE
cmake: include nrf reports cmake from repo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@
 set(NRF_DIR ${CMAKE_CURRENT_LIST_DIR} CACHE PATH "NCS root directory")
 
 include(cmake/multi_image.cmake)
+include(cmake/reports.cmake)
 
 zephyr_include_directories(include)
 

--- a/cmake/reports.cmake
+++ b/cmake/reports.cmake
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+add_custom_target(
+  partition_manager_report
+  COMMAND
+  ${PYTHON_EXECUTABLE}
+  ${ZEPHYR_BASE}/../nrf/scripts/partition_manager_report.py
+  --input ${CMAKE_BINARY_DIR}/partitions.yml
+  "$<$<NOT:$<TARGET_EXISTS:partition_manager>>:--quiet>"
+  )
+
+set_property(TARGET zephyr_property_target
+             APPEND PROPERTY rom_report_DEPENDENCIES
+             partition_manager_report
+	     )

--- a/west.yml
+++ b/west.yml
@@ -38,7 +38,7 @@ manifest:
     - name: zephyr
       repo-path: fw-nrfconnect-zephyr
       west-commands: scripts/west-commands.yml
-      revision: 8a6e96296c17b9902bb4392f87a5888b69c182b0
+      revision: 30f47eace36c9593c8f6efacebc75c0f66aa7b17
     - name: segger
       revision: 6fcf61606d6012d2c44129edc033f59331e268bc
       path: modules/debug/segger


### PR DESCRIPTION
To make patches simpler and diff smaller.

Depends on https://github.com/NordicPlayground/fw-nrfconnect-zephyr/pull/260

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>