### PR TITLE
net: lib: aws_fota: Change return semantics of aws_fota_mqtt_evt_handler

### DIFF
--- a/include/net/aws_fota.h
+++ b/include/net/aws_fota.h
@@ -51,8 +51,8 @@ int aws_fota_init(struct mqtt_client *const client,
  * @param client Pointer to the mqtt_client instance.
  * @param evt          Pointer to the recived mqtt_evt.
  *
- * @retval 0 If successful but wants the application to handle the event.
- * @retval 1 If successful and the application can skip handling this event.
+ * @retval 0 If successful and the application can skip handling this event.
+ * @retval 1 If successful but wants the application to handle the event.
  * @return   A negative value on error.
  */
 int aws_fota_mqtt_evt_handler(struct mqtt_client *const client,

--- a/samples/nrf9160/aws_fota/src/main.c
+++ b/samples/nrf9160/aws_fota/src/main.c
@@ -152,7 +152,7 @@ void mqtt_evt_handler(struct mqtt_client * const c,
 	int err;
 
 	err = aws_fota_mqtt_evt_handler(c, evt);
-	if (err > 0) {
+	if (err == 0) {
 		/* Event handled by FOTA library so we can skip it */
 		return;
 	} else if (err < 0) {

--- a/subsys/net/lib/aws_fota/src/aws_fota.c
+++ b/subsys/net/lib/aws_fota/src/aws_fota.c
@@ -173,7 +173,7 @@ static int update_job_execution(struct mqtt_client *const client,
  * @param[in] payload_len  Length of the payload going to be read out from the
  *			   MQTT message.
  *
- * @return 1 If successful otherwise a negative error code is returned.
+ * @return 0 If successful otherwise a negative error code is returned.
  */
 static int get_job_execution(struct mqtt_client *const client,
 			     u32_t payload_len)
@@ -196,7 +196,7 @@ static int get_job_execution(struct mqtt_client *const client,
 	} else  if (err == 0) {
 		LOG_DBG("Got only one field: %s", log_strdup(payload_buf));
 		LOG_INF("No queued jobs for this device");
-		return 1;
+		return 0;
 	}
 
 	LOG_DBG("Job ID: %s", log_strdup(job_id));
@@ -220,7 +220,7 @@ static int get_job_execution(struct mqtt_client *const client,
 	 */
 	fota_state = DOWNLOAD_FIRMWARE;
 
-	return 1;
+	return 0;
 }
 
 /**
@@ -230,7 +230,7 @@ static int get_job_execution(struct mqtt_client *const client,
  * @param[in] payload_len  Length of the payload going to be read out from the
  *			   MQTT message.
  *
- * @return 1 If successful otherwise a negative error code is returned.
+ * @return 0 If successful otherwise a negative error code is returned.
  */
 static int job_update_accepted(struct mqtt_client *const client,
 			       u32_t payload_len)
@@ -282,7 +282,7 @@ static int job_update_accepted(struct mqtt_client *const client,
 		LOG_INF("Ready to reboot");
 		callback(AWS_FOTA_EVT_DONE);
 	}
-	return 1;
+	return 0;
 }
 
 /**
@@ -412,7 +412,7 @@ int aws_fota_mqtt_evt_handler(struct mqtt_client *const client,
 				return err;
 			}
 		}
-		return 1;
+		return 0;
 
 	} break;
 
@@ -421,11 +421,11 @@ int aws_fota_mqtt_evt_handler(struct mqtt_client *const client,
 			LOG_ERR("MQTT PUBACK error %d", evt->result);
 			return 0;
 		}
-		return 0;
+		return 1;
 
 	case MQTT_EVT_SUBACK:
 		if (evt->result != 0) {
-			return 0;
+			return evt->result;
 		}
 		if (evt->param.suback.message_id == SUBSCRIBE_NOTIFY_NEXT) {
 			LOG_INF("subscribed to notify-next topic");
@@ -434,12 +434,12 @@ int aws_fota_mqtt_evt_handler(struct mqtt_client *const client,
 			if (err) {
 				return err;
 			}
-			return 1;
+			return 0;
 		}
 
 		if (evt->param.suback.message_id == SUBSCRIBE_GET) {
 			LOG_INF("subscribed to get topic");
-			return 1;
+			return 0;
 		}
 
 		if ((fota_state == DOWNLOAD_FIRMWARE) &&
@@ -452,16 +452,16 @@ int aws_fota_mqtt_evt_handler(struct mqtt_client *const client,
 			if (err) {
 				return err;
 			}
-			return 1;
+			return 0;
 		}
 
-		return 0;
+		return 1;
 
 	default:
 		/* Handling for default case */
-		return 0;
+		return 1;
 	}
-	return 0;
+	return 1;
 }
 
 

--- a/subsys/net/lib/aws_iot/src/aws_iot.c
+++ b/subsys/net/lib/aws_iot/src/aws_iot.c
@@ -357,7 +357,7 @@ static void mqtt_evt_handler(struct mqtt_client *const c,
 
 #if defined(CONFIG_AWS_FOTA)
 	err = aws_fota_mqtt_evt_handler(c, mqtt_evt);
-	if (err > 0) {
+	if (err == 0) {
 		/* Event handled by FOTA library so it can be skipped. */
 		return;
 	} else if (err < 0) {

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
@@ -522,7 +522,7 @@ static void nct_mqtt_evt_handler(struct mqtt_client *const mqtt_client,
 
 #if defined(CONFIG_AWS_FOTA)
 	err = aws_fota_mqtt_evt_handler(mqtt_client, _mqtt_evt);
-	if (err > 0) {
+	if (err == 0) {
 		/* Event handled by FOTA library so we can skip it */
 		return;
 	} else if (err < 0) {


### PR DESCRIPTION
This swaps the meaning of the return value where now `0` means `evt` handled by library and `1` means need more mqtt processing by the consumer of the library. Based on https://github.com/NordicPlayground/fw-nrfconnect-nrf/pull/1663 so reading the changes is a bit hard but it's the two last commits. 