### PR TITLE
sample: esb: Delay esb_init until hf clock has started.

### DIFF
--- a/samples/esb/prx/src/main.c
+++ b/samples/esb/prx/src/main.c
@@ -109,6 +109,13 @@ int clocks_start(void)
 		return err;
 	}
 
+	/* Block until clock is started.
+	 */
+	while (clock_control_get_status(clk, CLOCK_CONTROL_NRF_SUBSYS_HF) !=
+		CLOCK_CONTROL_STATUS_ON) {
+
+	}
+
 	LOG_DBG("HF clock started");
 	return 0;
 }

--- a/samples/esb/ptx/src/main.c
+++ b/samples/esb/ptx/src/main.c
@@ -72,6 +72,13 @@ int clocks_start(void)
 		return err;
 	}
 
+	/* Block until clock is started.
+	 */
+	while (clock_control_get_status(clk, CLOCK_CONTROL_NRF_SUBSYS_HF) !=
+		CLOCK_CONTROL_STATUS_ON) {
+
+	}
+
 	LOG_DBG("HF clock started");
 	return 0;
 }


### PR DESCRIPTION
sample: esb: Delay esb_init until high frequency clock has started. Without there sample crash on arbitrary devices based on timing.

Signed-off-by: Rune Holmgren <Rune.Holmgren@nordicsemi.no>