### PR TITLE
net: lib: fota_download: Fix invalid error message being printed

### DIFF
--- a/subsys/net/lib/fota_download/src/fota_download.c
+++ b/subsys/net/lib/fota_download/src/fota_download.c
@@ -114,7 +114,9 @@ static int download_client_callback(const struct download_client_evt *event)
 			download_client_disconnect(&dlc);
 			LOG_ERR("Download client error");
 			err = dfu_target_done(false);
-			if (err != 0) {
+			if (err == -EACCES) {
+				LOG_DBG("No DFU target was initialized");
+			} else if (err != 0) {
 				LOG_ERR("Unable to deinitialze resources "
 					"used by dfu_target.");
 			}


### PR DESCRIPTION
`fota_download` would print unable to de-initialize resources because
no resources were initialized. Fixed this by checking the error code
returned from the `dfu_target` library.

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>