### PR TITLE
boards: nrf9160_pca20035: Add COEX0 configuration

### DIFF
--- a/boards/arm/nrf9160_pca20035/board_nonsecure.c
+++ b/boards/arm/nrf9160_pca20035/board_nonsecure.c
@@ -18,6 +18,7 @@ LOG_MODULE_REGISTER(board_nonsecure, CONFIG_BOARD_LOG_LEVEL);
 #define AT_CMD_MAGPIO		"AT%XMAGPIO=1,1,1,7,1,746,803,2,698,748," \
 				"2,1710,2200,3,824,894,4,880,960,5,791,849," \
 				"7,1574,1577"
+#define AT_CMD_COEX0		"AT%XCOEX0=1,1,1570,1580"
 #define AT_CMD_TRACE		"AT%XMODEMTRACE=0"
 
 static int pca20035_magpio_configure(void)
@@ -57,6 +58,15 @@ static int pca20035_magpio_configure(void)
 		      AT_CMD_LEN(AT_CMD_MAGPIO), 0);
 	if (buffer != AT_CMD_LEN(AT_CMD_MAGPIO)) {
 		LOG_ERR("MAGPIO command failed");
+		close(at_socket_fd);
+		return -EIO;
+	}
+
+	LOG_DBG("AT CMD: %s", log_strdup(AT_CMD_COEX0));
+	buffer = send(at_socket_fd, AT_CMD_COEX0,
+		      AT_CMD_LEN(AT_CMD_COEX0), 0);
+	if (buffer != AT_CMD_LEN(AT_CMD_COEX0)) {
+		LOG_ERR("COEX0 command failed");
 		close(at_socket_fd);
 		return -EIO;
 	}


### PR DESCRIPTION
Adds a COEX0 AT-command to board initialization to support hardware
where the GPS RF path requires the COEX0 signal.

Signed-off-by: Bernt Johan Damslora <bernt.johan.damslora@nordicsemi.no>