### PR TITLE
net: lib: fota_download: Fix when last fragment write fails

### DIFF
--- a/subsys/net/lib/fota_download/src/fota_download.c
+++ b/subsys/net/lib/fota_download/src/fota_download.c
@@ -74,7 +74,7 @@ static int download_client_callback(const struct download_client_evt *event)
 				       event->fragment.len);
 		if (err != 0) {
 			LOG_ERR("dfu_target_write error %d", err);
-			err = download_client_disconnect(&dlc);
+			(void) download_client_disconnect(&dlc);
 			callback(FOTA_DOWNLOAD_EVT_ERROR);
 			return err;
 		}


### PR DESCRIPTION
When writing the last fragment fails the `dfu_target_done`is still
called applying the update. This is because two events are sent, both
`DOWNLOAD_CLIENT_EVT_FRAGMENT` and `DOWNLOAD_CLIENT_EVT_DONE` even if we
~~return a non-zero value~~. This is because `dl->progress == dl->file_size`
still applies.

**We apparently sent a zero value.** 

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>