### PR TITLE
doc: Added information about LTE Link Monitor in getting started

### DIFF
--- a/doc/nrf/gs_testing.rst
+++ b/doc/nrf/gs_testing.rst
@@ -16,8 +16,34 @@ To see the UART output, connect to the board with a terminal emulator, for examp
 
 Connect with the following settings:
 
- * Baud rate: 115.200
+ * Baud rate: 115200
  * 8 data bits
  * 1 stop bit
  * No parity
  * HW flow control: None
+
+.. _lte_connect:
+
+How to connect with LTE Link Monitor
+************************************
+
+To connect to nRF9160-based boards (for example, the nRF9160 DK or Nordic Thingy:91), you can also use `LTE Link Monitor`_, which is implemented in `nRF Connect for Desktop`_.
+This application is used to establish LTE communication with the nRF9160 modem through AT commands, and it also displays the UART output.
+
+To connect to the nRF9160-based board with LTE Link Monitor, perform the following steps:
+
+1. Launch the LTE Link Monitor app.
+
+   .. note::
+
+      Make sure that **Automatic requests** is enabled in LTE Link Monitor.
+
+#. Connect the nRF9160-based board to the PC with a USB cable.
+#. Power on the nRF9160-based board.
+#. Click **Select Device** and select the particular board entry from the drop-down list in the LTE Link Monitor.
+#. Observe that the LTE Link monitor app starts AT communication with the modem of the nRF9160-based board and shows the status of the communication in the display terminal.
+   The app also displays any information that is logged on UART.
+
+   .. note::
+
+      In the case of nRF9160 DK, the reset button must be pressed to restart the device and to start the application.

--- a/samples/nrf9160/at_client/README.rst
+++ b/samples/nrf9160/at_client/README.rst
@@ -34,27 +34,20 @@ Building and running
 .. include:: /includes/build_and_run_nrf9160.txt
 
 
-Connecting to the nRF9160 DK board with LTE Link Monitor
-========================================================
-
-To connect to the nRF9160 DK board with LTE Link Monitor, perform the following steps:
-
-#. Launch the LTE Link Monitor after programming the AT Client sample onto the nRF9160 DK board.
-#. Make sure that **Automatic requests** is enabled in LTE Link Monitor.
-#. Connect the nRF9160 DK board to the PC with a USB cable.
-#. Power on the nRF9160 DK board.
-#. Click **Select Device** and select the particular board device entry from the drop-down list in the LTE Link Monitor.
-#. Observe that initially the command :command:`AT+CFUN?` is automatically sent to the modem, which returns a value 4, indicating that the modem is in the offline mode.
-#. Observe that the LTE Link Monitor terminal display also shows :command:`AT+CFUN=1` indicating that the modem has changed to the normal mode.
-#. Press the reset button on the nRF9160 DK to reboot the board and start the AT Client sample.
-
-
 Testing
 =======
 
 After programming the sample to your board, test the sample by performing the following steps:
 
-1. `Connect to the nRF9160 DK board with LTE Link Monitor <Connecting to the nRF9160 DK board with LTE Link Monitor_>`_.
+1. Press the reset button on the nRF9160 DK to reboot the board and start the AT Client sample.
+#. :ref:`Connect to the nRF9160 DK board with LTE Link Monitor<lte_connect>`.
+
+   .. note::
+
+      Make sure that **Automatic requests** is enabled in LTE Link Monitor.
+
+#. Observe that initially the command :command:`AT+CFUN?` is automatically sent to the modem, which returns a value 4, indicating that the modem is in the offline mode.
+#. Observe that the LTE Link Monitor terminal display also shows :command:`AT+CFUN=1` followed by ``OK`` indicating that the modem has changed to the normal mode.
 #. Run the following commands from the LTE Link Monitor terminal:
 
    a. Enter the command: :command:`AT+CFUN?`
@@ -93,7 +86,6 @@ After programming the sample to your board, test the sample by performing the fo
       If the device has been added to nRF Cloud, a CA certificate, a client certificate, and a private key with security tag 16842753 (which is the security tag for nRF Cloud credentials) are displayed.
 
 
-
 Sample output
 =============
 
@@ -123,10 +115,6 @@ In addition, it uses the following samples:
 
 From |NCS|
   * :ref:`secure_partition_manager`
-
-
-
-
 
 
 References


### PR DESCRIPTION

[nRF9160_ AT Client — nRF Connect SDK 1.1.99 documentation.pdf](https://github.com/NordicPlayground/fw-nrfconnect-nrf/files/4204589/nRF9160_.AT.Client.nRF.Connect.SDK.1.1.99.documentation.pdf)
[Testing a sample application — nRF Connect SDK 1.1.99 documentation.pdf](https://github.com/NordicPlayground/fw-nrfconnect-nrf/files/4204590/Testing.a.sample.application.nRF.Connect.SDK.1.1.99.documentation.pdf)

Added missing information about connecting to nRF9160 devices
using LTE Link Monitor in getting started(testing) section.
Moved a relevant general section from AT Client sample to the
testing section.
ref:https://projecttools.nordicsemi.no/jira/browse/NCSDK-1104

Signed-off-by: Uma Praseeda <uma.praseeda@nordicsemi.no>