### PR TITLE
lib: modem_info: parse supported bands

### DIFF
--- a/lib/modem_info/modem_info.c
+++ b/lib/modem_info/modem_info.c
@@ -447,6 +447,14 @@ int modem_info_string_get(enum modem_info info, char *buf)
 			  CONFIG_MODEM_INFO_BUFFER_SIZE,
 			  NULL);
 
+	/* modem_info does not yet support array objects, so here we handle
+	 * the supported bands independently as a string
+	 */
+	if (info == MODEM_INFO_SUP_BAND) {
+		strcpy(buf, recv_buf + sizeof("%XCBAND: ") - 1);
+		return strlen(buf);
+	}
+
 	if (err != 0) {
 		return -EIO;
 	}


### PR DESCRIPTION
Adds handling of the supported bands independently as a string, as
modem_info does not yet support array objects.

Fixes TG91-123.

This change will be obsolete once the modem_info module is reworked to support all modem response formats.