### PR TITLE
doc: add a note about asset_tracker boot chain

### DIFF
--- a/applications/asset_tracker/README.rst
+++ b/applications/asset_tracker/README.rst
@@ -155,6 +155,9 @@ For example, configure ``CONFIG_POWER_OPTIMIZATION_ENABLE`` to enable power opti
 In |SES|, select **Project** > **Configure nRF Connect SDK project** to browse and configure these options.
 Alternatively, use the command line tool ``menuconfig`` or configure the options directly in ``prj.conf``.
 
+This application supports the |NCS| :ref:`ug_bootloader`, but it is disabled by default.
+To enable the immutable bootloader, set ``CONFIG_SECURE_BOOT=y``.
+
 Testing
 =======
 


### PR DESCRIPTION
I personally lost some time doing some development related to this
application due to an incorrect assumption that it was using the
secure bootloader chain which is documented in ug_bootloader.rst.

In fact, by default, this application does not use the secure
bootloader chain.

In case others are confused by this, try to help by adding a short
paragraph explaining this.