### PR TITLE
bootloader: kconfig: select fw_info

### DIFF
--- a/subsys/bootloader/Kconfig
+++ b/subsys/bootloader/Kconfig
@@ -17,7 +17,7 @@ config MCUBOOT_BUILD_S1_VARIANT
 config SECURE_BOOT
 	bool "Use Secure Bootloader"
 	depends on !IS_SECURE_BOOTLOADER
-	depends on FW_INFO
+	select FW_INFO
 	help
 	  Set this option to enable the first stage bootloader which
 	  verifies the signature of the app.
@@ -114,7 +114,7 @@ menuconfig IS_SECURE_BOOTLOADER
 	bool "Current app is bootloader"
 	depends on SECURE_BOOT_VALIDATION
 	select SW_VECTOR_RELAY if SOC_SERIES_NRF51X
-	depends on NRFX_NVMC
+	select NRFX_NVMC
 	help
 	  This option is set by the first stage bootloader app to include all
 	  files and set all the options required.

--- a/subsys/bootloader/bl_crypto/Kconfig
+++ b/subsys/bootloader/bl_crypto/Kconfig
@@ -7,7 +7,7 @@
 menuconfig SECURE_BOOT_CRYPTO
 	bool
 	prompt "Secure Boot Crypto"
-	depends on FW_INFO
+	select FW_INFO
 	select NRF_OBERON
 
 if (SECURE_BOOT_CRYPTO)

--- a/subsys/bootloader/bl_validation/Kconfig
+++ b/subsys/bootloader/bl_validation/Kconfig
@@ -8,7 +8,7 @@ menu "Secure Boot firmware validation"
 
 config SECURE_BOOT_VALIDATION
 	bool "Enable Secure Boot validation code"
-	depends on FW_INFO
+	select FW_INFO
 	depends on SECURE_BOOT_CRYPTO
 
 config SB_VALIDATION_INFO_MAGIC


### PR DESCRIPTION
To make it easier for the user to include the secure bootloader,
make the inclusion based on a select instead of depends on.

Also change 'depends on NRFX_NVMC' in 'IS_SECURE_BOOTLOADER'
to avoid circular dependency.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>