### PR TITLE
doc: update link to SUPL client

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -83,6 +83,8 @@
 
 .. _`nRF9160 DK product page`: https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF9160-DK/Download#infotabs
 
+.. _`SUPL client download`: https://www.nordicsemi.com/Software-and-tools/Development-Kits/nRF9160-DK/Download#supl-c
+
 .. _`nRF9160 product website`: https://www.nordicsemi.com/Products/Low-power-cellular-IoT/nRF9160-SiP
 
 .. _`nRF9160 product website (compatible downloads)`: https://www.nordicsemi.com/Products/Low-power-cellular-IoT/nRF9160/Download#infotabs

--- a/include/supl_os_client.rst
+++ b/include/supl_os_client.rst
@@ -14,9 +14,9 @@ You must accept the license before you can download the library.
 Downloading and installing
 **************************
 
-You can download the SUPL client library from the `nRF9160 DK product page`_.
+You can download the SUPL client library from the `nRF9160 DK product page <SUPL client download_>`_.
 
-Download the nRF9160 SiP SUPL Client library zip file and extract it into the :file:`nrf/ext/lib/bin/supl/` folder.
+Download the nRF9160 SiP SUPL client library zip file and extract it into the :file:`nrf/ext/lib/bin/supl/` folder.
 Make sure to maintain the folder structure that is used in the zip file.
 
 Configuration


### PR DESCRIPTION
The SUPL client library is now available on the website.
Update the link to point directly to the library.

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>