### PR TITLE
samples: nrf9160: lte_ble_gateway: startup message

### DIFF
--- a/samples/nrf9160/lte_ble_gateway/src/main.c
+++ b/samples/nrf9160/lte_ble_gateway/src/main.c
@@ -475,7 +475,7 @@ static void buttons_leds_init(void)
 
 void main(void)
 {
-	printk("Application started\n");
+	printk("LTE Sensor Gateway sample started\n");
 
 	buttons_leds_init();
 	ble_init();


### PR DESCRIPTION
Added a more descriptive startup message.

Signed-off-by: Martin Lesund <martin.lesund@nordicsemi.no>