### PR TITLE
drivers: bluetooth: Simplify BLE controller initialization

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -70,7 +70,7 @@ manifest:
       revision: 30b7efa827b04d2e47840716b0372737fe7d6c92
     - name: nrfxlib
       path: nrfxlib
-      revision: 439a0e1f2b9a7c55286b9a02fdd1132c12c6a6cd
+      revision: 2499d80d924b88e20e1ad90a41ed9cf7f5208a26
     - name: cmock
       path: test/cmock
       revision: c243b9a7a7b3c471023193992b46cf1bd1910450


### PR DESCRIPTION
We no longer need to initialize the controller before kernel startup
because the controller is now no longer responsible for initialization
the LF clock. This is now handled by MPSL.
Therefore all initialization can be done post-kernel.

Signed-off-by: Rubin Gerritsen <Rubin.Gerritsen@nordicsemi.no>