### PR TITLE
Const char handlers

### DIFF
--- a/include/at_cmd.h
+++ b/include/at_cmd.h
@@ -49,7 +49,7 @@ enum at_cmd_state {
  * @param response     Null terminated string containing the modem message
  *
  */
-typedef void (*at_cmd_handler_t)(char *response);
+typedef void (*at_cmd_handler_t)(const char *response);
 
 /**@brief Initialize AT command driver.
  *

--- a/include/at_notif.h
+++ b/include/at_notif.h
@@ -37,7 +37,7 @@ extern "C" {
  * @param response     Null terminated string containing the modem message
  *
  */
-typedef void (*at_notif_handler_t)(void *context, char *response);
+typedef void (*at_notif_handler_t)(void *context, const char *response);
 
 /**@brief Initialize AT command notification manager.
  *

--- a/include/net/fota_download.h
+++ b/include/net/fota_download.h
@@ -74,7 +74,7 @@ int fota_download_init(fota_download_callback_t client_callback);
  * @retval -EALREADY If download is already ongoing.
  *                   Otherwise, a negative value is returned.
  */
-int fota_download_start(char *host, char *file);
+int fota_download_start(const char *host, const char *file);
 
 #ifdef __cplusplus
 }

--- a/lib/at_host/at_host.c
+++ b/lib/at_host/at_host.c
@@ -65,7 +65,7 @@ static struct k_work cmd_send_work;
 
 
 
-static inline void write_uart_string(char *str)
+static inline void write_uart_string(const char *str)
 {
 	/* Send characters until, but not including, null */
 	for (size_t i = 0; str[i]; i++) {
@@ -73,7 +73,7 @@ static inline void write_uart_string(char *str)
 	}
 }
 
-static void response_handler(void *context, char *response)
+static void response_handler(void *context, const char *response)
 {
 	ARG_UNUSED(context);
 

--- a/lib/at_notif/at_notif.c
+++ b/lib/at_notif/at_notif.c
@@ -100,7 +100,7 @@ static int remove_notif_handler(void *ctx, at_notif_handler_t handler)
 }
 
 /**@brief AT command notifications handler. */
-static void notif_dispatch(char *response)
+static void notif_dispatch(const char *response)
 {
 	struct notif_handler *curr, *tmp;
 

--- a/lib/bin/lwm2m_carrier/include/lwm2m_os.h
+++ b/lib/bin/lwm2m_carrier/include/lwm2m_os.h
@@ -54,7 +54,7 @@ struct lwm2m_os_at_param_list {
 /**
  * @brief AT Command handler.
  */
-typedef void (*lwm2m_os_at_cmd_handler_t)(void *ctx, char *response);
+typedef void (*lwm2m_os_at_cmd_handler_t)(void *ctx, const char *response);
 
 /**
  * @defgroup lwm2m_os_download_evt_id LwM2M OS download events

--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -137,7 +137,7 @@ static const char cgauth[] = "AT+CGAUTH="CONFIG_LTE_PDN_AUTH;
 static const char legacy_pco[] = "AT%XEPCO=0";
 #endif
 
-void at_handler(void *context, char *response)
+void at_handler(void *context, const char *response)
 {
 	ARG_UNUSED(context);
 

--- a/lib/modem_info/modem_info.c
+++ b/lib/modem_info/modem_info.c
@@ -320,7 +320,7 @@ static const struct modem_info_data *const modem_data[] = {
 static rsrp_cb_t modem_info_rsrp_cb;
 static struct at_param_list m_param_list;
 
-static bool is_cesq_notification(char *buf, size_t len)
+static bool is_cesq_notification(const char *buf, size_t len)
 {
 	return strstr(buf, AT_CMD_CESQ_RESP) ? true : false;
 }
@@ -492,7 +492,7 @@ int modem_info_string_get(enum modem_info info, char *buf)
 	return len <= 0 ? -ENOTSUP : len;
 }
 
-static void modem_info_rsrp_subscribe_handler(void *context, char *response)
+static void modem_info_rsrp_subscribe_handler(void *context, const char *response)
 {
 	ARG_UNUSED(context);
 

--- a/samples/nrf9160/serial_lte_modem/src/slm_at_host.c
+++ b/samples/nrf9160/serial_lte_modem/src/slm_at_host.c
@@ -79,7 +79,7 @@ static inline void write_uart_string(char *str, size_t len)
 	}
 }
 
-static void response_handler(void *context, char *response)
+static void response_handler(void *context, const char *response)
 {
 	int len = strlen(response) + 1;
 
@@ -334,7 +334,7 @@ static int at_uart_init(char *uart_dev_name)
 	return err;
 }
 
-static void slm_at_callback(char *str)
+static void slm_at_callback(const char *str)
 {
 	write_uart_string(str, strlen(str));
 }

--- a/samples/nrf9160/serial_lte_modem/src/slm_at_host.c
+++ b/samples/nrf9160/serial_lte_modem/src/slm_at_host.c
@@ -70,7 +70,7 @@ extern void enter_sleep(u16_t mode);
 /* forward declaration */
 void slm_at_host_uninit(void);
 
-static inline void write_uart_string(char *str, size_t len)
+static inline void write_uart_string(const char *str, size_t len)
 {
 	LOG_HEXDUMP_DBG(str, len, "TX");
 

--- a/subsys/dfu/include/dfu_target_mcuboot.h
+++ b/subsys/dfu/include/dfu_target_mcuboot.h
@@ -38,7 +38,8 @@ extern "C" {
  * @retval 0 If successful (note that this does not imply that a space
  *           separator was found) negative errno otherwise.
  */
-int dfu_ctx_mcuboot_set_b1_file(char *file, bool s0_active, char **update);
+int dfu_ctx_mcuboot_set_b1_file(const char *file, bool s0_active,
+				const char **update);
 
 /**
  * @brief See if data in buf indicates MCUBoot style upgrade.

--- a/subsys/dfu/src/dfu_target_mcuboot.c
+++ b/subsys/dfu/src/dfu_target_mcuboot.c
@@ -31,7 +31,7 @@ LOG_MODULE_REGISTER(dfu_target_mcuboot, CONFIG_DFU_TARGET_LOG_LEVEL);
 
 static struct flash_img_context flash_img;
 
-int dfu_ctx_mcuboot_set_b1_file(char *file, bool s0_active, char **update)
+int dfu_ctx_mcuboot_set_b1_file(const char *file, bool s0_active, const char **update)
 {
 	if (file == NULL || update == NULL) {
 		return -EINVAL;

--- a/subsys/net/lib/fota_download/src/fota_download.c
+++ b/subsys/net/lib/fota_download/src/fota_download.c
@@ -180,7 +180,7 @@ static void download_with_offset(struct k_work *unused)
 	}
 }
 
-int fota_download_start(char *host, char *file)
+int fota_download_start(const char *host, const char *file)
 {
 	int err = -1;
 
@@ -199,7 +199,7 @@ int fota_download_start(char *host, char *file)
 	 * (s0 or s1), and update file to point to correct candidate if
 	 * space separated file is given.
 	 */
-	char *update;
+	const char *update;
 	struct fw_info s0;
 	struct fw_info s1;
 


### PR DESCRIPTION
Updated some C string uses to be const char instead of just char to make passing in const char a little bit easier -- especially since the APIs shouldn't be touching the buffer contents anyway. Might as well contractually say that in the signature.