### PR TITLE
doc: update mcuboot location

### DIFF
--- a/doc/nrf/doc_build.rst
+++ b/doc/nrf/doc_build.rst
@@ -35,7 +35,7 @@ The ``nrf`` subfolder in that directory contains all .rst source files that are 
 Documentation for samples and libraries are provided in a ``README.rst`` or ``*.rst`` file in the same directory as the code.
 
 Building the documentation output requires building output for all documentation sets.
-Currently, there are four sets: nrf, nrfxlib, zephyr, and mcuboot.
+Currently, there are four sets: nrf, nrfxlib, zephyr, and mcuboot (covering the contents of :file:`bootloader/mcuboot`).
 Since there are links from the ncs documentation set into other documentation sets, the other documentation sets must be built first.
 
 Building documentation output

--- a/doc/nrf/gs_ins_windows.rst
+++ b/doc/nrf/gs_ins_windows.rst
@@ -168,16 +168,19 @@ To clone the repositories, complete the following steps:
 
       west update
 
-Your directory structure now looks like this::
+Your directory structure now looks similar to this::
 
    ncs
     |___ .west
-    |___ mcuboot
+    |___ bootloader
+    |___ modules
     |___ nrf
     |___ nrfxlib
     |___ zephyr
     |___ ...
 
+Note that there are additional folders, and that the structure might change.
+The full set of repositories and folders is defined in the manifest file.
 
 Updating the repositories
 =========================
@@ -220,7 +223,7 @@ All branches, remotes, and other configuration in your repositories will be main
 To update your repositories to be managed by west, make sure that they are structured and named in the following way::
 
    ncs
-    |___ mcuboot
+    |___ bootloader/mcuboot
     |___ nrf
     |___ nrfxlib
     |___ zephyr
@@ -261,7 +264,7 @@ To install those, open a |bash| in the ``ncs`` folder and enter the following co
 
    pip3 |install_user| -r zephyr/scripts/requirements.txt
    pip3 |install_user| -r nrf/scripts/requirements.txt
-   pip3 |install_user| -r mcuboot/scripts/requirements.txt
+   pip3 |install_user| -r bootloader/mcuboot/scripts/requirements.txt
 
 .. add_deps_end
 

--- a/doc/nrf/mcuboot.rst
+++ b/doc/nrf/mcuboot.rst
@@ -7,6 +7,7 @@ MCUboot
 
 The |NCS| includes a fork of the MCUboot project.
 This fork is kept as close to the original repository as possible, but it might contain some additions that are specific to Nordic Semiconductor devices and applications.
+You can find the fork in :file:`bootloader/mcuboot` after obtaining the |NCS| source code.
 
 See the :doc:`documentation <mcuboot:index>` of Nordic Semiconductor's MCUboot fork for more information about MCUboot.
 

--- a/doc/nrf/ug_dev_model.rst
+++ b/doc/nrf/ug_dev_model.rst
@@ -263,7 +263,7 @@ If you want to create a `GitHub fork`_ follow the steps below:
 #. Create a `GitHub fork`_ using the **Fork** button in the GitHub user interface.
 #. Add the newly created remote repository as a Git remote::
 
-     cd ncs/{folder}
+     cd ncs/{folder_path}
      # Rename the default remote from 'origin' to 'ncs', if required
      git remote rename origin ncs
      git remote add origin https://github.com/{username}/{repo}.git
@@ -291,7 +291,7 @@ If you want to create a `GitHub fork`_ follow the steps below:
 To create a regular fork, follow the exact same steps as above, but the actual repository must be created by you beforehand, instead of clicking **Fork** in GitHub.
 Also, since a GitHub fork automatically initializes the forked repository with the exact same contents as the original one, you must push the contents yourself::
 
-  cd ncs/{folder}
+  cd ncs/{folder_path}
   # Rename the default remote from 'origin' to 'ncs'
   git remote rename origin ncs
   git remote add origin https://github.com/{username}/{repo}.git


### PR DESCRIPTION
MCUboot has moved from mcuboot to bootloader/mcuboot.
Reflect this change in the documentation.

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>