### PR TITLE
lib: at_cmd_parser: Fixed warnings about char subscripts

### DIFF
--- a/lib/at_cmd_parser/at_cmd_parser.c
+++ b/lib/at_cmd_parser/at_cmd_parser.c
@@ -214,7 +214,7 @@ static int at_parse_process_element(const char **str, int index,
 	} else if (state == SMS_PDU) {
 		const char *start_ptr = tmpstr;
 
-		while (isxdigit(*tmpstr)) {
+		while (isxdigit((int)*tmpstr)) {
 			tmpstr++;
 		}
 
@@ -241,7 +241,7 @@ static int at_parse_param(const char **at_params_str,
 	reset_state();
 
 	while ((!is_terminated(*str)) && (index < max_params)) {
-		if (isspace(*str)) {
+		if (isspace((int)*str)) {
 			str++;
 		}
 


### PR DESCRIPTION
Some toolchains will use macros that use the value as an array index,
so this combined with -Wchar-subscripts will give warnings about the
subscript being char (which tends to be used to remind people it's
potentially a signed value and might break out of arrays).