### PR TITLE
spm: make wdt non secure by default

### DIFF
--- a/subsys/spm/Kconfig
+++ b/subsys/spm/Kconfig
@@ -198,7 +198,7 @@ config SPM_NRF_REGULATORS_NS
 
 config SPM_NRF_WDT_NS
 	bool "WDT is Non-Secure"
-	default n
+	default y
 endmenu
 
 config SPM_NRF_DPPIC_NS


### PR DESCRIPTION
This is a better default value

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>