### PR TITLE
spm: add RTC0 to peripheral list

### DIFF
--- a/subsys/spm/Kconfig
+++ b/subsys/spm/Kconfig
@@ -104,6 +104,10 @@ config SPM_NRF_CLOCK_NS
 	bool "Clock control is Non-Secure"
 	default y
 
+config SPM_NRF_RTC0_NS
+	bool "RTC0 is Non-Secure"
+	default y
+
 config SPM_NRF_RTC1_NS
 	bool "RTC1 is Non-Secure"
 	default y

--- a/subsys/spm/spm.c
+++ b/subsys/spm/spm.c
@@ -303,6 +303,9 @@ static void spm_config_peripherals(void)
 #ifdef NRF_CLOCK
 		PERIPH("NRF_CLOCK", NRF_CLOCK, CONFIG_SPM_NRF_CLOCK_NS),
 #endif
+#ifdef NRF_RTC0
+		PERIPH("NRF_RTC0", NRF_RTC0, CONFIG_SPM_NRF_RTC0_NS),
+#endif
 #ifdef NRF_RTC1
 		PERIPH("NRF_RTC1", NRF_RTC1, CONFIG_SPM_NRF_RTC1_NS),
 #endif


### PR DESCRIPTION
Add RTC0 to peripheral list, and configure it as non-secure by default.