### PR TITLE
ci: add nrf53 ble samples to sanitycheck

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,10 +13,12 @@ def TestExecutionList = [:]
 
 properties([
   pipelineTriggers([
-    parameterizedCron((JOB_NAME =~ /latest\/night\/.*\/master/).find() ? CI_STATE.CFG.CRON.NIGHTLY : ''),
-    parameterizedCron((JOB_NAME =~ /latest\/week\/.*\/master/).find() ? CI_STATE.CFG.CRON.WEEKLY : ''),
+    parameterizedCron( [
+        ((JOB_NAME =~ /latest\/night\/.*\/master/).find() ? CI_STATE.CFG.CRON.NIGHTLY : ''),
+        ((JOB_NAME =~ /latest\/week\/.*\/master/).find() ? CI_STATE.CFG.CRON.WEEKLY : '')
+    ].join('    \n') )
   ]),
-  ( JOB_NAME.contains('sub/') ? disableResume() : disableResume() ) // allowing ConcurrentBuilds at the moment  // disableConcurrentBuilds()
+  ( JOB_NAME.contains('sub/') ? disableResume() :  disableConcurrentBuilds() )
 ])
 
 pipeline {
@@ -25,7 +27,7 @@ pipeline {
        booleanParam(name: 'RUN_DOWNSTREAM', description: 'if false skip downstream jobs', defaultValue: true)
        booleanParam(name: 'RUN_TESTS', description: 'if false skip testing', defaultValue: true)
        booleanParam(name: 'RUN_BUILD', description: 'if false skip building', defaultValue: true)
-       string(name: 'PLATFORMS', description: 'Default Platforms to test', defaultValue: 'nrf9160_pca10090 nrf52_pca10040 nrf52840_pca10056')
+       string(name: 'PLATFORMS', description: 'Default Platforms to test', defaultValue: 'nrf9160_pca10090 nrf52_pca10040 nrf52840_pca10056 nrf5340_dk_nrf5340_cpuapp')
        string(name: 'jsonstr_CI_STATE', description: 'Default State if no upstream job', defaultValue: CI_STATE.CFG.INPUT_STATE_STR)
        choice(name: 'CRON', choices: ['COMMIT', 'NIGHTLY', 'WEEKLY'], description: 'Cron Test Phase')
   }

--- a/samples/bluetooth/central_bas/sample.yaml
+++ b/samples/bluetooth/central_bas/sample.yaml
@@ -9,5 +9,5 @@ tests:
   test_build:
     build_only: true
     build_on_all: true
-    platform_whitelist: nrf51_pca10028 nrf52_pca10040 nrf52840_pca10056
+    platform_whitelist: nrf51_pca10028 nrf52_pca10040 nrf52840_pca10056 nrf5340_dk_nrf5340_cpuapp
     tags: bluetooth ci_build

--- a/samples/bluetooth/central_dfu_smp/sample.yaml
+++ b/samples/bluetooth/central_dfu_smp/sample.yaml
@@ -9,5 +9,5 @@ tests:
   test_build:
     build_only: true
     build_on_all: true
-    platform_whitelist: nrf51_pca10028 nrf52_pca10040 nrf52840_pca10056 nrf52810_pca10040
+    platform_whitelist: nrf51_pca10028 nrf52_pca10040 nrf52840_pca10056 nrf52810_pca10040 nrf5340_dk_nrf5340_cpuapp
     tags: bluetooth ci_build

--- a/samples/bluetooth/central_hids/sample.yaml
+++ b/samples/bluetooth/central_hids/sample.yaml
@@ -9,5 +9,5 @@ tests:
   test_build:
     build_only: true
     build_on_all: true
-    platform_whitelist: nrf51_pca10028 nrf52_pca10040 nrf52840_pca10056
+    platform_whitelist: nrf51_pca10028 nrf52_pca10040 nrf52840_pca10056 nrf5340_dk_nrf5340_cpuapp
     tags: bluetooth ci_build

--- a/samples/bluetooth/central_uart/sample.yaml
+++ b/samples/bluetooth/central_uart/sample.yaml
@@ -5,5 +5,5 @@ tests:
   test_build:
     build_only: true
     build_on_all: true
-    platform_whitelist: nrf51_pca10028 nrf52_pca10040 nrf52840_pca10056 nrf52810_pca10040
+    platform_whitelist: nrf51_pca10028 nrf52_pca10040 nrf52840_pca10056 nrf52810_pca10040 nrf5340_dk_nrf5340_cpuapp
     tags: bluetooth ci_build

--- a/samples/bluetooth/llpm/sample.yaml
+++ b/samples/bluetooth/llpm/sample.yaml
@@ -5,5 +5,5 @@ tests:
   test_build:
     build_only: true
     build_on_all: true
-    platform_whitelist: nrf52_pca10040 nrf52840_pca10056
+    platform_whitelist: nrf52_pca10040 nrf52840_pca10056 nrf5340_dk_nrf5340_cpuapp
     tags: bluetooth ci_build

--- a/samples/bluetooth/mesh/light/sample.yaml
+++ b/samples/bluetooth/mesh/light/sample.yaml
@@ -5,5 +5,5 @@ tests:
   test_build:
     build_only: true
     build_on_all: true
-    platform_whitelist: nrf51_pca10028 nrf52_pca10040 nrf52840_pca10056
+    platform_whitelist: nrf51_pca10028 nrf52_pca10040 nrf52840_pca10056 nrf5340_dk_nrf5340_cpuapp
     tags: bluetooth ci_build

--- a/samples/bluetooth/mesh/light_switch/sample.yaml
+++ b/samples/bluetooth/mesh/light_switch/sample.yaml
@@ -5,5 +5,5 @@ tests:
   test_build:
     build_only: true
     build_on_all: true
-    platform_whitelist: nrf51_pca10028 nrf52_pca10040 nrf52840_pca10056
+    platform_whitelist: nrf51_pca10028 nrf52_pca10040 nrf52840_pca10056 nrf5340_dk_nrf5340_cpuapp
     tags: bluetooth ci_build

--- a/samples/bluetooth/peripheral_gatt_dm/sample.yaml
+++ b/samples/bluetooth/peripheral_gatt_dm/sample.yaml
@@ -5,5 +5,5 @@ tests:
   test_build:
     build_only: true
     build_on_all: true
-    platform_whitelist: nrf51_pca10028 nrf52_pca10040 nrf52840_pca10056 nrf52810_pca10040
+    platform_whitelist: nrf51_pca10028 nrf52_pca10040 nrf52840_pca10056 nrf52810_pca10040 nrf5340_dk_nrf5340_cpuapp
     tags: bluetooth ci_build

--- a/samples/bluetooth/peripheral_hids_keyboard/sample.yaml
+++ b/samples/bluetooth/peripheral_hids_keyboard/sample.yaml
@@ -9,5 +9,5 @@ tests:
   test_build:
     build_only: true
     build_on_all: true
-    platform_whitelist: nrf52_pca10040 nrf52840_pca10056
+    platform_whitelist: nrf52_pca10040 nrf52840_pca10056 nrf5340_dk_nrf5340_cpuapp
     tags: bluetooth ci_build

--- a/samples/bluetooth/peripheral_hids_mouse/sample.yaml
+++ b/samples/bluetooth/peripheral_hids_mouse/sample.yaml
@@ -9,5 +9,5 @@ tests:
   test_build:
     build_only: true
     build_on_all: true
-    platform_whitelist: nrf51_pca10028 nrf52_pca10040 nrf52840_pca10056
+    platform_whitelist: nrf51_pca10028 nrf52_pca10040 nrf52840_pca10056 nrf5340_dk_nrf5340_cpuapp
     tags: bluetooth ci_build

--- a/samples/bluetooth/peripheral_lbs/sample.yaml
+++ b/samples/bluetooth/peripheral_lbs/sample.yaml
@@ -5,5 +5,5 @@ tests:
   test_build:
     build_only: true
     build_on_all: true
-    platform_whitelist: nrf51_pca10028 nrf52_pca10040 nrf52840_pca10056 nrf52810_pca10040
+    platform_whitelist: nrf51_pca10028 nrf52_pca10040 nrf52840_pca10056 nrf52810_pca10040 nrf5340_dk_nrf5340_cpuapp
     tags: bluetooth ci_build

--- a/samples/bluetooth/peripheral_uart/sample.yaml
+++ b/samples/bluetooth/peripheral_uart/sample.yaml
@@ -5,5 +5,5 @@ tests:
   test_build:
     build_only: true
     build_on_all: true
-    platform_whitelist: nrf51_pca10028 nrf52_pca10040 nrf52840_pca10056
+    platform_whitelist: nrf51_pca10028 nrf52_pca10040 nrf52840_pca10056 nrf5340_dk_nrf5340_cpuapp
     tags: bluetooth ci_build

--- a/samples/bluetooth/shell_bt_nus/sample.yaml
+++ b/samples/bluetooth/shell_bt_nus/sample.yaml
@@ -5,5 +5,5 @@ tests:
   test_build:
     build_only: true
     build_on_all: true
-    platform_whitelist: nrf51_pca10028 nrf52_pca10040 nrf52840_pca10056
+    platform_whitelist: nrf51_pca10028 nrf52_pca10040 nrf52840_pca10056 nrf5340_dk_nrf5340_cpuapp
     tags: bluetooth ci_build

--- a/samples/bluetooth/throughput/sample.yaml
+++ b/samples/bluetooth/throughput/sample.yaml
@@ -5,5 +5,5 @@ tests:
   test_build:
     build_only: true
     build_on_all: true
-    platform_whitelist: nrf51_pca10028 nrf52_pca10040 nrf52840_pca10056
+    platform_whitelist: nrf51_pca10028 nrf52_pca10040 nrf52840_pca10056 nrf5340_dk_nrf5340_cpuapp
     tags: bluetooth ci_build


### PR DESCRIPTION
- add 'nrf5340_dk_nrf5340_cpuapp' to bluetooth samples

Signed-off-by: Thomas Stilwell <Thomas.Stilwell@nordicsemi.no>