### PR TITLE
net: lib: Erase pending may cause the modem FOTA to hang 

### DIFF
--- a/applications/asset_tracker/src/main.c
+++ b/applications/asset_tracker/src/main.c
@@ -902,6 +902,9 @@ void cloud_event_handler(const struct cloud_backend *const backend,
 		break;
 	case CLOUD_EVT_FOTA_DONE:
 		LOG_INF("CLOUD_EVT_FOTA_DONE");
+#if defined(CONFIG_LTE_LINK_CONTROL)
+		lte_lc_power_off();
+#endif
 		sys_reboot(SYS_REBOOT_COLD);
 		break;
 	default:

--- a/include/dfu/dfu_target.h
+++ b/include/dfu/dfu_target.h
@@ -23,10 +23,17 @@ extern "C" {
 #define DFU_TARGET_IMAGE_TYPE_MCUBOOT 1
 #define DFU_TARGET_IMAGE_TYPE_MODEM_DELTA 2
 
+enum dfu_target_evt_id {
+	DFU_TARGET_EVT_TIMEOUT,
+	DFU_TARGET_EVT_ERASE_DONE
+};
+
+typedef void (*dfu_target_callback_t)(enum dfu_target_evt_id evt_id);
+
 /** @brief Functions which needs to be supported by all DFU targets.
  */
 struct dfu_target {
-	int (*init)(size_t file_size);
+	int (*init)(size_t file_size, dfu_target_callback_t cb);
 	int (*offset_get)(size_t *offset);
 	int (*write)(const void *const buf, size_t len);
 	int (*done)(bool successful);
@@ -58,12 +65,14 @@ int dfu_target_img_type(const void *const buf, size_t len);
  *
  * @param[in] img_type Image type identifier.
  * @param[in] file_size Size of the current file being downloaded.
+ * @param[in] cb Callback function in case the DFU operation requires additional
+ *		 proceedures to be called.
  *
  * @return 0 for a supported image type or a negative error
  *	   code identicating reason of failure.
  *
  **/
-int dfu_target_init(int img_type, size_t file_size);
+int dfu_target_init(int img_type, size_t file_size, dfu_target_callback_t cb);
 
 /**
  * @brief Get offset of the firmware upgrade

--- a/include/net/aws_fota.h
+++ b/include/net/aws_fota.h
@@ -25,7 +25,11 @@ enum aws_fota_evt_id {
 	/** AWS FOTA complete and status reported to job document */
 	AWS_FOTA_EVT_DONE,
 	/** AWS FOTA error */
-	AWS_FOTA_EVT_ERROR
+	AWS_FOTA_EVT_ERROR,
+	/** AWS FOTA Erase pending*/
+	AWS_FOTA_EVT_ERASE_PENDING,
+	/** AWS FOTA Erase done*/
+	AWS_FOTA_EVT_ERASE_DONE
 };
 
 typedef void (*aws_fota_callback_t)(enum aws_fota_evt_id evt_id);

--- a/include/net/fota_download.h
+++ b/include/net/fota_download.h
@@ -34,6 +34,10 @@ enum fota_download_evt_id {
 	FOTA_DOWNLOAD_EVT_PROGRESS,
 	/** FOTA download finished. */
 	FOTA_DOWNLOAD_EVT_FINISHED,
+	/** FOTA download erase pending. */
+	FOTA_DOWNLOAD_EVT_ERASE_PENDING,
+	/** FOTA download erase done. */
+	FOTA_DOWNLOAD_EVT_ERASE_DONE,
 	/** FOTA download error. */
 	FOTA_DOWNLOAD_EVT_ERROR,
 };

--- a/subsys/dfu/Kconfig
+++ b/subsys/dfu/Kconfig
@@ -38,6 +38,22 @@ config DFU_TARGET_MODEM
 	help
 	  Enable support for updates to the modem firmware.
 
+if (DFU_TARGET_MODEM)
+
+config DFU_TARGET_MODEM_TIMEOUT
+	int "Erase pending timeout"
+	default 60
+	help
+	  Set the timeout in seconds for how long the code will wait when
+	  reading DFU_ERASE_PENDING from the modem. If the timeout is reached
+	  an DFU_TARGET_EVT_TIMEOUT is issued and a disconnect of the LTE link
+	  is recommended so that the modem has time to service the
+	  DFU_ERASE_PENDING request. It's also possible to reboot the device to
+	  achive the same desired behavior.
+
+
+endif # DFU_TARGET_MODEM
+
 module=DFU_TARGET
 module-dep=LOG
 module-str=Device Firmware Upgrade

--- a/subsys/dfu/include/dfu_target_mcuboot.h
+++ b/subsys/dfu/include/dfu_target_mcuboot.h
@@ -52,10 +52,11 @@ bool dfu_target_mcuboot_identify(const void *const buf);
  * @brief Initialize dfu target, perform steps necessary to receive firmware.
  *
  * @param[in] file_size Size of the current file being downloaded.
+ * @param[in] cb Callback for signaling events(unused).
  *
  * @retval 0 If successful, negative errno otherwise.
  */
-int dfu_target_mcuboot_init(size_t file_size);
+int dfu_target_mcuboot_init(size_t file_size, dfu_target_callback_t cb);
 
 /**
  * @brief Get offset of firmware

--- a/subsys/dfu/include/dfu_target_modem.h
+++ b/subsys/dfu/include/dfu_target_modem.h
@@ -31,10 +31,12 @@ bool dfu_target_modem_identify(const void *const buf);
  * @brief Initialize dfu target, perform steps necessary to receive firmware.
  *
  * @param[in] file_size Size of the current file being downloaded.
+ * @param[in] callback Callback function for signaling if the modem is not able
+ *		       to service the erase request.
  *
  * @retval 0 If successful, negative errno otherwise.
  */
-int dfu_target_modem_init(size_t file_size);
+int dfu_target_modem_init(size_t file_size, dfu_target_callback_t callback);
 
 /**
  * @brief Get offset of firmware

--- a/subsys/dfu/src/dfu_target.c
+++ b/subsys/dfu/src/dfu_target.c
@@ -54,7 +54,7 @@ int dfu_target_img_type(const void *const buf, size_t len)
 	return -ENOTSUP;
 }
 
-int dfu_target_init(int img_type, size_t file_size)
+int dfu_target_init(int img_type, size_t file_size, dfu_target_callback_t cb)
 {
 	const struct dfu_target *new_target = NULL;
 
@@ -83,7 +83,7 @@ int dfu_target_init(int img_type, size_t file_size)
 
 	current_target = new_target;
 
-	return current_target->init(file_size);
+	return current_target->init(file_size, cb);
 }
 
 int dfu_target_offset_get(size_t *offset)
@@ -124,4 +124,3 @@ int dfu_target_done(bool successful)
 
 	return 0;
 }
-

--- a/subsys/dfu/src/dfu_target_mcuboot.c
+++ b/subsys/dfu/src/dfu_target_mcuboot.c
@@ -21,6 +21,7 @@
 #include <pm_config.h>
 #include <logging/log.h>
 #include <dfu/mcuboot.h>
+#include <dfu/dfu_target.h>
 #include <dfu/flash_img.h>
 #include <settings/settings.h>
 
@@ -31,7 +32,8 @@ LOG_MODULE_REGISTER(dfu_target_mcuboot, CONFIG_DFU_TARGET_LOG_LEVEL);
 
 static struct flash_img_context flash_img;
 
-int dfu_ctx_mcuboot_set_b1_file(const char *file, bool s0_active, const char **update)
+int dfu_ctx_mcuboot_set_b1_file(const char *file, bool s0_active,
+				const char **update)
 {
 	if (file == NULL || update == NULL) {
 		return -EINVAL;
@@ -112,8 +114,9 @@ bool dfu_target_mcuboot_identify(const void *const buf)
 	return *((const u32_t *)buf) == MCUBOOT_HEADER_MAGIC;
 }
 
-int dfu_target_mcuboot_init(size_t file_size)
+int dfu_target_mcuboot_init(size_t file_size, dfu_target_callback_t cb)
 {
+	ARG_UNUSED(cb);
 	int err = flash_img_init(&flash_img);
 
 	if (err != 0) {
@@ -122,7 +125,8 @@ int dfu_target_mcuboot_init(size_t file_size)
 	}
 
 	if (file_size > PM_MCUBOOT_SECONDARY_SIZE) {
-		LOG_ERR("Requested file too big to fit in flash");
+		LOG_ERR("Requested file too big to fit in flash %d > %d",
+			file_size, PM_MCUBOOT_SECONDARY_SIZE);
 		return -EFBIG;
 	}
 

--- a/subsys/dfu/src/dfu_target_modem.c
+++ b/subsys/dfu/src/dfu_target_modem.c
@@ -195,9 +195,17 @@ int dfu_target_modem_write(const void *const buf, size_t len)
 		} else {
 			return 0;
 		}
+	case DFU_AREA_NOT_BLANK:
+		delete_banked_modem_fw();
+		err = dfu_target_modem_write(buf, len);
+		if (err < 0) {
+			return -EINVAL;
+		} else {
+			return 0;
+		}
+	default:
+		return -EFAULT;
 	}
-
-	return -EFAULT;
 }
 
 int dfu_target_modem_done(bool successful)

--- a/subsys/net/lib/aws_fota/src/aws_fota.c
+++ b/subsys/net/lib/aws_fota/src/aws_fota.c
@@ -486,6 +486,15 @@ static void http_fota_handler(const struct fota_download_evt *evt)
 			callback(AWS_FOTA_EVT_ERROR);
 		}
 		break;
+
+	case FOTA_DOWNLOAD_EVT_ERASE_PENDING:
+		callback(AWS_FOTA_EVT_ERASE_PENDING);
+		break;
+
+	case FOTA_DOWNLOAD_EVT_ERASE_DONE:
+		callback(AWS_FOTA_EVT_ERASE_DONE);
+		break;
+
 	case FOTA_DOWNLOAD_EVT_ERROR:
 		LOG_ERR("FOTA download failed, report back");
 		fota_state = NONE;

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
@@ -458,6 +458,15 @@ static void aws_fota_cb_handler(enum aws_fota_evt_id evt)
 		nct_apply_update();
 		break;
 
+	case AWS_FOTA_EVT_ERASE_PENDING:
+		LOG_DBG("AWS_FOTA_EVT_ERASE_PENDING rebooting");
+		nct_apply_update();
+		break;
+
+	case AWS_FOTA_EVT_ERASE_DONE:
+		LOG_DBG("AWS_FOTA_EVT_ERASE_DONE.\n");
+		break;
+
 	case AWS_FOTA_EVT_ERROR:
 		LOG_ERR("AWS_FOTA_EVT_ERROR");
 		break;


### PR DESCRIPTION
Doing a modem DFU may cause the modem to never execute the erase just functioning normally so the code will hang on `DFU_ERASE_PENDING`.
This is due to the modem being too busy doing normal operations than to do the actual erase. Either
reboot the device or turn of the LTE link until the erase operation is
complete to mitigate this issue.
