### PR TITLE
subsys: net: Add support for keepalive_time_left() function.

### DIFF
--- a/applications/asset_tracker/src/main.c
+++ b/applications/asset_tracker/src/main.c
@@ -1195,15 +1195,8 @@ connect:
 	};
 
 	while (true) {
-		/* The timeout is set to (keepalive / 3), so that the worst case
-		 * time between two messages from device to broker is
-		 * ((4 / 3) * keepalive + connection overhead), which is within
-		 * MQTT specification of (1.5 * keepalive) before the broker
-		 * must close the connection.
-		 */
 		ret = poll(fds, ARRAY_SIZE(fds),
-			K_SECONDS(CONFIG_MQTT_KEEPALIVE / 3));
-
+			   cloud_keepalive_time_left(cloud_backend));
 		if (ret < 0) {
 			LOG_ERR("poll() returned an error: %d", ret);
 			error_handler(ERROR_CLOUD, ret);

--- a/include/net/cloud.h
+++ b/include/net/cloud.h
@@ -115,6 +115,7 @@ struct cloud_api {
 	int (*send)(const struct cloud_backend *const backend,
 		    const struct cloud_msg *const msg);
 	int (*ping)(const struct cloud_backend *const backend);
+	int (*keepalive_time_left)(const struct cloud_backend *const backend);
 	int (*input)(const struct cloud_backend *const backend);
 	int (*ep_subscriptions_add)(const struct cloud_backend *const backend,
 				    const struct cloud_endpoint *const list,
@@ -254,6 +255,26 @@ static inline int cloud_ping(const struct cloud_backend *const backend)
 	}
 
 	return 0;
+}
+
+/**
+ * @brief Helper function to determine when next keep alive message should be
+ *        sent. Can be used for instance as a source for `poll` timeout.
+ *
+ * @param backend Pointer to cloud backend.
+ *
+ * @return Time in milliseconds until next keep alive message is expected to
+ *         be sent.
+ */
+static inline int cloud_keepalive_time_left(const struct cloud_backend *const backend)
+{
+	if (backend == NULL || backend->api == NULL ||
+	    backend->api->keepalive_time_left == NULL) {
+		__ASSERT(0, "Missing cloud backend functionality");
+		return K_FOREVER;
+	}
+
+	return backend->api->keepalive_time_left(backend);
 }
 
 /**

--- a/samples/nrf9160/cloud_client/src/main.c
+++ b/samples/nrf9160/cloud_client/src/main.c
@@ -168,15 +168,8 @@ void main(void)
 	};
 
 	while (true) {
-		/* The timeout is set to (keepalive / 3), so that the worst case
-		 * time between two messages from device to broker is
-		 * ((4 / 3) * keepalive + connection overhead), which is within
-		 * MQTT specification of (1.5 * keepalive) before the broker
-		 * must close the connection.
-		 */
 		err = poll(fds, ARRAY_SIZE(fds),
-			K_SECONDS(CONFIG_MQTT_KEEPALIVE / 3));
-
+			   cloud_keepalive_time_left(cloud_backend));
 		if (err < 0) {
 			printk("poll() returned an error: %d\n", err);
 			continue;

--- a/samples/nrf9160/mqtt_simple/src/main.c
+++ b/samples/nrf9160/mqtt_simple/src/main.c
@@ -404,7 +404,7 @@ void main(void)
 	}
 
 	while (1) {
-		err = poll(&fds, 1, K_SECONDS(CONFIG_MQTT_KEEPALIVE));
+		err = poll(&fds, 1, mqtt_keepalive_time_left(&client));
 		if (err < 0) {
 			printk("ERROR: poll %d\n", errno);
 			break;

--- a/subsys/net/lib/aws_iot/src/aws_iot.c
+++ b/subsys/net/lib/aws_iot/src/aws_iot.c
@@ -583,6 +583,11 @@ int aws_iot_ping(void)
 	return mqtt_ping(&client);
 }
 
+int aws_iot_keepalive_time_left(void)
+{
+	return (int)mqtt_keepalive_time_left(&client);
+}
+
 int aws_iot_input(void)
 {
 	return mqtt_input(&client);
@@ -824,12 +829,18 @@ static int c_ping(const struct cloud_backend *const backend)
 	return aws_iot_ping();
 }
 
+static int c_keepalive_time_left(const struct cloud_backend *const backend)
+{
+	return aws_iot_keepalive_time_left();
+}
+
 static const struct cloud_api aws_iot_api = {
 	.init			= c_init,
 	.connect		= c_connect,
 	.disconnect		= c_disconnect,
 	.send			= c_send,
 	.ping			= c_ping,
+	.keepalive_time_left	= c_keepalive_time_left,
 	.input			= c_input,
 	.ep_subscriptions_add	= c_ep_subscriptions_add
 };

--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_transport.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_transport.h
@@ -111,6 +111,12 @@ void nct_dc_endpoint_get(struct nrf_cloud_data *tx_endpoint,
 /**@brief Needed for keep alive. */
 void nct_process(void);
 
+/**
+ * @brief Helper function to determine when next keep alive message should be
+ *        sent. Can be used for instance as a source for `poll` timeout.
+ */
+int nct_keepalive_time_left(void);
+
 /**@brief Input from the cloud module. */
 int nct_input(const struct nct_evt *evt);
 

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud.c
@@ -396,6 +396,11 @@ static int ping(const struct cloud_backend *const backend)
 	return 0;
 }
 
+static int keepalive_time_left(const struct cloud_backend *const backend)
+{
+	return nct_keepalive_time_left();
+}
+
 static int input(const struct cloud_backend *const backend)
 {
 	nrf_cloud_process();
@@ -418,6 +423,7 @@ static const struct cloud_api nrf_cloud_api = {
 	.disconnect = disconnect,
 	.send = send,
 	.ping = ping,
+	.keepalive_time_left = keepalive_time_left,
 	.input = input,
 	.user_data_set = user_data_set
 };

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
@@ -915,6 +915,11 @@ void nct_process(void)
 	mqtt_live(&nct.client);
 }
 
+int nct_keepalive_time_left(void)
+{
+	return (int)mqtt_keepalive_time_left(&nct.client);
+}
+
 int nct_socket_get(void)
 {
 	return nct.client.transport.tls.sock;


### PR DESCRIPTION
Added support for keepalive_time_left() function in the cloud
API and nrf_cloud backend.

Updated asset_tracker application to use the new functionality.

Signed-off-by: Jon Helge Nistad <jon.helge.nistad@nordicsemi.no>