### PR TITLE
net: mqtt: Handle EAGAIN return value from mqtt_live

### DIFF
--- a/samples/nrf9160/aws_fota/src/main.c
+++ b/samples/nrf9160/aws_fota/src/main.c
@@ -543,7 +543,7 @@ void main(void)
 		}
 
 		err = mqtt_live(&client);
-		if (err != 0) {
+		if ((err != 0) && (err != -EAGAIN)) {
 			printk("ERROR: mqtt_live %d\n", err);
 			break;
 		}

--- a/samples/nrf9160/mqtt_simple/src/main.c
+++ b/samples/nrf9160/mqtt_simple/src/main.c
@@ -411,7 +411,7 @@ void main(void)
 		}
 
 		err = mqtt_live(&client);
-		if (err != 0) {
+		if ((err != 0) && (err != -EAGAIN)) {
 			printk("ERROR: mqtt_live %d\n", err);
 			break;
 		}


### PR DESCRIPTION
Due to upstream changes, `mqtt_live` can now return -EAGAIN when no ping
was sent. Handle this in our code.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>