### PR TITLE
scripts: profiler: Use LowLevel API and detect device family

### DIFF
--- a/scripts/profiler/rtt_nordic_config.py
+++ b/scripts/profiler/rtt_nordic_config.py
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 
 RttNordicConfig = {
-    'device_family': 'NRF52',
     'device_snr' : None,
     'rtt_info_channel': 2,
     'rtt_data_channel': 1,

--- a/scripts/profiler/rtt_nordic_profiler_host.py
+++ b/scripts/profiler/rtt_nordic_profiler_host.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 
-from pynrfjprog import API
+from pynrfjprog.LowLevel import API
 import time
 import matplotlib.pyplot as plt
 from datetime import datetime
@@ -52,7 +52,7 @@ class RttNordicProfilerHost:
 
     def rtt_get_device_family(snr):
         family = None
-        with API.API('UNKNOWN') as api:
+        with API('UNKNOWN') as api:
             if snr is not None:
                 api.connect_to_emu_with_snr(snr)
             else:
@@ -65,7 +65,7 @@ class RttNordicProfilerHost:
         snr = self.config['device_snr']
         device_family = RttNordicProfilerHost.rtt_get_device_family(snr)
         self.logger.info('Recognized device family: ' + device_family)
-        self.jlink = API.API(device_family)
+        self.jlink = API(device_family)
         self.jlink.open()
 
         if snr is not None:


### PR DESCRIPTION
Use LowLevel API (currently used API is becoming deprecated) and automatically detect device family (it used to be defined in configuration).