### PR TITLE
applications: asset_tracker: Add configurable automatic start of GPS

### DIFF
--- a/applications/asset_tracker/Kconfig
+++ b/applications/asset_tracker/Kconfig
@@ -319,6 +319,14 @@ config LIGHT_SENSOR_DATA_SEND_INTERVAL
 
 endif # LIGHT_SENSOR
 
+config GPS_START_AFTER_CLOUD_EVT_READY
+	bool "Automatic start of GPS on CLOUD_EVT_READY event after reset"
+	default n
+	help
+	  Enabling this will make the GPS automatically start after a reset.
+	  Useful when operating as a GPS tracker outdoors for a longer period
+	  of time.
+
 config USE_AT_HOST
 	bool "Enable AT commands"
 	default y

--- a/applications/asset_tracker/src/main.c
+++ b/applications/asset_tracker/src/main.c
@@ -1038,6 +1038,9 @@ static void sensors_init(void)
 	}
 
 	gps_control_init(&application_work_q, gps_trigger_handler);
+	if (IS_ENABLED(CONFIG_GPS_START_AFTER_CLOUD_EVT_READY)) {
+		set_gps_enable(true);
+	}
 }
 
 #if defined(CONFIG_USE_UI_MODULE)


### PR DESCRIPTION
Added configuration option to make the GPS start automatically after
reset when CLOUD_EVT_READY is received.

Jira:TG91-169

Signed-off-by: Jon Helge Nistad <jon.helge.nistad@nordicsemi.no>