### PR TITLE
applications: asset_tracker: Use application workqueue in modules

### DIFF
--- a/applications/asset_tracker/src/env_sensors/env_sensors.h
+++ b/applications/asset_tracker/src/env_sensors/env_sensors.h
@@ -89,7 +89,8 @@ int env_sensors_get_air_quality(env_sensor_data_t *sensor_data);
  *
  * @return 0 if the operation was successful, otherwise a (negative) error code.
  */
-int env_sensors_init_and_start(const env_sensors_data_ready_cb cb);
+int env_sensors_init_and_start(struct k_work_q *work_q,
+			       const env_sensors_data_ready_cb cb);
 
 /**
  * @brief Set environmental sensor's poll/send interval.

--- a/applications/asset_tracker/src/light_sensor/light_sensor.h
+++ b/applications/asset_tracker/src/light_sensor/light_sensor.h
@@ -38,7 +38,8 @@ typedef void (*light_sensor_data_ready_cb)(void);
  *
  * @return 0 if the operation was successful, otherwise a (negative) error code.
  */
-int light_sensor_init_and_start(const light_sensor_data_ready_cb cb);
+int light_sensor_init_and_start(struct k_work_q *work_q,
+				const light_sensor_data_ready_cb cb);
 
 /**
  * @brief Get latest sampled light data.

--- a/applications/asset_tracker/src/main.c
+++ b/applications/asset_tracker/src/main.c
@@ -1029,17 +1029,18 @@ static void sensors_init(void)
 {
 	int err;
 
-	err = motion_init_and_start(motion_handler);
+	err = motion_init_and_start(&application_work_q, motion_handler);
 	if (err) {
 		LOG_ERR("motion module init failed, error: %d", err);
 	}
 
-	err = env_sensors_init_and_start(env_data_send);
+	err = env_sensors_init_and_start(&application_work_q, env_data_send);
 	if (err) {
 		LOG_ERR("Environmental sensors init failed, error: %d", err);
 	}
 #if CONFIG_LIGHT_SENSOR
-	err = light_sensor_init_and_start(light_sensor_data_send);
+	err = light_sensor_init_and_start(&application_work_q,
+					  light_sensor_data_send);
 	if (err) {
 		LOG_ERR("Light sensor init failed, error: %d", err);
 	}

--- a/applications/asset_tracker/src/motion/motion.h
+++ b/applications/asset_tracker/src/motion/motion.h
@@ -51,7 +51,8 @@ typedef void (*motion_handler_t)(motion_data_t  motion_data);
  *
  * @return 0 if the operation was successful, otherwise a (negative) error code.
  */
-int motion_init_and_start(motion_handler_t motion_handler);
+int motion_init_and_start(struct k_work_q *work_q,
+			  motion_handler_t motion_handler);
 
 /**
  * @brief Manually trigger the motion module to fetch data.


### PR DESCRIPTION
Use application workqueue in env_sensors, light_sensor and motion
module.

Jira:NCSDK-4422

Signed-off-by: Jon Helge Nistad <jon.helge.nistad@nordicsemi.no>