### PR TITLE
doc: update supported note on index page

### DIFF
--- a/doc/nrf/index.rst
+++ b/doc/nrf/index.rst
@@ -8,7 +8,7 @@ It offers a range of application samples and reference implementations, as well 
 The |NCS| includes the Zephyr™ real-time operating system (RTOS), which is built for connected low power products.
 
 .. note::
-   The |NCS| contains references and code for Bluetooth Low Energy devices in the nRF52 Series, though product development on these devices is not currently supported with the |NCS|.
+   The |NCS| contains reference applications, sample source code, and libraries for developing low-power wireless applications with nRF52 and nRF53 Series devices, though support for these devices is incomplete and not recommended for production.
 
 Documentation for different versions of the |NCS| is available at the following links:
 

--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -2,7 +2,7 @@
 
 .. |SES| replace:: SEGGER Embedded Studio
 
-.. |noBLE| replace:: Bluetooth Low Energy device implementations including libraries, drivers, samples, and applications are currently not supported for product development.
+.. |noBLE| replace:: Bluetooth Low Energy device implementations including libraries, drivers, samples, and applications are currently not recommended for production.
 
 .. |connect_terminal| replace:: Connect to the board with a terminal emulator (for example, PuTTY).
    See :ref:`putty` for the required settings.


### PR DESCRIPTION
Update the note on the documentation start page to clarify
the support for nRF52 and nRF53 devices.

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>