### PR TITLE
b0: Add note and warning about flashing on nrf9160 (UICR must be erased)

### DIFF
--- a/samples/bootloader/README.rst
+++ b/samples/bootloader/README.rst
@@ -69,6 +69,14 @@ By default, the bootloader sample will automatically generate and provision publ
 Alternatively, to facilitate the manufacturing process of a device with the bootloader sample, it is possible to decouple this process and program the sample HEX file and the HEX file containing the public key hashes separately.
 If you choose to do so, use the Python scripts in ``scripts\bootloader`` to create and provision the keys manually.
 
+   .. note::
+      On nRF9160, the provisioning data is held in the OTP region in UICR.
+      Because of this, you must erase the UICR before programming the bootloader.
+      On nRF9160, the UICR can only be erased by erasing the whole chip.
+      To do so on the command line, call ``west flash`` with the ``--erase`` option.
+      This will erase the whole chip before programming the new image.
+      In |SES|, choose :guilabel:`Target` > :guilabel:`Connect J-Link` and then :guilabel:`Target` > :guilabel:`Erase All` to erase the whole chip.
+
 
 Requirements
 ************

--- a/subsys/bootloader/CMakeLists.txt
+++ b/subsys/bootloader/CMakeLists.txt
@@ -16,3 +16,12 @@ if (NOT IMAGE_NAME)
           "'prj.conf'.")
   zephyr_include_directories(include/dummy_values/)
 endif()
+
+if (DEFINED CONFIG_SOC_NRF9160)
+  message(WARNING "
+      --------------------------------------------------------
+      --- WARNING: When using the immutable bootloader on  ---
+      --- nRF9160, the UICR must be erased when flashing.  ---
+      --- E.g. by calling 'west flash --erase'             ---
+      --------------------------------------------------------")
+endif()


### PR DESCRIPTION
Because the provision data is placed in OTP.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>