### PR TITLE
lib: at_cmd: Added protecting against multiple initialization

### DIFF
--- a/lib/at_cmd/at_cmd.c
+++ b/lib/at_cmd/at_cmd.c
@@ -308,6 +308,14 @@ void at_cmd_set_notification_handler(at_cmd_handler_t handler)
 
 static int at_cmd_driver_init(struct device *dev)
 {
+	static bool initialized;
+
+	if (initialized) {
+		return 0;
+	}
+
+	initialized = true;
+
 	int err;
 
 	ARG_UNUSED(dev);


### PR DESCRIPTION
There have been a few cases where multiple things have tried to
initialize the AT command module, only to have some bad things happen
(like the thread being created mutliple times and the slab allocated
for response handling permanently leaking at least one allocation).
This will at least make it easier for multiple things to call the
initialization routine without having that happen.

Signed-off-by: Erik Johnson <erik.johnson@nimbelink.com>