### PR TITLE
samples: nrf9160: gps: fixing compilation warnings

### DIFF
--- a/lib/supl/os/lte_params.c
+++ b/lib/supl/os/lte_params.c
@@ -7,6 +7,7 @@
 #include <zephyr.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include "lte_params.h"
 #include "utils.h"

--- a/samples/nrf9160/gps/src/main.c
+++ b/samples/nrf9160/gps/src/main.c
@@ -75,7 +75,7 @@ static const char status2[] = "+CEREG:1";
 static const char status3[] = "+CEREG: 5";
 static const char status4[] = "+CEREG:5";
 
-static void wait_for_lte(void *context, char *response)
+static void wait_for_lte(void *context, const char *response)
 {
 	if (!memcmp(status1, response, AT_CMD_SIZE(status1)) ||
 		!memcmp(status2, response, AT_CMD_SIZE(status2)) ||


### PR DESCRIPTION
 * Fixing warning about implicit memset function declaration
 * Fixing warning about wrong argument when registering and
   deregistering at_notif handler

Signed-off-by: <even.falch-larsen@nordicsemi.no>