### PR TITLE
Add nrf_cloud specific FOTA download progress.

### DIFF
--- a/include/net/aws_fota.h
+++ b/include/net/aws_fota.h
@@ -22,6 +22,8 @@ extern "C" {
 #endif
 
 enum aws_fota_evt_id {
+	/** AWS FOTA has started */
+	AWS_FOTA_EVT_START,
 	/** AWS FOTA complete and status reported to job document */
 	AWS_FOTA_EVT_DONE,
 	/** AWS FOTA error */
@@ -29,10 +31,24 @@ enum aws_fota_evt_id {
 	/** AWS FOTA Erase pending*/
 	AWS_FOTA_EVT_ERASE_PENDING,
 	/** AWS FOTA Erase done*/
-	AWS_FOTA_EVT_ERASE_DONE
+	AWS_FOTA_EVT_ERASE_DONE,
+	/** AWS FOTA download progress */
+	AWS_FOTA_EVT_DL_PROGRESS,
 };
 
-typedef void (*aws_fota_callback_t)(enum aws_fota_evt_id evt_id);
+#define AWS_FOTA_EVT_DL_COMPLETE_VAL 100
+struct aws_fota_event_dl {
+	int progress; /* Download progress percent, 0-100 */
+};
+
+struct aws_fota_event {
+	enum aws_fota_evt_id id;
+	union {
+		struct aws_fota_event_dl dl;
+	};
+};
+
+typedef void (*aws_fota_callback_t)(struct aws_fota_event *fota_evt);
 
 /**@brief Initialize the AWS Firmware Over the Air library.
  *
@@ -58,6 +74,16 @@ int aws_fota_init(struct mqtt_client *const client,
  */
 int aws_fota_mqtt_evt_handler(struct mqtt_client *const client,
 			      const struct mqtt_evt *evt);
+
+/**@brief Get the null-terminated job id string.
+ *
+ * @param job_id_buf Buffer to which the job id will be copied.
+ * @param buf_size   Size of the buffer.
+ *
+ * @return Length of the job id string (not counting the terminating
+ *         null character) or a negative value on error.
+ */
+int aws_fota_get_job_id(u8_t *const job_id_buf, size_t buf_size);
 
 #ifdef __cplusplus
 }

--- a/include/net/aws_jobs.h
+++ b/include/net/aws_jobs.h
@@ -191,6 +191,7 @@ int aws_jobs_unsubscribe_topic_update(struct mqtt_client *const client,
  * @param[in] status           The job execution status.
  * @param[in] status_details   JSON object in string format containing
  *                             additional information. Max 10 fields.
+ *                             Can be NULL.
  * @param[in] expected_version The expected job document version. Must be
  *                             incremented by 1 for every update.
  * @param[in] client_token     This can be an arbitrary value and will be
@@ -251,4 +252,3 @@ bool aws_jobs_cmp(const char *sub, const char *pub, size_t pub_len,
  */
 
 #endif /* AWS_JOBS_H__ */
-

--- a/include/net/fota_download.h
+++ b/include/net/fota_download.h
@@ -47,7 +47,8 @@ enum fota_download_evt_id {
  */
 struct fota_download_evt {
 	enum fota_download_evt_id id;
-	int offset;
+	/** Download progress % */
+	int progress;
 };
 
 /**

--- a/subsys/net/lib/aws_jobs/src/aws_jobs.c
+++ b/subsys/net/lib/aws_jobs/src/aws_jobs.c
@@ -217,7 +217,7 @@ int aws_jobs_update_job_execution(struct mqtt_client *const client,
 				  const u8_t *client_token, u8_t *topic_buf)
 {
 	/* The rest of the parameters are checked later */
-	if (status_details == NULL || client_token == NULL) {
+	if (client_token == NULL) {
 		return -EINVAL;
 	}
 
@@ -229,7 +229,8 @@ int aws_jobs_update_job_execution(struct mqtt_client *const client,
 
 	int ret = snprintf(update_job_payload, sizeof(update_job_payload),
 			   UPDATE_JOB_PAYLOAD, execution_status_strings[status],
-			   status_details, expected_version, client_token);
+			   (status_details ? (char *)status_details : "null"),
+			   expected_version, client_token);
 
 	if (ret >= CONFIG_UPDATE_JOB_PAYLOAD_LEN) {
 		LOG_ERR("Unable to fit formated string in provided buffer.");
@@ -278,4 +279,3 @@ bool aws_jobs_cmp(const char *sub, const char *pub, size_t pub_len,
 		return ret == 0;
 	}
 }
-

--- a/subsys/net/lib/nrf_cloud/Kconfig
+++ b/subsys/net/lib/nrf_cloud/Kconfig
@@ -58,6 +58,14 @@ config NRF_CLOUD_MQTT_PAYLOAD_BUFFER_LEN
 	int "Size of the buffer for MQTT PUBLISH payload."
 	default 2048
 
+config NRF_CLOUD_FOTA_PROGRESS_PCT_INCREMENT
+	int "Percentage increment at which FOTA download progress is reported"
+	depends on FOTA_DOWNLOAD_PROGRESS_EVT
+	range 0 100
+	default 10
+	help
+		0 disables progress report.
+
 module=NRF_CLOUD
 module-dep=LOG
 module-str=Log level for nRF Cloud

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
@@ -88,6 +88,18 @@ static char update_delta_topic[NCT_UPDATE_DELTA_TOPIC_LEN + 1];
 static char update_topic[NCT_UPDATE_TOPIC_LEN + 1];
 static char shadow_get_topic[NCT_SHADOW_GET_LEN + 1];
 
+#if defined(CONFIG_AWS_FOTA)
+#define NCT_M_D_TOPIC_PREFIX "m/d/"
+#define NCT_TOPIC_PREFIX_M_D_LEN (sizeof(NCT_M_D_TOPIC_PREFIX) - 1)
+#define NCT_JOB_STATUS_TOPIC "/jobs"
+#define NCT_JOB_STATUS_TOPIC_LEN (sizeof(NCT_JOB_STATUS_TOPIC) - 1)
+#define JOB_ID_LEN 8
+/* FOTA status message: job id, space, % progress, null */
+#define JOB_STATUS_STR_LEN (JOB_ID_LEN + 1 + 3 + 1)
+char current_job_id[JOB_ID_LEN + 1];
+static int last_sent_fota_progress;
+#endif
+
 #define NCT_CC_SUBSCRIBE_ID 1234
 #define NCT_DC_SUBSCRIBE_ID 8765
 
@@ -106,6 +118,7 @@ static struct nct {
 	struct mqtt_utf8 dc_tx_endp;
 	struct mqtt_utf8 dc_rx_endp;
 	struct mqtt_utf8 dc_m_endp;
+	struct mqtt_utf8 job_status_endp;
 	u32_t message_id;
 	u8_t rx_buf[CONFIG_NRF_CLOUD_MQTT_MESSAGE_BUFFER_LEN];
 	u8_t tx_buf[CONFIG_NRF_CLOUD_MQTT_MESSAGE_BUFFER_LEN];
@@ -170,6 +183,9 @@ static void dc_endpoint_reset(void)
 
 	nct.dc_m_endp.utf8 = NULL;
 	nct.dc_m_endp.size = 0;
+
+	nct.job_status_endp.utf8 = NULL;
+	nct.job_status_endp.size = 0;
 }
 
 /* Get the next unused message id. */
@@ -195,6 +211,9 @@ static void dc_endpoint_free(void)
 	}
 	if (nct.dc_m_endp.utf8 != NULL) {
 		nrf_cloud_free(nct.dc_m_endp.utf8);
+	}
+	if (nct.job_status_endp.utf8 != NULL) {
+		nrf_cloud_free(nct.job_status_endp.utf8);
 	}
 	dc_endpoint_reset();
 }
@@ -450,26 +469,127 @@ static int nct_provision(void)
 }
 
 #if defined(CONFIG_AWS_FOTA)
-/* Handle AWS FOTA events */
-static void aws_fota_cb_handler(enum aws_fota_evt_id evt)
+static int job_status_stream(const struct nct_dc_data *dc_data)
 {
-	switch (evt) {
+	if (dc_data == NULL) {
+		return -EINVAL;
+	}
+
+	if (nct.job_status_endp.utf8 == NULL) {
+		LOG_ERR("Job status topic not set");
+		return -EACCES;
+	}
+
+	struct mqtt_publish_param publish = {
+		.message.topic.qos = MQTT_QOS_0_AT_MOST_ONCE };
+
+	publish.message.topic.topic.size = nct.job_status_endp.size;
+	publish.message.topic.topic.utf8 = nct.job_status_endp.utf8;
+
+	/* Populate payload. */
+	if ((dc_data->data.len != 0) && (dc_data->data.ptr != NULL)) {
+		publish.message.payload.data = (u8_t *)dc_data->data.ptr;
+		publish.message.payload.len = dc_data->data.len;
+	}
+
+	publish.message_id = 0;
+
+	return mqtt_publish(&nct.client, &publish);
+}
+
+/* Handle AWS FOTA events */
+static void aws_fota_cb_handler(struct aws_fota_event *fota_evt)
+{
+	if (fota_evt == NULL) {
+		return;
+	}
+
+	char fota_status[JOB_STATUS_STR_LEN] = { 0 };
+	struct nct_dc_data prog;
+	int err;
+
+	switch (fota_evt->id) {
+	case AWS_FOTA_EVT_START:
+		LOG_DBG("AWS_FOTA_EVT_START");
+		if (aws_fota_get_job_id(current_job_id, sizeof(current_job_id))
+			< JOB_ID_LEN) {
+			LOG_ERR("Failed to get current job ID");
+			current_job_id[0] = 0;
+		}
+		break;
 	case AWS_FOTA_EVT_DONE:
-		LOG_DBG("AWS_FOTA_EVT_DONE, rebooting to apply update.");
+		LOG_DBG("AWS_FOTA_EVT_DONE: rebooting to apply update");
+		last_sent_fota_progress = 0;
+		current_job_id[0] = 0;
 		nct_apply_update();
 		break;
 
 	case AWS_FOTA_EVT_ERASE_PENDING:
-		LOG_DBG("AWS_FOTA_EVT_ERASE_PENDING rebooting");
+		LOG_DBG("AWS_FOTA_EVT_ERASE_PENDING: rebooting");
 		nct_apply_update();
 		break;
 
 	case AWS_FOTA_EVT_ERASE_DONE:
-		LOG_DBG("AWS_FOTA_EVT_ERASE_DONE.\n");
+		LOG_DBG("AWS_FOTA_EVT_ERASE_DONE");
 		break;
 
 	case AWS_FOTA_EVT_ERROR:
 		LOG_ERR("AWS_FOTA_EVT_ERROR");
+		last_sent_fota_progress = 0;
+		current_job_id[0] = 0;
+		break;
+	case AWS_FOTA_EVT_DL_PROGRESS:
+		LOG_DBG("AWS_FOTA_EVT_DL_PROGRESS");
+		if ((fota_evt->dl.progress < 0) ||
+		    (fota_evt->dl.progress > AWS_FOTA_EVT_DL_COMPLETE_VAL)) {
+			LOG_ERR("Invalid progress value %d",
+				fota_evt->dl.progress);
+		}
+		/* Do not send complete status more than once */
+		if ((last_sent_fota_progress == AWS_FOTA_EVT_DL_COMPLETE_VAL) &&
+		    (fota_evt->dl.progress == AWS_FOTA_EVT_DL_COMPLETE_VAL)) {
+			return;
+		}
+
+		/* Reset if new progress is less than previous */
+		if (last_sent_fota_progress > fota_evt->dl.progress) {
+			last_sent_fota_progress = 0;
+		}
+
+		/* Send dl complete status regardless of increment setting */
+		/* Otherwise skip if increment is not met or disabled (0) */
+#if defined(CONFIG_FOTA_DOWNLOAD_PROGRESS_EVT)
+		if ((fota_evt->dl.progress < AWS_FOTA_EVT_DL_COMPLETE_VAL) &&
+		    (((fota_evt->dl.progress - last_sent_fota_progress) <
+		      CONFIG_NRF_CLOUD_FOTA_PROGRESS_PCT_INCREMENT) ||
+		     (CONFIG_NRF_CLOUD_FOTA_PROGRESS_PCT_INCREMENT == 0))) {
+			return;
+		}
+#endif
+
+		if (current_job_id[0] == 0) {
+			LOG_ERR("Invalid job ID, progress will not be sent");
+			return;
+		}
+
+		prog.data.len =
+			snprintf(fota_status, sizeof(fota_status), "%s %d",
+				 current_job_id, fota_evt->dl.progress);
+		if ((prog.data.len <= 0) ||
+		    (prog.data.len >= sizeof(fota_status))) {
+			LOG_ERR("Failed to create FOTA progress message");
+			return;
+		}
+
+		prog.data.ptr = fota_status;
+		LOG_ERR("JOB STATUS: %s", log_strdup(prog.data.ptr));
+		err = job_status_stream(&prog);
+		if (err) {
+			LOG_ERR("job_status_stream failed %d", err);
+			return;
+		}
+
+		last_sent_fota_progress = fota_evt->dl.progress;
 		break;
 	}
 }
@@ -850,6 +970,34 @@ void nct_dc_endpoint_set(const struct nrf_cloud_data *tx_endp,
 	if (m_endp != NULL) {
 		nct.dc_m_endp.utf8 = (u8_t *)m_endp->ptr;
 		nct.dc_m_endp.size = m_endp->len;
+
+#if defined(CONFIG_AWS_FOTA)
+		int ret;
+
+		nct.job_status_endp.size =
+			nct.dc_m_endp.size + NCT_TOPIC_PREFIX_M_D_LEN +
+			NRF_CLOUD_CLIENT_ID_LEN + NCT_JOB_STATUS_TOPIC_LEN + 1;
+		nct.job_status_endp.utf8 =
+			nrf_cloud_malloc(nct.job_status_endp.size);
+		if (nct.job_status_endp.utf8 == NULL) {
+			LOG_ERR("Failed to allocate mem for job status topic");
+			return;
+		}
+
+		ret = snprintf(nct.job_status_endp.utf8,
+			       nct.job_status_endp.size, "%s%s%s%s",
+			       nct.dc_m_endp.utf8, NCT_M_D_TOPIC_PREFIX,
+			       client_id_buf, NCT_JOB_STATUS_TOPIC);
+		if ((ret <= 0) || (ret >= nct.job_status_endp.size)) {
+			nrf_cloud_free(nct.job_status_endp.utf8);
+			nct.job_status_endp.utf8 = NULL;
+			nct.job_status_endp.size = 0;
+			LOG_ERR("Failed to build job status topic");
+			return;
+		}
+		/* size is actually string length */
+		nct.job_status_endp.size = ret;
+#endif
 	}
 }
 


### PR DESCRIPTION
Publish FOTA download progress to `<stage>/<tenant_id>/m/d/<device_id>/jobs`.
The message string will only contain the first 8 characters of the job id and the downloaded %.
Kconfig value NRF_CLOUD_FOTA_PROGRESS_PCT_INCREMENT controls how often the message is published.

TG91-174

Signed-off-by: Justin Morton justin.morton@nordicsemi.no