### PR TITLE
samples: nrf9160: mqtt/aws_fota mqtt_live returns `-EAGAIN`

### DIFF
--- a/samples/nrf9160/aws_fota/src/main.c
+++ b/samples/nrf9160/aws_fota/src/main.c
@@ -543,7 +543,7 @@ void main(void)
 		}
 
 		err = mqtt_live(&client);
-		if (err != 0) {
+		if (err != 0 && err != -EAGAIN) {
 			printk("ERROR: mqtt_live %d\n", err);
 			break;
 		}

--- a/samples/nrf9160/mqtt_simple/src/main.c
+++ b/samples/nrf9160/mqtt_simple/src/main.c
@@ -411,7 +411,7 @@ void main(void)
 		}
 
 		err = mqtt_live(&client);
-		if (err != 0) {
+		if (err != 0 && err != -EAGAIN) {
 			printk("ERROR: mqtt_live %d\n", err);
 			break;
 		}


### PR DESCRIPTION
After the upmerge `mqtt_live` started to return `-EAGAIN` when it wants
you to call it again. This breaks the current `while` loop and throws a
disconnect. This change checks for the error and ignores it letting the
`while` loop run and call `mqtt_live` again.

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>