### PR TITLE
lib: bsdlib: Add interpretation for NRF_EDOM

### DIFF
--- a/lib/bsdlib/bsd_os.c
+++ b/lib/bsdlib/bsd_os.c
@@ -247,6 +247,9 @@ void bsd_os_errno_set(int err_code)
 	case NRF_EAGAIN:
 		errno = EAGAIN;
 		break;
+	case NRF_EDOM:
+		errno = EDOM;
+		break;
 	case NRF_EPROTOTYPE:
 		errno = EPROTOTYPE;
 		break;


### PR DESCRIPTION
Added interpretation for NRF_EDOM errno.

Signed-off-by: Kimmo Puusaari <kimmo.puusaari@nordicsemi.no>
