### PR TITLE
net: lib: aws_fota: Bugfix reset `fota_state` on failure

### DIFF
--- a/subsys/net/lib/aws_fota/src/aws_fota.c
+++ b/subsys/net/lib/aws_fota/src/aws_fota.c
@@ -467,7 +467,6 @@ int aws_fota_mqtt_evt_handler(struct mqtt_client *const client,
 		/* Handling for default case */
 		return 1;
 	}
-	return 1;
 }
 
 
@@ -489,6 +488,8 @@ static void http_fota_handler(const struct fota_download_evt *evt)
 		break;
 	case FOTA_DOWNLOAD_EVT_ERROR:
 		LOG_ERR("FOTA download failed, report back");
+		fota_state = NONE;
+		execution_state = AWS_JOBS_QUEUED;
 		(void) update_job_execution(c, job_id, AWS_JOBS_FAILED,
 					    fota_state, -1, "");
 		callback(AWS_FOTA_EVT_ERROR);


### PR DESCRIPTION
If the `fota_state` variable is not reset upon failure we won't be able
to process any new jobs. This fixes this issue.

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>