### PR TITLE
v1.2 rebase + rc1

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -38,7 +38,7 @@ manifest:
     - name: zephyr
       repo-path: fw-nrfconnect-zephyr
       west-commands: scripts/west-commands.yml
-      revision: v2.1.99-ncs1-snapshot1
+      revision: v2.1.99-ncs1-rc1
     - name: segger
       revision: 6fcf61606d6012d2c44129edc033f59331e268bc
       path: modules/debug/segger
@@ -49,11 +49,11 @@ manifest:
       remote: zephyrproject
     - name: mcuboot
       repo-path: fw-nrfconnect-mcuboot
-      revision: v1.4.99-ncs2-snapshot1
+      revision: v1.4.99-ncs2-rc1
       path: bootloader/mcuboot
     - name: mcumgr
       repo-path: fw-nrfconnect-mcumgr
-      revision: v0.0.1-ncs1-snapshot1
+      revision: v0.0.1-ncs1-rc1
       path: modules/lib/mcumgr
     - name: tinycbor
       path: modules/lib/tinycbor

--- a/west.yml
+++ b/west.yml
@@ -38,7 +38,7 @@ manifest:
     - name: zephyr
       repo-path: fw-nrfconnect-zephyr
       west-commands: scripts/west-commands.yml
-      revision: 43f55fa7be2c86116af78e0a60486e5131b16ea1
+      revision: v2.1.99-ncs1-snapshot1
     - name: segger
       revision: 6fcf61606d6012d2c44129edc033f59331e268bc
       path: modules/debug/segger
@@ -49,11 +49,11 @@ manifest:
       remote: zephyrproject
     - name: mcuboot
       repo-path: fw-nrfconnect-mcuboot
-      revision: d0c2fbefd26e830ddff08b3060d7f16af5eccd26
+      revision: v1.4.99-ncs2-snapshot1
       path: bootloader/mcuboot
     - name: mcumgr
       repo-path: fw-nrfconnect-mcumgr
-      revision: 1afd6bbbfed0137b3156349f968634bbd8fc6fff
+      revision: v0.0.1-ncs1-snapshot1
       path: modules/lib/mcumgr
     - name: tinycbor
       path: modules/lib/tinycbor


### PR DESCRIPTION
Move to rebased release histories for v1.2 in the zephyr, mcuboot, and mcumgr projects.