### PR TITLE
spm: secure_services: Change default for PREVALIDATE to 'n'

### DIFF
--- a/subsys/spm/Kconfig
+++ b/subsys/spm/Kconfig
@@ -88,8 +88,8 @@ config SPM_SERVICE_FIND_FIRMWARE_INFO
 	  about image stored at a given address.
 
 config SPM_SERVICE_PREVALIDATE
-	bool "Prevalidate B1 upgrades"
-	default y
+	bool "Prevalidate B1 upgrades (Requires Immutable Bootloader)"
+	default n
 	select SECURE_BOOT_CRYPTO
 	select SECURE_BOOT_VALIDATION
 	select BL_VALIDATE_FW_EXT_API_ATLEAST_OPTIONAL


### PR DESCRIPTION
SPM doesn't boot with this if B0 is not present.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>

This should fix failing builds on master.