### PR TITLE
samples: nrf9160: cloud_client: make PSM configurable

### DIFF
--- a/samples/nrf9160/cloud_client/Kconfig
+++ b/samples/nrf9160/cloud_client/Kconfig
@@ -30,6 +30,9 @@ config CLOUD_PUBLICATION_SEQUENTIAL
 
 endchoice
 
+config POWER_SAVING_MODE_ENABLE
+	bool "Request PSM from cellular network"
+
 endmenu
 
 menu "Zephyr Kernel"

--- a/samples/nrf9160/cloud_client/src/main.c
+++ b/samples/nrf9160/cloud_client/src/main.c
@@ -108,12 +108,14 @@ static void modem_configure(void)
 
 		printk("Connected to LTE network\n");
 
+#if defined(CONFIG_POWER_SAVING_MODE_ENABLE)
 		err = lte_lc_psm_req(true);
 		if (err) {
 			printk("lte_lc_psm_req, error: %d\n", err);
 		}
 
 		printk("PSM mode requested\n");
+#endif
 	}
 #endif
 }


### PR DESCRIPTION
Added Kconfigurable option to decide if PSM should be
requested or not.

Signed-off-by: Simen S. Røstad <simen.rostad@nordicsemi.no>