### PR TITLE
spm: only set IRQ target state for peripherals with irq

### DIFF
--- a/subsys/spm/spm.c
+++ b/subsys/spm/spm.c
@@ -271,10 +271,13 @@ static int spm_config_peripheral(u8_t id, bool dma_present)
 			PERIPH_LOCK;
 	}
 
-	/* Even for non-present peripherals we force IRQs to be routed
-	 * to Non-Secure state.
-	 */
-	irq_target_state_set(id, 0);
+	/* Route IRQs for peripherals which has it */
+	if (id != NRFX_PERIPHERAL_ID_GET(NRF_P0)) {
+		/* Even for non-present peripherals we force IRQs to be routed
+		 * to Non-Secure state.
+		 */
+		irq_target_state_set(id, 0);
+	}
 	return 0;
 }
 


### PR DESCRIPTION
Prior to this an assert would be triggered when trying to
set the target state for P0 peripheral, which does not
have IRQ.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>