### PR TITLE
manifest: update nrfxlib to include doc update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -69,7 +69,7 @@ manifest:
       revision: 30b7efa827b04d2e47840716b0372737fe7d6c92
     - name: nrfxlib
       path: nrfxlib
-      revision: c6a87c02666f6b319c723367b9ec1159733693b0
+      revision: 7d5e7624ec7fdb071ab8def3ae772e5ee5b65f21
     - name: cmock
       path: test/cmock
       revision: c243b9a7a7b3c471023193992b46cf1bd1910450


### PR DESCRIPTION
This commit updates the manifest file to point to nrfxlib revision:
pull/142/head

This update includes correction of some outdated doc of nrf security
module.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>