### PR TITLE
cmake: add elf dependencies to multi image builds

### DIFF
--- a/cmake/multi_image.cmake
+++ b/cmake/multi_image.cmake
@@ -22,7 +22,10 @@ endfunction()
 
 if(IMAGE_NAME)
   share("set(${IMAGE_NAME}KERNEL_HEX_NAME ${KERNEL_HEX_NAME})")
+  # Share the elf file, in order to support symbol loading for debuggers.
+  share("set(${IMAGE_NAME}KERNEL_ELF_NAME ${KERNEL_ELF_NAME})")
   share("list(APPEND ${IMAGE_NAME}BUILD_BYPRODUCTS ${PROJECT_BINARY_DIR}/${KERNEL_HEX_NAME})")
+  share("list(APPEND ${IMAGE_NAME}BUILD_BYPRODUCTS ${PROJECT_BINARY_DIR}/${KERNEL_ELF_NAME})")
 
   file(GENERATE OUTPUT ${CMAKE_BINARY_DIR}/shared_vars.cmake
     CONTENT $<TARGET_PROPERTY:zephyr_property_target,shared_vars>
@@ -181,6 +184,7 @@ function(add_child_image_from_source name sourcedir)
 
   # Increase the scope of this variable to make it more available
   set(${name}_KERNEL_HEX_NAME ${${name}_KERNEL_HEX_NAME} CACHE STRING "" FORCE)
+  set(${name}_KERNEL_ELF_NAME ${${name}_KERNEL_ELF_NAME} CACHE STRING "" FORCE)
 
   if(MULTI_IMAGE_DEBUG_MAKEFILE AND "${CMAKE_GENERATOR}" STREQUAL "Ninja")
     set(multi_image_build_args "-d" "${MULTI_IMAGE_DEBUG_MAKEFILE}")

--- a/cmake/partition_manager.cmake
+++ b/cmake/partition_manager.cmake
@@ -106,6 +106,7 @@ if(PM_IMAGES OR (EXISTS ${static_configuration_file}))
   foreach(part ${PM_ALL_BY_SIZE})
     string(TOUPPER ${part} PART)
     get_property(${part}_PM_HEX_FILE GLOBAL PROPERTY ${part}_PM_HEX_FILE)
+    get_property(${part}_PM_ELF_FILE GLOBAL PROPERTY ${part}_PM_ELF_FILE)
 
     # Process container partitions (if it has a SPAN list it is a container partition).
     if(DEFINED PM_${PART}_SPAN)
@@ -120,6 +121,7 @@ if(PM_IMAGES OR (EXISTS ${static_configuration_file}))
     else()
       if(${part} IN_LIST images)
         set(${part}_PM_HEX_FILE ${CMAKE_BINARY_DIR}/${part}/zephyr/${${part}_KERNEL_HEX_NAME})
+        set(${part}_PM_ELF_FILE ${CMAKE_BINARY_DIR}/${part}/zephyr/${${part}_KERNEL_ELF_NAME})
         set(${part}_PM_TARGET ${part}_subimage)
       elseif(${part} IN_LIST containers)
         set(${part}_PM_HEX_FILE ${PROJECT_BINARY_DIR}/${part}.hex)
@@ -141,6 +143,7 @@ if(PM_IMAGES OR (EXISTS ${static_configuration_file}))
     foreach(part ${PM_${CONTAINER}_SPAN})
       string(TOUPPER ${part} PART)
       list(APPEND ${container}hex_files ${${part}_PM_HEX_FILE})
+      list(APPEND ${container}elf_files ${${part}_PM_ELF_FILE})
       list(APPEND ${container}targets ${${part}_PM_TARGET})
     endforeach()
 
@@ -161,6 +164,10 @@ if(PM_IMAGES OR (EXISTS ${static_configuration_file}))
       DEPENDS
       ${${container}targets}
       ${${container}hex_files}
+      # SES will load symbols from all elf files listed as dependencies to ${PROJECT_BINARY_DIR}/merged.hex.
+      # Therefore we add ${${container}elf_files} as dependency to ensure they are loaded by SES even though
+      # it is unnecessary for building the application.
+      ${${container}elf_files}
       )
 
     # Wrapper target for the merge command.


### PR DESCRIPTION
This commit add elf file dependencies to merged.hex target for multi image
builds.

The elf file dependency will be reflected in the generated ninja file and
thus allowing IDE/Debuggers to obtain relation of hex-file to elf-file
relation for symbol loading during a debug session.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>