### PR TITLE
applications: asset_tracker: gps_controller: remove k_sleep()

### DIFF
--- a/applications/asset_tracker/src/gps_controller/gps_controller.c
+++ b/applications/asset_tracker/src/gps_controller/gps_controller.c
@@ -44,8 +44,6 @@ static int start(void)
 		} else {
 			printk("PSM enabled\n");
 		}
-
-		k_sleep(K_SECONDS(1));
 	}
 
 	err = gps_start(gps_work.dev);


### PR DESCRIPTION
Removed an unnecessary k_sleep() in gps_controller that was blocking the
system workqueue for 1 second and randomly would lock up the asset tracker
when enabling GPS.

Jira:TG91-153

Signed-off-by: Jon Helge Nistad <jon.helge.nistad@nordicsemi.no>