### PR TITLE
bootloader: kconfig: enable s1 build by default

### DIFF
--- a/subsys/bootloader/Kconfig
+++ b/subsys/bootloader/Kconfig
@@ -7,12 +7,9 @@
 menu "Bootloader"
 
 config MCUBOOT_BUILD_S1_VARIANT
-	# This can not depend on BOOTLOADER_MCUBOOT, or SECURE_BOOT as this
-	# option has to be set when building MCUBoot itself. Instead an error
-	# is raised by CMake if an incorrect configuration is found.
-	bool "Build S1 variant of MCUBoot"
-	help
-	  Build upgrade candidate of MCUBoot for alternative slot S1.
+	bool
+	prompt "Build S1 variant of mcuboot" if !SECURE_BOOT
+	default y if SECURE_BOOT
 
 config SECURE_BOOT
 	bool "Use Secure Bootloader"


### PR DESCRIPTION
Always generate and merge in s1 candidate, as it will work
as a fail safe in case there is a corruption in the S0
variant.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>