### PR TITLE
net: lib: download_client: add support for non-default ports

### DIFF
--- a/include/net/download_client.h
+++ b/include/net/download_client.h
@@ -81,10 +81,17 @@ struct download_client_evt {
  * @brief Download client configuration options.
  */
 struct download_client_cfg {
-	/** TLS security tag. If -1, TLS is disabled. */
+	/** IP port.
+	 *  Pass zero to use default, or non-zero to override.
+	 */
+	u16_t port;
+	/** TLS security tag.
+	 *  Pass -1 to disable TLS.
+	 */
 	int sec_tag;
 	/** Access point name identifying a packet data network.
-	 * Must be a null-terminated string or NULL to use the default APN.
+	 *  Pass a null-terminated string with the APN
+	 *  or NULL to use the default APN.
 	 */
 	const char *apn;
 };

--- a/subsys/net/lib/download_client/src/download_client.c
+++ b/subsys/net/lib/download_client/src/download_client.c
@@ -132,13 +132,13 @@ static int resolve_and_connect(int family, const char *host,
 
 	/* Set up port and protocol */
 	if (cfg->sec_tag == -1) {
-		/* HTTP, port 80 */
 		proto = IPPROTO_TCP;
-		port = htons(80);
+		port = (cfg->port != 0) ? htons(cfg->port) :
+					  htons(80); /* HTTP, port 80 */
 	} else {
-		/* HTTPS, port 443 */
 		proto = IPPROTO_TLS_1_2;
-		port = htons(443);
+		port = (cfg->port != 0) ? htons(cfg->port) :
+					  htons(443); /* HTTPS, port 443 */
 	}
 
 	/* Lookup host */


### PR DESCRIPTION
Let the user specify a port to be used when connecting.