### PR TITLE
samples: nfc: align cmake supported boards description

### DIFF
--- a/samples/nfc/record_text/CMakeLists.txt
+++ b/samples/nfc/record_text/CMakeLists.txt
@@ -6,16 +6,14 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
+set(NRF_SUPPORTED_BOARDS
+  nrf52_pca10040
+  nrf52840_pca10056
+  )
+
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
-
-# Check if selected board is supported.
-if(${BOARD} STREQUAL "nrf52_pca10040")
-elseif(${BOARD} STREQUAL "nrf52840_pca10056")
-else()
-	message(FATAL_ERROR "board ${BOARD} is not supported")
-endif()
 
 FILE(GLOB app_sources src/*.c)
 # NORDIC SDK APP START

--- a/samples/nfc/writable_ndef_msg/CMakeLists.txt
+++ b/samples/nfc/writable_ndef_msg/CMakeLists.txt
@@ -6,16 +6,14 @@
 
 cmake_minimum_required(VERSION 3.8.2)
 
+set(NRF_SUPPORTED_BOARDS
+  nrf52_pca10040
+  nrf52840_pca10056
+  )
+
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(NONE)
-
-# Check if selected board is supported.
-if(${BOARD} STREQUAL "nrf52_pca10040")
-elseif(${BOARD} STREQUAL "nrf52840_pca10056")
-else()
-	message(FATAL_ERROR "board ${BOARD} is not supported")
-endif()
 
 FILE(GLOB app_sources src/*.c)
 # NORDIC SDK APP START


### PR DESCRIPTION
Aligned Cmake descriptions for supported boards across all NFC samples.
All samples now use NRF_SUPPORTED_BOARDS variable to indicate the board
support.

Signed-off-by: Kamil Piszczek <Kamil.Piszczek@nordicsemi.no>