### PR TITLE
manifest: ci: lock python requirement versions

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -38,7 +38,7 @@ manifest:
     - name: zephyr
       repo-path: fw-nrfconnect-zephyr
       west-commands: scripts/west-commands.yml
-      revision: v2.1.99-ncs1-rc1
+      revision: 870fc37297cdb5a6e48782fc35d85a12d1f74675
     - name: segger
       revision: 6fcf61606d6012d2c44129edc033f59331e268bc
       path: modules/debug/segger


### PR DESCRIPTION
- lock `sphinx==2.3.0` and `west==0.6.3` until manually updated
- manifest adds this PR in zephyr: https://github.com/NordicPlayground/fw-nrfconnect-zephyr/pull/271

Signed-off-by: Thomas Stilwell <Thomas.Stilwell@nordicsemi.no>