### PR TITLE
Bluetooth: Mesh: Use max TTL in samples

### DIFF
--- a/samples/bluetooth/mesh/light/src/model_handler.c
+++ b/samples/bluetooth/mesh/light/src/model_handler.c
@@ -115,7 +115,7 @@ static struct bt_mesh_cfg_srv cfg_srv = {
 	.beacon = BT_MESH_BEACON_ENABLED,
 	.frnd = IS_ENABLED(CONFIG_BT_MESH_FRIEND),
 	.gatt_proxy = IS_ENABLED(CONFIG_BT_MESH_GATT_PROXY),
-	.default_ttl = BT_MESH_TTL_DEFAULT,
+	.default_ttl = 7,
 
 	/* 3 transmissions with 20ms interval */
 	.net_transmit = BT_MESH_TRANSMIT(2, 20),

--- a/samples/bluetooth/mesh/light_switch/src/model_handler.c
+++ b/samples/bluetooth/mesh/light_switch/src/model_handler.c
@@ -96,7 +96,7 @@ static struct bt_mesh_cfg_srv cfg_srv = {
 	.beacon = BT_MESH_BEACON_ENABLED,
 	.frnd = IS_ENABLED(CONFIG_BT_MESH_FRIEND),
 	.gatt_proxy = IS_ENABLED(CONFIG_BT_MESH_GATT_PROXY),
-	.default_ttl = BT_MESH_TTL_DEFAULT,
+	.default_ttl = 7,
 
 	/* 3 transmissions with 20ms interval */
 	.net_transmit = BT_MESH_TRANSMIT(2, 20),


### PR DESCRIPTION
Default TTL value was erronously set to TTL_DEFAULT, which is
an invalid value. Changing to max guarantees correct behavior.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>