### PR TITLE
cmake: remove incorrect warning

### DIFF
--- a/subsys/bootloader/image/CMakeLists.txt
+++ b/subsys/bootloader/image/CMakeLists.txt
@@ -32,11 +32,6 @@ if (CONFIG_BOOTLOADER_MCUBOOT)
 
 else()
 
-  if (CONFIG_MCUBOOT_BUILD_S1_VARIANT)
-    message(WARNING "kconfig option 'MCUBOOT_BUILD_S1_VARIANT' is set,
-but MCUboot is not being built.")
-  endif()
-
   if (CONFIG_SPM)
     set(image_to_boot spm_)
   endif()


### PR DESCRIPTION
S1 variant is always built if mcuboot is enabled.
In other words this option will always be true for B0.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>