### PR TITLE
doc: add information about toolchain zip

### DIFF
--- a/doc/nrf/getting_started.rst
+++ b/doc/nrf/getting_started.rst
@@ -16,6 +16,7 @@ After that, pick a sample that is related to the application you want to create 
    :maxdepth: 2
 
    gs_assistant
+   gs_toolchain
    gs_installing
    gs_programming
    gs_testing

--- a/doc/nrf/gs_toolchain.rst
+++ b/doc/nrf/gs_toolchain.rst
@@ -1,0 +1,19 @@
+.. _gs_toolchain:
+
+Installing the |NCS| from a zip (experimental)
+##############################################
+
+.. warning::
+   Installing from a zip is not officially supported yet.
+   It should work fine for common use cases, but not all scenarios have been tested.
+
+To simplify the |NCS| installation on Windows operating systems, you can download a zip file that contains the full |NCS| toolchain.
+
+The toolchain zip includes the full `GNU Arm Embedded Toolchain`_, the Nordic Edition of |SES|, and all tools that are required to build and program |NCS| applications.
+The |NCS| code base must be downloaded separately as part of the installation process.
+
+To install the |NCS| from a zip, download the toolchain zip from INSERTLINK.
+Then follow the instructions in the :file:`INSTALL.txt` file to set up your environment.
+
+.. note::
+   The toolchain zip is only available for Windows operating systems.


### PR DESCRIPTION
Add documentation about the new way of installing the
NCS from a zip file.

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>

Output: 
![image](https://user-images.githubusercontent.com/11227796/73654201-5e04e900-468b-11ea-850c-e8a6ea4203d7.png)

Need to decide if this should go in for the release.
Link must be added before the PR is merged.