### PR TITLE
lib: at_cmd: Added putting NULL byte in response string

### DIFF
--- a/lib/at_cmd/at_cmd.c
+++ b/lib/at_cmd/at_cmd.c
@@ -182,6 +182,7 @@ static void socket_thread_fn(void *arg1, void *arg2, void *arg3)
 				if (response_buf_len > payload_len) {
 					memcpy(response_buf, item->data,
 					       payload_len);
+					response_buf[payload_len] = '\0';
 				} else {
 					LOG_ERR("Response buffer not large "
 						"enough");


### PR DESCRIPTION
There is already a check to make sure the buffer has enough room for
the entire string plus one -- a strict greater-than check -- so there
isn't a reason this can't terminate the string itself. Since it doesn't
send back the length of the response, it puts a heavy burden on users
of the AT command module to have to completely clear out their buffers
each time they send another command.

Signed-off-by: Erik Johnson <erik.johnson@nimbelink.com>