### PR TITLE
lib: at_notif: Added protecting against multiple initialization

### DIFF
--- a/lib/at_notif/at_notif.c
+++ b/lib/at_notif/at_notif.c
@@ -122,6 +122,15 @@ static int module_init(struct device *dev)
 {
 	ARG_UNUSED(dev);
 
+	static bool initialized;
+
+	if (initialized) {
+		LOG_WRN("Already initialized. Nothing to do");
+		return 0;
+	}
+
+	initialized = true;
+
 	LOG_DBG("Initialization");
 	sys_slist_init(&handler_list);
 	at_cmd_set_notification_handler(notif_dispatch);


### PR DESCRIPTION
Otherwise it might end up dropping handlers that have already been
registered.

Signed-off-by: Erik Johnson <erik.johnson@nimbelink.com>