### PR TITLE
Bluetooth: Mesh: Sensor models

### DIFF
--- a/include/bluetooth/mesh.rst
+++ b/include/bluetooth/mesh.rst
@@ -15,4 +15,4 @@ development of Bluetooth Mesh-based applications:
    mesh/models.rst
    mesh/properties.rst
    mesh/dk_prov.rst
-
+   mesh/sensor.rst

--- a/include/bluetooth/mesh/models.h
+++ b/include/bluetooth/mesh/models.h
@@ -36,6 +36,9 @@
 #include <bluetooth/mesh/gen_prop_cli.h>
 #include <bluetooth/mesh/lightness_srv.h>
 #include <bluetooth/mesh/lightness_cli.h>
+#include <bluetooth/mesh/sensor_types.h>
+#include <bluetooth/mesh/sensor_srv.h>
+#include <bluetooth/mesh/sensor_cli.h>
 
 /** @brief Check whether the model publishes to a unicast address.
  *

--- a/include/bluetooth/mesh/models.rst
+++ b/include/bluetooth/mesh/models.rst
@@ -19,6 +19,7 @@ Nordic Semiconductor provides a variety of model implementations from the `Mesh 
 
    ../../../include/bluetooth/mesh/gen_*
    ../../../include/bluetooth/mesh/lightness.rst
+   ../../../include/bluetooth/mesh/sensor_models.rst
 
 For more information about these and other models, see also `Mesh Model Overview`_.
 

--- a/include/bluetooth/mesh/properties.h
+++ b/include/bluetooth/mesh/properties.h
@@ -248,6 +248,23 @@
 #define BT_MESH_PROP_ID_TOT_LUMINOUS_ENERGY 0x0070
 /** Desired ambient temperature. */
 #define BT_MESH_PROP_ID_DESIRED_AMB_TEMP 0x0071
+/** Precise Total Device Energy Use. */
+#define BT_MESH_PROP_ID_PRECISE_TOT_DEV_ENERGY_USE 0x0072
+/** Power Factor. */
+#define BT_MESH_PROP_ID_POWER_FACTOR 0x0073
+/** Sensor Gain. */
+#define BT_MESH_PROP_ID_SENSOR_GAIN 0x0074
+/** Precise Present Ambient Temperature. */
+#define BT_MESH_PROP_ID_PRECISE_PRESENT_AMB_TEMP 0x0075
+/** Present Ambient Relative Humidity. */
+#define BT_MESH_PROP_ID_PRESENT_AMB_REL_HUMIDITY 0x0076
+/** Present Ambient Carbon Dioxide Concentration. */
+#define BT_MESH_PROP_ID_PRESENT_AMB_CO2_CONCENTRATION 0x0077
+/** Present Ambient Volatile Organic Compounds Concentration. */
+#define BT_MESH_PROP_ID_PRESENT_AMB_VOC_CONCENTRATION 0x0078
+/** Present Ambient Noise. */
+#define BT_MESH_PROP_ID_PRESENT_AMB_NOISE 0x0079
+
 /** @} */
 
 #endif /* BT_MESH_PROPERTIES_H__ */

--- a/include/bluetooth/mesh/sensor.h
+++ b/include/bluetooth/mesh/sensor.h
@@ -1,0 +1,567 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/** @file
+ *  @defgroup bt_mesh_sensor Bluetooth Mesh Sensors
+ *  @{
+ *  @brief API for Bluetooth Mesh Sensors.
+ */
+
+#ifndef BT_MESH_SENSOR_H__
+#define BT_MESH_SENSOR_H__
+
+#include <bluetooth/mesh.h>
+#include <bluetooth/mesh/model_types.h>
+#include <drivers/sensor.h>
+#include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Largest period divisor value allowed. */
+#define BT_MESH_SENSOR_PERIOD_DIV_MAX 15
+/** Largest sensor interval allowed (in seconds). */
+#define BT_MESH_SENSOR_INTERVAL_MAX 26
+
+/** String length for representing a single sensor channel. */
+#define BT_MESH_SENSOR_CH_STR_LEN 19
+
+/** Sensor sampling type.
+ *
+ *  Represents the sampling function used to produce the presented sensor value.
+ */
+enum bt_mesh_sensor_sampling {
+	/** The sampling function is unspecified */
+	BT_MESH_SENSOR_SAMPLING_UNSPECIFIED,
+	/** The presented value is an instantaneous sample. */
+	BT_MESH_SENSOR_SAMPLING_INSTANTANEOUS,
+	/** The presented value is the arithmetic mean of multiple samples. */
+	BT_MESH_SENSOR_SAMPLING_ARITHMETIC_MEAN,
+	/** The presented value is the root mean square of multiple samples. */
+	BT_MESH_SENSOR_SAMPLING_RMS,
+	/** The presented value is the maximum of multiple samples. */
+	BT_MESH_SENSOR_SAMPLING_MAXIMUM,
+	/** The presented value is the minimum of multiple samples. */
+	BT_MESH_SENSOR_SAMPLING_MINIMUM,
+	/** The presented value is the accumulated moving average value of the
+	 *  samples. The updating frequency of the moving average should be
+	 *  indicated in @ref bt_mesh_descriptor::update_interval. The total
+	 *  measurement period should be indicated in @ref
+	 *  bt_mesh_descriptor::period.
+	 */
+	BT_MESH_SENSOR_SAMPLING_ACCUMULATED,
+	/** The presented value is a count of events in a specific measurement
+	 *  period. @ref bt_mesh_descriptor::period should denote the
+	 *  measurement period, or left to 0 to indicate that the sample is a
+	 *  lifetime value.
+	 */
+	BT_MESH_SENSOR_SAMPLING_COUNT,
+};
+
+/** Sensor descriptor representing various static metadata for the sensor. */
+struct bt_mesh_sensor_descriptor {
+	/** Sensor measurement tolerance specification. */
+	struct {
+		/** Maximum positive measurement error (in percent).
+		 *  A tolerance of 0 should be interpreted as "unspecified".
+		 */
+		struct sensor_value positive;
+		/** Maximum negative measurement error (in percent).
+		 *  A tolerance of 0 should be interpreted as "unspecified".
+		 */
+		struct sensor_value negative;
+	} tolerance;
+	/** Sampling type for the sensor data. */
+	enum bt_mesh_sensor_sampling sampling_type;
+	/** Measurement period for the samples, if applicable. */
+	u64_t period;
+	/** Update interval for the samples, if applicable. */
+	u64_t update_interval;
+};
+
+/** Delta threshold type. */
+enum bt_mesh_sensor_delta {
+	/** Value based delta threshold.
+	 *  The delta threshold values are represented as absolute value
+	 *  changes.
+	 */
+	BT_MESH_SENSOR_DELTA_VALUE,
+	/** Percent based delta threshold.
+	 *  The delta threshold values are represented as percentages of their
+	 *  old value (resolution: 0.01 %).
+	 */
+	BT_MESH_SENSOR_DELTA_PERCENT,
+	/** Delta threshold is disabled. */
+	BT_MESH_SENSOR_DELTA_DISABLED,
+};
+
+/** Sensor sampling cadence */
+enum bt_mesh_sensor_cadence {
+	/** Normal sensor publish interval. */
+	BT_MESH_SENSOR_CADENCE_NORMAL,
+	/** Fast sensor publish interval. */
+	BT_MESH_SENSOR_CADENCE_FAST,
+};
+
+/** Sensor thresholds for publishing. */
+struct bt_mesh_sensor_threshold {
+	/** Delta threshold values.
+	 *
+	 *  Denotes the minimal sensor value change that should cause the sensor
+	 *  to publish its value.
+	 */
+	struct {
+		/** Type of delta threshold */
+		enum bt_mesh_sensor_delta type;
+		/** Minimal delta for a positive change. */
+		struct sensor_value up;
+		/** Minimal delta for a negative change. */
+		struct sensor_value down;
+	} delta;
+	/** Range based threshold values.
+	 *
+	 *  Denotes the value range in which the sensor should be in fast
+	 *  cadence mode.
+	 */
+	struct {
+		/** Cadence when the sensor value is inside the range.
+		 *
+		 *  If the cadence is fast when the value is inside the range,
+		 *  it's normal when it's outside the range. If the cadence is
+		 *  normal when the value is inside the range, it's fast outside
+		 *  the range.
+		 */
+		enum bt_mesh_sensor_cadence cadence;
+		/** Lower boundary for the range based sensor cadence threshold.
+		 */
+		struct sensor_value low;
+		/** Upper boundary for the range based sensor cadence threshold.
+		 */
+		struct sensor_value high;
+	} range;
+};
+
+/** Unit for single sensor channel values. */
+struct bt_mesh_sensor_unit {
+	/** English name of the unit, e.g. "Decibel". */
+	const char *name;
+	/** Symbol of the unit, e.g. "dB". */
+	const char *symbol;
+};
+
+/** Sensor channel value format. */
+struct bt_mesh_sensor_format {
+	/** @brief Sensor channel value encode function.
+	 *
+	 *  @param[in]  format Pointer to the format structure.
+	 *  @param[in]  val    Sensor channel value to encode.
+	 *  @param[out] buf    Buffer to encode the value into.
+	 *
+	 *  @return 0 on success, or (negative) error code otherwise.
+	 */
+	int (*const encode)(const struct bt_mesh_sensor_format *format,
+			    const struct sensor_value *val,
+			    struct net_buf_simple *buf);
+
+	/** @brief Sensor channel value decode function.
+	 *
+	 *  @param[in]  format Pointer to the format structure.
+	 *  @param[in]  buf    Buffer to decode the value from.
+	 *  @param[out] val    Resulting sensor channel value.
+	 *
+	 *  @return 0 on success, or (negative) error code otherwise.
+	 */
+	int (*const decode)(const struct bt_mesh_sensor_format *format,
+			    struct net_buf_simple *buf,
+			    struct sensor_value *val);
+
+	/** User data pointer. */
+	void *user_data;
+	/** Size of the encoded data in bytes. */
+	size_t size;
+
+#ifdef CONFIG_BT_MESH_SENSOR_LABELS
+	/** Pointer to the unit associated with this format. */
+	const struct bt_mesh_sensor_unit *unit;
+#endif
+};
+
+/** Signle sensor channel */
+struct bt_mesh_sensor_channel {
+	/** Format for this sensor channel. */
+	const struct bt_mesh_sensor_format *format;
+#ifdef CONFIG_BT_MESH_SENSOR_LABELS
+	/** Name of this sensor channel. */
+	const char *name;
+#endif
+};
+
+/** Flag indicating this sensor type has a series representation. */
+#define BT_MESH_SENSOR_TYPE_FLAG_SERIES BIT(0)
+
+/** Sensor type. Should only be instantiated in sensor_types.c.
+ *  See sensor_types.h for a list of all defined sensor types.
+ */
+struct bt_mesh_sensor_type {
+	/** Device Property ID. */
+	u16_t id;
+	/** Flags, @see BT_MESH_SENSOR_TYPE_FLAG_SERIES */
+	u8_t flags;
+	/** The number of channels supported by this type. */
+	u8_t channel_count;
+	/** Array of channel descriptors.
+	 *
+	 *  All channels are mandatory and immutable.
+	 */
+	const struct bt_mesh_sensor_channel *channels;
+};
+
+struct bt_mesh_sensor;
+
+/** Single sensor setting. */
+struct bt_mesh_sensor_setting {
+	/** Sensor type of this setting. */
+	const struct bt_mesh_sensor_type *type;
+
+	/** @brief Getter for this sensor setting.
+	 *
+	 *  @note This handler is mandatory.
+	 *
+	 *  @param[in]  sensor  Sensor this setting belongs to.
+	 *  @param[in]  setting Pointer to this setting structure.
+	 *  @param[in]  ctx     Context parameters for the packet this call
+	 *                      originated from, or NULL if this call wasn't
+	 *                      triggered by a packet.
+	 *  @param[out] rsp     Response buffer for the setting value. Points to
+	 *                      an array with the number of channels specified
+	 *                      by the setting sensor type. All channels must be
+	 *                      filled.
+	 */
+	void (*get)(struct bt_mesh_sensor *sensor,
+		    const struct bt_mesh_sensor_setting *setting,
+		    struct bt_mesh_msg_ctx *ctx,
+		    struct sensor_value *rsp);
+
+	/** @brief Setter for this sensor setting.
+	 *
+	 *  Should only be specified for writable sensor settings.
+	 *
+	 *  @param[in] sensor  Sensor this setting belongs to.
+	 *  @param[in] setting Pointer to this setting structure.
+	 *  @param[in] ctx     Context parameters for the packet this call
+	 *                     originated from, or NULL if this call wasn't
+	 *                     triggered by a packet.
+	 *  @param[in] value   New setting value. Contains the number of
+	 *                     channels specified by the setting sensor type.
+	 *
+	 *  @return 0 on success, or (negative) error code otherwise.
+	 */
+	int (*set)(
+		struct bt_mesh_sensor *sensor,
+		const struct bt_mesh_sensor_setting *setting,
+		struct bt_mesh_msg_ctx *ctx,
+		const struct sensor_value *value);
+};
+
+/** Single sensor series data column.
+ *
+ *  The series data columns represent a range for specific measurement values,
+ *  inside which a set of sensor measurements were made. The range is
+ *  interpreted as a half-open interval (i.e. start <= value < end).
+ *
+ *  @note Contrary to the Bluetooth Mesh specification, the column has an end
+ *        value instead of a width, to match the conventional property format.
+ *        This reduces implementation complexity for sensor series values that
+ *        include the start and end (or min and max) of the measurement range,
+ *        as the value of the column can be copied directly into the
+ *        corresponding channels.
+ */
+struct bt_mesh_sensor_column {
+	/** Start of the column (inclusive). */
+	struct sensor_value start;
+	/** End of the column (exclusive). */
+	struct sensor_value end;
+};
+
+/** Sensor series specification. */
+struct bt_mesh_sensor_series {
+	/** Pointer to the list of columns.
+	 *
+	 *  The columns may overlap, but the start value of each column must be
+	 *  unique. The list of columns do not have to cover the entire valid
+	 *  range, and values that don't fit in any of the columns should be
+	 *  ignored. If columns overlap, samples must be present in all columns
+	 *  they fall into. The columns may come in any order.
+	 */
+	const struct bt_mesh_sensor_column *columns;
+
+	/** Number of columns. */
+	u32_t column_count;
+
+	/** @brief Getter for the series values.
+	 *
+	 *  Should return the historical data for the latest sensor readings in
+	 *  the given column.
+	 *
+	 *  @param[in]  sensor Sensor pointer.
+	 *  @param[in]  ctx    Message context pointer, or NULL if this call
+	 *                     didn't originate from a mesh message.
+	 *  @param[in]  column The requested sensor column. Points to a column
+	 *                     in the @c columns array.
+	 *  @param[out] value  Sensor value response buffer. Holds the number of
+	 *                     channels indicated by the sensor type. All
+	 *                     channels must be filled.
+	 *
+	 *  @return 0 on success, or (negative) error code otherwise.
+	 */
+	int (*get)(struct bt_mesh_sensor *sensor, struct bt_mesh_msg_ctx *ctx,
+		   const struct bt_mesh_sensor_column *column,
+		   struct sensor_value *value);
+};
+
+/** Sensor instance. */
+struct bt_mesh_sensor {
+	/** Sensor type.
+	 *
+	 *  Must be one of the specification defined types listed in @ref
+	 *  bt_mesh_sensor_types.
+	 */
+	const struct bt_mesh_sensor_type *type;
+	/** Optional sensor descriptor. */
+	const struct bt_mesh_sensor_descriptor *descriptor;
+	/** Sensor settings access specification. */
+	const struct {
+		/** Static array of sensor settings */
+		const struct bt_mesh_sensor_setting *list;
+		/** Number of sensor settings. */
+		size_t count;
+	} settings;
+
+	/** Sensor series specification.
+	 *
+	 *  Only sensors whose type have the @ref
+	 *  BT_MESH_SENSOR_TYPE_FLAG_SERIES flag set, a non-empty list of
+	 *  columns and a defined series getter will accept series messages.
+	 */
+	const struct bt_mesh_sensor_series series;
+
+	/** @brief Getter function for the sensor value.
+	 *
+	 *  @param[in]  sensor Sensor instance.
+	 *  @param[in]  ctx    Message context, or NULL if the call wasn't
+	 *                     triggered by a mesh message.
+	 *  @param[out] rsp    Value response buffer. Fits the number of
+	 *                     channels specified by the sensor type. All
+	 *                     channels must be filled.
+	 *
+	 *  @return 0 on success, or (negative) error code otherwise.
+	 */
+	int (*const get)(struct bt_mesh_sensor *sensor,
+			 struct bt_mesh_msg_ctx *ctx, struct sensor_value *rsp);
+
+	/* Internal state, overwritten on init. Should only be written to by
+	 * internal modules.
+	 */
+	struct {
+		/** Sensor threshold specification. */
+		struct bt_mesh_sensor_threshold threshold;
+
+		/** Linked list node. */
+		sys_snode_t node;
+
+		/** The previously published sensor value. */
+		struct sensor_value prev;
+
+		/** Sequence number of the previous publication. */
+		u16_t seq;
+
+		/** Minimum possible interval for fast cadence value publishing
+		 *  in seconds.
+		 *
+		 *  @see BT_MESH_SENSOR_INTERVAL_MAX
+		 */
+		u8_t min_int;
+
+		/** Fast period divisor used when publishing with fast cadence.
+		 */
+		u8_t pub_div : 4;
+
+		/** Flag indicating whether the sensor is in fast cadence mode.
+		 */
+		u8_t fast_pub : 1;
+	} state;
+};
+
+/** @brief Check if a value change breaks the delta threshold.
+ *
+ *  Sensors should publish their value if the measured sample is outside the
+ *  delta threshold compared to the previously published value. This function
+ *  checks the threshold and the previously published value for this sensor,
+ *  and returns whether the sensor should publish its value.
+ *
+ *  @note Only single-channel sensors support cadence. Multi-channel sensors are
+ *        always considered out of their threshold range, and will always return
+ *        true from this function. Single-channel sensors that haven't been
+ *        assigned a threshold will return true if the value is different.
+ *
+ *  @param[in] threshold Threshold parameters.
+ *  @param[in] curr      Sensor value.
+ *
+ *  @return true if the difference between the measurements exceeds the delta
+ *          threshold, false otherwise.
+ */
+bool bt_mesh_sensor_delta_threshold(const struct bt_mesh_sensor *sensor,
+				    const struct sensor_value *value);
+
+/** @brief Get the sensor type associated with the given Device Property ID.
+ *
+ *  Only known sensor types from @ref bt_mesh_sensor_types will be available.
+ *  Sensor types can be made known to the sensor module by enabling @ref
+ *  CONFIG_BT_MESH_SENSOR_ALL_TYPES or by referencing them in the application.
+ *
+ *  @param[in] id A Device Property ID.
+ *
+ *  @return The associated sensor type, or NULL if the ID is unknown.
+ */
+const struct bt_mesh_sensor_type *bt_mesh_sensor_type_get(u16_t id);
+
+/** @brief Check whether a single channel sensor value lies within a column.
+ *
+ *  @param[in] value Value to check. Only the first channel is considered.
+ *  @param[in] col   Sensor column.
+ *
+ *  @return true if the value belongs in the column, false otherwise.
+ */
+bool bt_mesh_sensor_value_in_column(const struct sensor_value *value,
+				    const struct bt_mesh_sensor_column *col);
+
+/** @brief Get the format of the sensor column data.
+ *
+ *  @param[in] type Sensor type.
+ *
+ *  @return The sensor type's sensor column format if series access is
+ *          supported. Otherwise NULL.
+ */
+const struct bt_mesh_sensor_format *
+bt_mesh_sensor_column_format_get(const struct bt_mesh_sensor_type *type);
+
+/** @brief Get a human readable representation of a single sensor channel.
+ *
+ *  @param[in]  ch  Sensor channel to represent.
+ *  @param[out] str String buffer to fill. Should be @ref
+ *                  BT_MESH_SENSOR_CH_STR_LEN bytes long.
+ *  @param[in]  len Length of @c str buffer.
+ *
+ *  @return Number of bytes that should have been written if @c str is
+ *          sufficiently large.
+ */
+static inline int bt_mesh_sensor_ch_to_str(const struct sensor_value *ch,
+					   char *str, size_t len)
+{
+	return snprintk(str, sizeof(str), "%s%u.%06u",
+			((ch->val1 < 0 || ch->val2 < 0) ? "-" : ""),
+			abs(ch->val1), abs(ch->val2));
+}
+
+/** @brief Get a human readable representation of a single sensor channel.
+ *
+ *  @note This function is not thread safe.
+ *
+ *  @param[in] ch Sensor channel to represent.
+ *
+ *  @return A string representing the sensor channel.
+ */
+const char *bt_mesh_sensor_ch_str_real(const struct sensor_value *ch);
+
+/** String duplication variant of @ref bt_mesh_sensor_ch_str_real for use in
+ *  logging.
+ *
+ *  @param[in] ch Sensor channel to represent.
+ */
+#define bt_mesh_sensor_ch_str(ch) log_strdup(bt_mesh_sensor_ch_str_real(ch))
+
+/** @cond INTERNAL_HIDDEN */
+
+#define BT_MESH_SENSOR_OP_DESCRIPTOR_GET BT_MESH_MODEL_OP_2(0x82, 0x30)
+#define BT_MESH_SENSOR_OP_DESCRIPTOR_STATUS BT_MESH_MODEL_OP_1(0x51)
+#define BT_MESH_SENSOR_OP_GET BT_MESH_MODEL_OP_2(0x82, 0x31)
+#define BT_MESH_SENSOR_OP_STATUS BT_MESH_MODEL_OP_1(0x52)
+#define BT_MESH_SENSOR_OP_COLUMN_GET BT_MESH_MODEL_OP_2(0x82, 0x32)
+#define BT_MESH_SENSOR_OP_COLUMN_STATUS BT_MESH_MODEL_OP_1(0x53)
+#define BT_MESH_SENSOR_OP_SERIES_GET BT_MESH_MODEL_OP_2(0x82, 0x33)
+#define BT_MESH_SENSOR_OP_SERIES_STATUS BT_MESH_MODEL_OP_1(0x54)
+#define BT_MESH_SENSOR_OP_CADENCE_GET BT_MESH_MODEL_OP_2(0x82, 0x34)
+#define BT_MESH_SENSOR_OP_CADENCE_SET BT_MESH_MODEL_OP_1(0x55)
+#define BT_MESH_SENSOR_OP_CADENCE_SET_UNACKNOWLEDGED BT_MESH_MODEL_OP_1(0x56)
+#define BT_MESH_SENSOR_OP_CADENCE_STATUS BT_MESH_MODEL_OP_1(0x57)
+#define BT_MESH_SENSOR_OP_SETTINGS_GET BT_MESH_MODEL_OP_2(0x82, 0x35)
+#define BT_MESH_SENSOR_OP_SETTINGS_STATUS BT_MESH_MODEL_OP_1(0x58)
+#define BT_MESH_SENSOR_OP_SETTING_GET BT_MESH_MODEL_OP_2(0x82, 0x36)
+#define BT_MESH_SENSOR_OP_SETTING_SET BT_MESH_MODEL_OP_1(0x59)
+#define BT_MESH_SENSOR_OP_SETTING_SET_UNACKNOWLEDGED BT_MESH_MODEL_OP_1(0x5A)
+#define BT_MESH_SENSOR_OP_SETTING_STATUS BT_MESH_MODEL_OP_1(0x5B)
+
+#define BT_MESH_SENSOR_ENCODED_VALUE_MAXLEN                                    \
+	(CONFIG_BT_MESH_SENSOR_CHANNELS_MAX *                                  \
+	 CONFIG_BT_MESH_SENSOR_CHANNEL_ENCODED_SIZE_MAX)
+
+#define BT_MESH_SENSOR_STATUS_MAXLEN (3 + BT_MESH_SENSOR_ENCODED_VALUE_MAXLEN)
+
+#define BT_MESH_SENSOR_MSG_MINLEN_DESCRIPTOR_GET 0
+#define BT_MESH_SENSOR_MSG_MAXLEN_DESCRIPTOR_GET 2
+#define BT_MESH_SENSOR_MSG_MINLEN_DESCRIPTOR_STATUS 2
+#define BT_MESH_SENSOR_MSG_MAXLEN_DESCRIPTOR_STATUS 8
+#define BT_MESH_SENSOR_MSG_MINLEN_GET 0
+#define BT_MESH_SENSOR_MSG_MAXLEN_GET 2
+#define BT_MESH_SENSOR_MSG_MINLEN_STATUS 0
+#define BT_MESH_SENSOR_MSG_MINLEN_COLUMN_GET 2
+#define BT_MESH_SENSOR_MSG_MAXLEN_COLUMN_GET                                   \
+	(2 + CONFIG_BT_MESH_SENSOR_CHANNEL_ENCODED_SIZE_MAX)
+#define BT_MESH_SENSOR_MSG_MINLEN_COLUMN_STATUS 2
+#define BT_MESH_SENSOR_MSG_MAXLEN_COLUMN_STATUS                                \
+	(2 + CONFIG_BT_MESH_SENSOR_CHANNEL_ENCODED_SIZE_MAX * 3)
+#define BT_MESH_SENSOR_MSG_MINLEN_SERIES_GET 2
+#define BT_MESH_SENSOR_MSG_MAXLEN_SERIES_GET                                   \
+	(2 + 2 * CONFIG_BT_MESH_SENSOR_CHANNEL_ENCODED_SIZE_MAX)
+#define BT_MESH_SENSOR_MSG_MINLEN_SERIES_STATUS 2
+#define BT_MESH_SENSOR_MSG_LEN_CADENCE_GET 2
+#define BT_MESH_SENSOR_MSG_MINLEN_CADENCE_SET 8
+#define BT_MESH_SENSOR_MSG_MAXLEN_CADENCE_SET                                  \
+	(4 + CONFIG_BT_MESH_SENSOR_CHANNEL_ENCODED_SIZE_MAX * 4)
+#define BT_MESH_SENSOR_MSG_MINLEN_CADENCE_STATUS 8
+#define BT_MESH_SENSOR_MSG_MAXLEN_CADENCE_STATUS                               \
+	(4 + 4 * CONFIG_BT_MESH_SENSOR_CHANNEL_ENCODED_SIZE_MAX)
+#define BT_MESH_SENSOR_MSG_LEN_SETTINGS_GET 2
+#define BT_MESH_SENSOR_MSG_MINLEN_SETTINGS_STATUS 2
+#define BT_MESH_SENSOR_MSG_LEN_SETTING_GET 4
+#define BT_MESH_SENSOR_MSG_MINLEN_SETTING_SET 4
+#define BT_MESH_SENSOR_MSG_MAXLEN_SETTING_SET                                  \
+	(4 + BT_MESH_SENSOR_ENCODED_VALUE_MAXLEN)
+#define BT_MESH_SENSOR_MSG_MINLEN_SETTING_STATUS 4
+#define BT_MESH_SENSOR_MSG_MAXLEN_SETTING_STATUS                               \
+	(4 + BT_MESH_SENSOR_ENCODED_VALUE_MAXLEN)
+
+#define BT_MESH_SENSOR_SRV_PUB_MAXLEN(_count)                                  \
+	BT_MESH_MODEL_BUF_LEN(BT_MESH_SENSOR_OP_STATUS,                        \
+			      MAX(CONFIG_BT_MESH_SENSOR_SRV_SENSORS_MAX,       \
+				  _count) *                                    \
+				      BT_MESH_SENSOR_STATUS_MAXLEN)
+
+#define BT_MESH_SENSOR_SETUP_SRV_PUB_MAXLEN                                    \
+	MAX(BT_MESH_MODEL_BUF_LEN(BT_MESH_SENSOR_OP_SETTING_STATUS,            \
+				  BT_MESH_SENSOR_MSG_MAXLEN_SETTING_STATUS),   \
+	    BT_MESH_MODEL_BUF_LEN(BT_MESH_SENSOR_OP_CADENCE_STATUS,            \
+				  BT_MESH_SENSOR_MSG_MAXLEN_CADENCE_STATUS))
+/** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+
+#endif /* BT_MESH_SENSOR_H__ */

--- a/include/bluetooth/mesh/sensor.rst
+++ b/include/bluetooth/mesh/sensor.rst
@@ -1,0 +1,340 @@
+.. _bt_mesh_sensors_readme:
+
+Bluetooth Mesh Sensors
+######################
+
+The Bluetooth Mesh specification provides a common scheme for representing all sensors.
+A single Bluetooth Mesh Sensor instance represents a single physical sensor, and a mesh device may present any number of sensors to the network through a Sensor Server model.
+Sensors represent their measurements as a list of sensor channels, as described by the sensor's assigned type.
+
+Topics on Bluetooth Mesh Sensors covered in this document:
+
+* :ref:`bt_mesh_sensor_basic_example`
+* :ref:`bt_mesh_sensor_types`
+
+  - :ref:`bt_mesh_sensor_types_channels`
+  - :ref:`bt_mesh_sensor_types_series`
+  - :ref:`bt_mesh_sensor_types_settings`
+  - :ref:`bt_mesh_sensor_types_list`
+
+* :ref:`bt_mesh_sensor_publishing`
+
+  - :ref:`bt_mesh_sensor_publishing_cadence`
+  - :ref:`bt_mesh_sensor_publishing_delta`
+
+* :ref:`bt_mesh_sensor_descriptors`
+* :ref:`bt_mesh_sensor_usage`
+* :ref:`bt_mesh_sensor_api`
+
+Sensors are accessed through the Sensor models, which are documented separately:
+
+* :ref:`bt_mesh_sensor_models`
+
+  - :ref:`bt_mesh_sensor_srv_readme`
+  - :ref:`bt_mesh_sensor_cli_readme`
+
+.. _bt_mesh_sensor_basic_example:
+
+Basic example
+=============
+
+A sensor reporting the device operating temperature could combine the Bluetooth Mesh :cpp:var:`Present Device Operating Temperature <bt_mesh_sensor_present_dev_op_temp>` sensor type with the on-chip ``TEMP_NRF5`` temperature sensor driver:
+
+.. code-block:: c
+
+   static struct device *dev;
+
+   static int temp_get(struct bt_mesh_sensor *sensor,
+                       struct bt_mesh_msg_ctx *ctx,
+                       struct sensor_value *rsp)
+   {
+       sensor_sample_fetch(dev);
+       return sensor_channel_get(dev, SENSOR_CHAN_DIE_TEMP, rsp);
+   }
+
+   struct bt_mesh_sensor temp_sensor = {
+       .type = &bt_mesh_sensor_present_dev_op_temp,
+       .get = temp_get,
+   };
+
+   void init(void)
+   {
+       dev = device_get_binding(DT_INST_0_NORDIC_NRF_TEMP_LABEL);
+   }
+
+Additionally, a pointer to the ``temp_sensor`` structure should be passed to a Sensor Server to be exposed to the mesh.
+See :ref:`bt_mesh_sensor_srv_readme` for details.
+
+.. _bt_mesh_sensor_types:
+
+Sensor types
+============
+
+Sensor types are the specification defined data types for the various Bluetooth Mesh sensor parameters.
+Each sensor type is assigned its own Device Property ID, as specified in the Bluetooth Mesh Device Properties Specification.
+Like the Device Properties, the Sensor types are connected to a Bluetooth GATT Characteristic, which describes the unit, range, resolution and encoding scheme of the sensor type.
+
+.. note::
+   The Bluetooth Mesh specification only allows sensor types that have a Device Property ID in the Bluetooth Mesh Device Properties Specification. It's not possible to represent vendor specific sensor values.
+
+The sensor types may either be used as the data types of the sensor output values, or as configuration parameters for the sensors.
+
+The Bluetooth Mesh Sensor type API is built to mirror and integrate well with the Zephyr :ref:`zephyr:sensor` API.
+Some concepts in the Bluetooth Mesh Specification are changed slightly to fit better with the Zephyr Sensor API, with focus on making integration as simple as possible.
+
+.. _bt_mesh_sensor_types_channels:
+
+Sensor Channels
+***************
+
+Each sensor type may consist of one or more channels.
+The list of sensor channels in each sensor type is immutable, and all channels must always have a valid value when the sensor data is passed around.
+This is slightly different from the sensor type representation in the Bluetooth Mesh Specification, which represents multi-channel sensors as structures, rather than flat lists.
+
+Each channel in a sensor type is represented by a single :c:type:`sensor_value`.
+For sensor values that are represented as whole numbers, the fractional part of the value (:cpp:member:`sensor_value::val2`) is ignored.
+Boolean types are inferred only from the integer part of the value (:cpp:member:`sensor_value::val1`).
+
+Every sensor channel has a name and a unit, as listed in the sensor type documentation.
+The name and unit are only available if :option:`CONFIG_BT_MESH_SENSOR_LABELS` option is set, and can aid in debugging and presentation of the sensor output.
+Both the channel name and unit is also listed in the documentation for each sensor type.
+
+Most sensor values are reported as scalars with some scaling factor applied to
+them during encoding. This scaling factor and the encoded data type determines
+the resolution and range of the sensor data in a specific channel. For instance,
+if a sensor channel measuring electric current has a resolution of 0.5 Ampere,
+this is the highest resolution value other mesh devices will be able to read out
+from the sensor. Before encoding, the sensor values are rounded to their nearest
+available representation, so the following sensor value would be read as 7.5
+Ampere:
+
+.. code-block:: c
+
+   /* Sensor value: 7.3123 A */
+   struct sensor_value electrical_current = {
+       .val1 = 7,
+       .val2 = 312300, /* 6 digit fraction */
+   };
+
+Various other encoding schemes are used to represent non-scalars.
+See the documentation or specification for the individual sensor channels for more details.
+
+.. _bt_mesh_sensor_types_series:
+
+Sensor series types
+*******************
+
+Some sensor types are made specially for being used in a sensor series.
+These sensor types have one primary channel containing the sensor data and two secondary channels that denote some interval in which the primary channel's data is captured.
+Together, the three channels are able to represent historical sensor data as a histogram, and Sensor Client models may request access to specific measurement spans from a Sensor Server model.
+
+The unit of the measurement span is defined by the sensor type, and will typically be a time interval or a range of operational parameters, like temperature or voltage level.
+For instance, the :cpp:var:`bt_mesh_sensor_rel_dev_energy_use_in_a_period_of_day` sensor type represents the energy used by the device in specific periods of the day.
+The primary channel of this sensor type measures energy usage in kWh, and the secondary channels denote the timespan in which the specific energy usage was measured.
+A sensor of this type may be queried for specific measurement periods measured in hours, and should provide the registered energy usage only for the requested time span.
+
+.. _bt_mesh_sensor_types_settings:
+
+Sensor setting types
+********************
+
+Some sensor types are made specifically to act as sensor settings.
+These values are encoded the same way as other sensor types, but typically represent a configurable sensor setting or some specification value assigned to the sensor from the manufacturer.
+For instance, the :cpp:var:`bt_mesh_sensor_motion_threshold` sensor type can be used to configure the sensitivity of a sensor reporting motion sensor data (:cpp:var:`bt_mesh_sensor_motion_sensed`).
+
+Typically, settings should only be meta data related to the sensor data type, but the API contains no restrictions for which sensor types can be used for sensor settings.
+
+.. _bt_mesh_sensor_types_list:
+
+Available sensor types
+**********************
+
+All available sensor types are collected in a single module:
+
+.. toctree::
+   :maxdepth: 1
+
+   sensor_types.rst
+
+.. _bt_mesh_sensor_publishing:
+
+Sample data reporting
+=====================
+
+Sensors may report their values to the mesh in three ways:
+
+- Unprompted publications
+- Periodic publication
+- Polling
+
+Unprompted publications may be done at any time, and only includes the sensor data of a single sensor at a time.
+The application may generate an unprompted publication by calling :cpp:func:`bt_mesh_sensor_srv_sample`.
+This triggers the sensor's :cpp:member:`bt_mesh_sensor::get` callback, and only publishes if the sensor's *Delta threshold* is satisfied.
+
+Unprompted publications can also be forced by calling :cpp:func:`bt_mesh_sensor_srv_pub` directly.
+
+Periodic publication is controlled by the Sensor Server model's publication parameters, and configured by the Config models.
+The sensor Server model reports data for all its sensor instances periodically, at a rate determined by the sensors' cadence.
+Every publication interval, the Server consolidates a list of sensors to include in the publication, and requests the most recent data from each.
+The combined data of all these sensors is published as a single message for other nodes in the mesh network.
+
+If no publication parameters are configured for the Sensor Server model, Sensor Client models may poll the most recent sensor samples directly.
+
+All three methods of reporting may be combined.
+
+.. _bt_mesh_sensor_publishing_cadence:
+
+Cadence
+*******
+
+Each sensor may use the cadence state to control the rate at which their data is published.
+The sensor's publication interval is defined as a divisor of the holding sensor Server's publication interval, that is always a power of two.
+Under normal circumstances, the sensor's period divisor is always 1, and the sensor only publishes on the Server's actual publication interval.
+
+All single-channel sensors have a configurable *fast cadence* range that automatically controls the sensor cadence.
+If the sensor's value is within its configured fast cadence range, the sensor engages the period divisor, and starts publishing with fast cadence.
+
+The fast cadence range always starts at the cadence range ``low`` value, and spans to the cadence range ``high`` value.
+If the ``high`` value is lower than the ``low`` value, the effect is inverted, and the sensor operates at high cadence if its value is *outside* the range.
+
+To prevent sensors from saturating the mesh network, each sensor also defines a minimum publication interval, which is always taken into account when performing the period division.
+
+The period divisor, fast cadence range and minimum interval is configured by a Sensor Client model (through a Sensor Setup Server).
+The sensor's cadence is automatically recalculated for every sample, based on its configuration.
+
+.. _bt_mesh_sensor_publishing_delta:
+
+Delta threshold
+***************
+
+All single channel sensors have a delta threshold state to aid the publication rate.
+The delta threshold state determines the smallest change in sensor value that should trigger a publication.
+Whenever a sensor value is published to the mesh network (through periodic publishing or otherwise), the sensor saves the value, and compares it to subsequent samples.
+Once a sample is sufficiently far away from the previously published value, it gets published.
+
+The delta threshold works on both periodic publication and unprompted publications.
+If periodic publication is enabled and the minimum interval has expired, the
+sensor will periodically check whether the delta threshold has been breached, so that it can publish the value on the next periodic interval.
+
+The delta threshold may either be specified as a percent wise change, or as an absolute delta.
+The percent wise change is always measured relatively to the previously published value, and allows the sensor to automatically scale its threshold to account for relative inaccuracy or noise.
+
+The sensor has separate delta thresholds for positive and negative changes.
+
+.. _bt_mesh_sensor_descriptors:
+
+Descriptors
+============
+
+Descriptors are optional meta information structures for every sensor.
+A sensor's Descriptor contains parameters that may aid other mesh nodes in interpreting the data:
+
+* Tolerance
+* Sampling function
+* Measurement period
+* Update interval
+
+The sensor descriptor is constant throughout the sensor's lifetime. If the sensor has a descriptor, a pointer to it should be passed to :cpp:member:`bt_mesh_sensor::descriptor` on init.
+
+See :cpp:type:`bt_mesh_sensor_descriptor` for details.
+
+.. _bt_mesh_sensor_usage:
+
+Usage
+=====
+
+Sensors instances are generally static structures that are initialized at startup.
+Only the :cpp:member:`bt_mesh_sensor::type` member is mandatory, the rest are optional.
+Apart from the Cadence and Descriptor states, all states are accessed through getter functions.
+The absence of a getter for a state marks it as not supported by the sensor.
+
+Sensor data
+***********
+
+Sensor data is accessed through the :cpp:member:`bt_mesh_sensor::get` callback, which is expected to fill the ``rsp`` parameter with the most recent sensor data and return a status code.
+Each sensor channel will be encoded internally according to the sensor type.
+
+The sensor data in the callback typically comes from a sensor using the :ref:`Zephyr sensor API <zephyr:sensor>`.
+The Zephyr sensor API records samples in two steps:
+
+1. Tell the sensor to take a sample by calling :cpp:func:`sensor_sample_fetch`.
+2. Read the recorded sample data with :cpp:func:`sensor_channel_get`.
+
+The first step may be done at any time.
+Typically, the sensor fetching is triggered by a timer, an external event or a sensor trigger, but it may be called in the ``get`` callback itself.
+Note that the ``get`` callback requires an immediate response, so if the sample fetching takes a significant amount of time, it should generally be done asynchronously.
+The method of sampling may be communicated to other mesh nodes through the sensor's :ref:`descriptor <bt_mesh_sensor_descriptors>`.
+
+The read step would typically be done in the callback, to pass the sensor data to the mesh.
+
+If the Sensor Server is configured to do periodic publishing, the ``get`` callback will be called for every publication interval. Publication may also be forced by calling :cpp:func:`bt_mesh_sensor_srv_sample`, which will trigger the ``get`` callback and publish only if the sensor value has changed.
+
+Sensor series
+*************
+
+Sensor series data is organized into a static set of columns, specified at init.
+The sensor series :cpp:member:`bt_mesh_sensor_series::get` callback must be implemented to enable the sensor's series data feature.
+Only some sensor types support series access, see the sensor type's documentation.
+The format of the column may be queried with :cpp:func:`bt_mesh_sensor_column_format_get`.
+
+The ``get`` callback gets called with a direct pointer to one of the columns in the column list, and is expected to fill the ``value`` parameter with sensor data for the specified column. If a Sensor Client requests a series of columns, the callback may be called repeatedly, requesting data from each column.
+
+Example: Average ambient temperature in a period of day as a sensor series:
+
+.. code-block:: c
+
+   /* 4 columns representing different hours in a day */
+   static const struct bt_mesh_sensor_column columns[] = {
+       {{0}, {6}},
+       {{6}, {12}},
+       {{12}, {18}},
+       {{18}, {24}},
+   };
+
+   static struct bt_mesh_sensor temp_sensor = {
+       .type = &bt_mesh_sensor_avg_amb_temp_in_day,
+       .series = {
+           columns,
+           ARRAY_SIZE(columns),
+           getter,
+       },
+   };
+
+   /** Sensor data is divided into columns and filled elsewhere */
+   static struct sensor_value avg_temp[ARRAY_SIZE(columns)];
+
+   static int getter(struct bt_mesh_sensor *sensor, struct bt_mesh_msg_ctx *ctx,
+		                 const struct bt_mesh_sensor_column *column,
+		                 struct sensor_value *value)
+   {
+       /* The column pointer is always a direct pointer to one of our columns,
+        *  so determining the column index is easy:
+        */
+       u32_t index = column - &columns[0];
+
+       value[0] = avg_temp[index];
+       value[1] = column->start;
+       value[2] = column->end;
+
+       return 0;
+   }
+
+Sensor settings
+***************
+
+The list of settings a sensor supports should be set on init. The list should be constant throughout the sensor's lifetime, and may be declared ``const``.
+Each entry in the list has a type and two access callbacks, and the list should only contain unique entry types.
+
+The :cpp:member:`bt_mesh_sensor_setting::get` callback is mandatory, while the :cpp:member:`bt_mesh_sensor_setting::set` is optional, allowing for read-only entries. The value of the settings may change at runtime, even outside the ``set`` callback. New values may be rejected by returning a negative error code from the ``set`` callback.
+
+.. _bt_mesh_sensor_api:
+
+API documentation
+=================
+
+| Header file: :file:`include/bluetooth/mesh/sensor.h`
+| Source file: :file:`subsys/bluetooth/mesh/sensor.c`
+
+.. doxygengroup:: bt_mesh_sensor
+   :project: nrf
+   :members:

--- a/include/bluetooth/mesh/sensor_cli.h
+++ b/include/bluetooth/mesh/sensor_cli.h
@@ -1,0 +1,627 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/** @file
+ *  @defgroup bt_mesh_sensor_cli Sensor Client model
+ *  @{
+ *  @brief API for the Sensor Client.
+ */
+
+#ifndef BT_MESH_SENSOR_CLI_H__
+#define BT_MESH_SENSOR_CLI_H__
+
+#include <bluetooth/mesh/sensor.h>
+#include <bluetooth/mesh/model_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct bt_mesh_sensor_cli_handlers;
+
+/** @def BT_MESH_SENSOR_CLI_INIT
+ *
+ *  @brief Initialization parameters for @ref bt_mesh_sensor_cli.
+ *
+ *  @sa bt_mesh_sensor_cli_handlers
+ *
+ *  @param[in] _handlers Optional message handler structure.
+ */
+#define BT_MESH_SENSOR_CLI_INIT(_handlers)                                     \
+	{                                                                      \
+		.cb = _handlers,                                               \
+		.pub = {                                                       \
+			.msg = NET_BUF_SIMPLE(BT_MESH_MODEL_BUF_LEN(           \
+				BT_MESH_SENSOR_OP_CADENCE_SET,                 \
+				MAX(BT_MESH_SENSOR_MSG_MAXLEN_CADENCE_SET,     \
+				    BT_MESH_SENSOR_MSG_MAXLEN_SETTING_SET)))   \
+		},                                                             \
+	}
+
+/** @def BT_MESH_MODEL_SENSOR_CLI
+ *
+ *  @brief Sensor Client model composition data entry.
+ *
+ *  @param[in] _cli Pointer to a @ref bt_mesh_sensor_cli instance.
+ */
+#define BT_MESH_MODEL_SENSOR_CLI(_cli)                                         \
+	BT_MESH_MODEL_CB(BT_MESH_MODEL_ID_SENSOR_CLI, _bt_mesh_sensor_cli_op,  \
+			 &(_cli)->pub,                                         \
+			 BT_MESH_MODEL_USER_DATA(struct bt_mesh_sensor_cli,    \
+						 _cli),                        \
+			 &_bt_mesh_sensor_cli_cb)
+
+/** Sensor client instance.
+ *
+ *  Should be initialized with @ref BT_MESH_SENSOR_CLI_INIT.
+ */
+struct bt_mesh_sensor_cli {
+	/** Composition data model instance. */
+	struct bt_mesh_model *mod;
+	/** Model publication parameters. */
+	struct bt_mesh_model_pub pub;
+	/** Response context for acknowledged messages. */
+	struct bt_mesh_model_ack_ctx ack;
+	/** Client callback functions. */
+	const struct bt_mesh_sensor_cli_handlers *cb;
+};
+
+/** Sensor cadence status parameters */
+struct bt_mesh_sensor_cadence_status {
+	/** Logarithmic fast publish period divisor value.
+	 *
+	 *  The sensor's fast period interval is
+	 *  publish_period / (1 << fast_period_div).
+	 */
+	u8_t fast_period_div;
+	/** Logarithmic minimum publish period.
+	 *
+	 *  The sensor's fast period interval is never lower than
+	 *  (1 << min_int).
+	 */
+	u8_t min_int;
+	/** Sensor threshold values. */
+	struct bt_mesh_sensor_threshold threshold;
+};
+
+/** Sensor settings parameters. */
+struct bt_mesh_sensor_setting_status {
+	/** Setting type */
+	const struct bt_mesh_sensor_type *type;
+	/** Setting value. */
+	struct sensor_value value[CONFIG_BT_MESH_SENSOR_CHANNELS_MAX];
+	/** Whether the setting can be written to. */
+	bool writable;
+};
+
+/** Sensor series entry **/
+struct bt_mesh_sensor_series_entry {
+	/** Sensor column descriptor. */
+	struct bt_mesh_sensor_column column;
+	/** Sensor column value. */
+	struct sensor_value value[CONFIG_BT_MESH_SENSOR_CHANNELS_MAX];
+};
+
+/** Sensor info structure. */
+struct bt_mesh_sensor_info {
+	/** Sensor Device Property ID */
+	u16_t id;
+	/** Sensor descriptor. */
+	struct bt_mesh_sensor_descriptor descriptor;
+};
+
+/** Sensor client handler functions. */
+struct bt_mesh_sensor_cli_handlers {
+	/** @brief Sensor data callback.
+	 *
+	 *  Called when the client receives sensor sample data, either as a
+	 *  result of calling @ref bt_mesh_sensor_cli_get, or as an unsolicited
+	 *  message.
+	 *
+	 *  @param[in] cli    Sensor client receiving the message.
+	 *  @param[in] ctx    Message context.
+	 *  @param[in] sensor Sensor instance.
+	 *  @param[in] value  The interpreted sensor data value as an array of
+	 *                    channels. The length of the array matches the
+	 *                    sensor channel count.
+	 */
+	void (*data)(struct bt_mesh_sensor_cli *cli,
+		     struct bt_mesh_msg_ctx *ctx,
+		     const struct bt_mesh_sensor_type *sensor,
+		     const struct sensor_value *value);
+
+	/** @brief Sensor description callback.
+	 *
+	 *  Called when the client receives sensor descriptors, either as a
+	 *  result of calling @ref bt_mesh_sensor_cli_list_get or @ref
+	 *  bt_mesh_sensor_cli_desc_get, or as an unsolicited message.
+	 *
+	 *  The sensor description does not reference the sensor type directly,
+	 *  to allow discovery of sensor types unknown to the client. To get the
+	 *  sensor type of a known sensor, call @ref bt_mesh_sensor_type_get.
+	 *
+	 *  @param[in] cli    Sensor client receiving the message.
+	 *  @param[in] ctx    Message context.
+	 *  @param[in] sensor Sensor information for a single sensor.
+	 */
+	void (*sensor)(struct bt_mesh_sensor_cli *cli,
+		       struct bt_mesh_msg_ctx *ctx,
+		       const struct bt_mesh_sensor_info *sensor);
+
+	/** @brief Sensor cadence callback.
+	 *
+	 *  Called when the client receives the cadence of a sensor, either as a
+	 *  result of calling one of @ref bt_mesh_sensor_cli_cadence_get,
+	 *  @ref bt_mesh_sensor_cli_cadence_set or
+	 *  @ref bt_mesh_sensor_cli_cadence_set_unack, or as an unsolicited
+	 *  message.
+	 *
+	 *  @param[in] cli     Sensor client receiving the message.
+	 *  @param[in] ctx     Message context.
+	 *  @param[in] sensor  Sensor instance.
+	 *  @param[in] cadence Sensor cadence information.
+	 */
+	void (*cadence)(struct bt_mesh_sensor_cli *cli,
+			struct bt_mesh_msg_ctx *ctx,
+			const struct bt_mesh_sensor_type *sensor,
+			const struct bt_mesh_sensor_cadence_status *cadence);
+
+	/** @brief Sensor settings list callback.
+	 *
+	 *  Called when the client receives the full list of sensor settings, as
+	 *  a result of calling @ref bt_mesh_sensor_cli_settings_get or as an
+	 *  unsolicited message.
+	 *
+	 *  @param[in] cli    Sensor client receiving the message.
+	 *  @param[in] ctx    Message context.
+	 *  @param[in] sensor Sensor instance.
+	 *  @param[in] ids    Available sensor setting IDs.
+	 *  @param[in] count  The number of sensor setting IDs.
+	 */
+	void (*settings)(struct bt_mesh_sensor_cli *cli,
+			 struct bt_mesh_msg_ctx *ctx,
+			 const struct bt_mesh_sensor_type *sensor,
+			 const u16_t *ids, u32_t count);
+
+	/** @brief Sensor setting status callback.
+	 *
+	 *  Called when the client receives a sensor setting status, either as
+	 *  result of calling @ref bt_mesh_sensor_cli_setting_get, @ref
+	 *  bt_mesh_sensor_cli_setting_set, @ref
+	 *  bt_mesh_sensor_cli_setting_set_unack, or as an unsolicited message.
+	 *
+	 *  @param[in] cli     Sensor client receiving the message.
+	 *  @param[in] ctx     Message context.
+	 *  @param[in] sensor  Sensor instance.
+	 *  @param[in] setting Sensor setting information.
+	 */
+	void (*setting_status)(
+		struct bt_mesh_sensor_cli *cli, struct bt_mesh_msg_ctx *ctx,
+		const struct bt_mesh_sensor_type *sensor,
+		const struct bt_mesh_sensor_setting_status *setting);
+
+	/** @brief Series entry callback.
+	 *
+	 *  Called when the client receives series entries, either as result of
+	 *  calling one of @ref bt_mesh_sensor_cli_series_entry_get or @ref
+	 *  bt_mesh_sensor_cli_series_entries_get, or as a result of an
+	 *  unsolicited message.
+	 *
+	 *  If the received series entry message contains several entries, this
+	 *  callback is called once per entry, with the @c index and @c count
+	 *  parameters indicating the progress.
+	 *
+	 *  @note The @c index and @c count parameters does not necessarily
+	 *        match the total number of series entries of the sensor, as the
+	 *        callback may be the result of a filtered query.
+	 *
+	 *  @param[in] cli    Sensor client receiving the message.
+	 *  @param[in] ctx    Message context.
+	 *  @param[in] sensor Sensor instance.
+	 *  @param[in] index  Index of this entry in the list of entries
+	 *                    received.
+	 *  @param[in] count  Total number of entries received.
+	 *  @param[in] entry  Single sensor series entry.
+	 */
+	void (*series_entry)(struct bt_mesh_sensor_cli *cli,
+			     struct bt_mesh_msg_ctx *ctx,
+			     const struct bt_mesh_sensor_type *sensor,
+			     u8_t index, u8_t count,
+			     const struct bt_mesh_sensor_series_entry *entry);
+
+	/** @brief Unknown type callback.
+	 *
+	 *  Called when the client receives a message with a sensor type it
+	 *  doesn't have type information for.
+	 *
+	 *  @param[in] cli    Sensor client receiving the message.
+	 *  @param[in] ctx    Message context.
+	 *  @param[in] id     Sensor type ID.
+	 *  @param[in] opcode The opcode of the message containing the unknown
+	 *                    sensor type.
+	 */
+	void (*unknown_type)(struct bt_mesh_sensor_cli *cli,
+			     struct bt_mesh_msg_ctx *ctx, u16_t id,
+			     u32_t opcode);
+};
+
+/** @brief Retrieve a list of all sensors in a sensor server.
+ *
+ *  This call is blocking if the @c sensors buffer is non-NULL. Otherwise, this
+ *  function will return, and the response will be passed to the
+ *  @ref bt_mesh_sensor_cli_handlers::sensor callback as a list of sensor
+ *  descriptors.
+ *
+ *  If a @c sensors array is provided and the client received a response, the
+ *  array will be filled with as many of the response sensors as it can fit,
+ *  even if the buffer isn't big enough. If the call fails in a way that results
+ *  in no response, @c count is set to 0.
+ *
+ *  @param[in]     cli     Sensor client instance.
+ *  @param[in]     ctx     Message context parameters, or NULL to use the
+ *                         configured publish parameters.
+ *  @param[out]    sensors Array of sensors to fill with the response, or NULL
+ *                         to keep from blocking.
+ *  @param[in,out] count   The number of elements in the @c sensors array. Will
+ *                         be changed to reflect the resulting number of
+ *                         sensors.
+ *
+ *  @retval 0              Successfully received the full list of sensors.
+ *                         The @c sensors array and @c count has been changed to
+ *                         reflect the response contents.
+ *  @retval -EALREADY      A blocking request is already in progress.
+ *  @retval -E2BIG         The list of sensors in the response was too big to
+ *                         fit in the @c sensors array. The @c sensors array has
+ *                         been filled up to the original @c count, and @c count
+ *                         has been changed to the number of sensors in the
+ *                         response.
+ *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ *                         not configured.
+ *  @retval -EAGAIN        The device has not been provisioned.
+ */
+int bt_mesh_sensor_cli_list_get(struct bt_mesh_sensor_cli *cli,
+				struct bt_mesh_msg_ctx *ctx,
+				struct bt_mesh_sensor_info *sensors,
+				u32_t *count);
+
+/** @brief Get the descriptor for the given sensor.
+ *
+ *  This call is blocking if the @c rsp buffer is non-NULL. Otherwise, this
+ *  function will return, and the response will be passed to the
+ *  @ref bt_mesh_sensor_cli_handlers::sensor callback.
+ *
+ *  @param[in]  cli    Sensor client instance.
+ *  @param[in]  ctx    Message context parameters, or NULL to use the configured
+ *                     publish parameters.
+ *  @param[in]  sensor Sensor instance present on the targeted sensor server.
+ *  @param[out] rsp    Sensor descriptor response buffer, or NULL to keep from
+ *                     blocking.
+ *
+ *  @retval 0              Successfully received the descriptor. The @c rsp
+ *                         buffer has been filled.
+ *  @retval -ENODEV        The sensor server doesn't have the given sensor.
+ *  @retval -EALREADY      A blocking request is already in progress.
+ *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ *                         not configured.
+ *  @retval -EAGAIN        The device has not been provisioned.
+ */
+int bt_mesh_sensor_cli_desc_get(struct bt_mesh_sensor_cli *cli,
+				struct bt_mesh_msg_ctx *ctx,
+				struct bt_mesh_sensor_type *sensor,
+				struct bt_mesh_sensor_descriptor *rsp);
+
+/** @brief Get the cadence state.
+ *
+ *  This call is blocking if the @c rsp buffer is non-NULL. Otherwise, this
+ *  function will return, and the response will be passed to the
+ *  @ref bt_mesh_sensor_cli_handlers::cadence callback.
+ *
+ *  @param[in]  cli    Sensor client instance.
+ *  @param[in]  ctx    Message context parameters, or NULL to use the configured
+ *                     publish parameters.
+ *  @param[in]  sensor Sensor to get the cadence of.
+ *  @param[out] rsp    Sensor cadence response buffer, or NULL to keep from
+ *                     blocking.
+ *
+ *  @retval 0              Successfully received the cadence. The @c rsp
+ *                         buffer has been filled.
+ *  @retval -ENOTSUP       The sensor doesn't support cadence settings.
+ *  @retval -EALREADY      A blocking request is already in progress.
+ *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ *                         not configured.
+ *  @retval -EAGAIN        The device has not been provisioned.
+ */
+int bt_mesh_sensor_cli_cadence_get(struct bt_mesh_sensor_cli *cli,
+				   struct bt_mesh_msg_ctx *ctx,
+				   struct bt_mesh_sensor_type *sensor,
+				   struct bt_mesh_sensor_cadence_status *rsp);
+
+/** @brief Set the cadence state for the given sensor.
+ *
+ *  This call is blocking if the @c rsp buffer is non-NULL. Otherwise, this
+ *  function will return, and the response will be passed to the
+ *  @ref bt_mesh_sensor_cli_handlers::cadence callback.
+ *
+ *  @note Only single-channel sensors support cadence.
+ *
+ *  @param[in]  cli     Sensor client instance.
+ *  @param[in]  ctx     Message context parameters, or NULL to use the
+ *                      configured publish parameters.
+ *  @param[in]  sensor  Sensor instance present on the targeted sensor server.
+ *  @param[in]  cadence New sensor cadence for the sensor.
+ *  @param[out] rsp     Sensor cadence response buffer, or NULL to keep from
+ *                      blocking.
+ *
+ *  @retval 0              Successfully received the cadence. The @c rsp
+ *                         buffer has been filled.
+ *  @retval -ENOTSUP       The sensor doesn't support cadence settings.
+ *  @retval -EALREADY      A blocking request is already in progress.
+ *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ *                         not configured.
+ *  @retval -EAGAIN        The device has not been provisioned.
+ */
+int bt_mesh_sensor_cli_cadence_set(
+	struct bt_mesh_sensor_cli *cli, struct bt_mesh_msg_ctx *ctx,
+	struct bt_mesh_sensor_type *sensor,
+	const struct bt_mesh_sensor_cadence_status *cadence,
+	struct bt_mesh_sensor_cadence_status *rsp);
+
+/** @brief Set the cadence state for the given sensor without requesting a
+ *         response.
+ *
+ *  @note Only single-channel sensors support cadence.
+ *
+ *  @param[in] cli     Sensor client instance.
+ *  @param[in] ctx     Message context parameters, or NULL to use the configured
+ *                     publish parameters.
+ *  @param[in] sensor  Sensor instance present on the targeted sensor server.
+ *  @param[in] cadence New sensor cadence for the sensor.
+ *
+ *  @retval 0              Successfully received the cadence.
+ *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ *                         not configured.
+ *  @retval -EAGAIN        The device has not been provisioned.
+ */
+int bt_mesh_sensor_cli_cadence_set_unack(
+	struct bt_mesh_sensor_cli *cli, struct bt_mesh_msg_ctx *ctx,
+	struct bt_mesh_sensor_type *sensor,
+	const struct bt_mesh_sensor_cadence_status *cadence);
+
+/** @brief Get the list of settings for the given sensor.
+ *
+ *  This call is blocking if the @c rsp buffer is non-NULL. Otherwise, this
+ *  function will return, and the response will be passed to the
+ *  @ref bt_mesh_sensor_cli_handlers::settings callback.
+ *
+ *  If an @c ids array is provided and the client received a response, the array
+ *  will be filled with as many of the response ids as it can fit, even if the
+ *  buffer isn't big enough. If the call fails in a way that results in no
+ *  response, @c count is set to 0.
+ *
+ *  @param[in]     cli    Sensor client instance.
+ *  @param[in]     ctx    Message context parameters, or NULL to use the
+ *                        configured publish parameters.
+ *  @param[in]     sensor Sensor instance present on the targeted sensor server.
+ *  @param[out]    ids    Array of sensor setting IDs to fill with the response,
+ *                        or NULL to keep from blocking.
+ *  @param[in,out] count  The number of elements in the @c ids array. Will be
+ *                        changed to reflect the resulting number of IDs.
+ *
+ *  @retval 0              Successfully received the full list of sensor setting
+ *                         IDs. The @c ids array and @c count has been changed
+ *                         to reflect the response contents.
+ *  @retval -ENODEV        The sensor server doesn't have the given sensor.
+ *  @retval -E2BIG         The list of IDs in the response was too big to fit in
+ *                         the @c ids array. The @c ids array has been filled
+ *                         up to the original @c count, and @c count has been
+ *                         changed to the number of IDs in the response.
+ *  @retval -EALREADY      A blocking request is already in progress.
+ *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ *                         not configured.
+ *  @retval -EAGAIN        The device has not been provisioned.
+ */
+int bt_mesh_sensor_cli_settings_get(struct bt_mesh_sensor_cli *cli,
+				    struct bt_mesh_msg_ctx *ctx,
+				    struct bt_mesh_sensor_type *sensor,
+				    u16_t *ids, u32_t *count);
+
+/** @brief Get a setting value for a sensor.
+ *
+ *  This call is blocking if the @c rsp buffer is non-NULL. Otherwise, this
+ *  function will return, and the response will be passed to the
+ *  @ref bt_mesh_sensor_cli_handlers::setting callback.
+ *
+ *  @param[in]  cli     Sensor client instance.
+ *  @param[in]  ctx     Message context parameters, or NULL to use the
+ *                      configured publish parameters.
+ *  @param[in]  sensor  Sensor instance present on the targeted sensor server.
+ *  @param[in]  setting Setting to read.
+ *  @param[out] rsp     Sensor setting value response buffer, or NULL to keep
+ *                      from blocking.
+ *
+ *  @retval 0              Successfully received the setting value. The @c rsp
+ *                         buffer has been filled.
+ *  @retval -ENOENT        The sensor doesn't have the given setting.
+ *  @retval -EALREADY      A blocking request is already in progress.
+ *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ *                         not configured.
+ *  @retval -EAGAIN        The device has not been provisioned.
+ */
+int bt_mesh_sensor_cli_setting_get(struct bt_mesh_sensor_cli *cli,
+				   struct bt_mesh_msg_ctx *ctx,
+				   struct bt_mesh_sensor_type *sensor,
+				   const struct bt_mesh_sensor_type *setting,
+				   struct bt_mesh_sensor_setting_status *rsp);
+
+/** @brief Set a setting value for a sensor.
+ *
+ *  This call is blocking if the @c rsp buffer is non-NULL. Otherwise, this
+ *  function will return, and the response will be passed to the
+ *  @ref bt_mesh_sensor_cli_handlers::setting callback.
+ *
+ *  @param[in]  cli     Sensor client instance.
+ *  @param[in]  ctx     Message context parameters, or NULL to use the
+ *                      configured publish parameters.
+ *  @param[in]  sensor  Sensor instance present on the targeted sensor server.
+ *  @param[in]  setting Setting to change.
+ *  @param[in]  value   New setting value. Must contain values for all channels
+ *                      described by @c setting.
+ *  @param[out] rsp     Sensor setting value response buffer, or NULL to keep
+ *                      from blocking.
+ *
+ *  @retval 0              Successfully changed the setting. The @c rsp
+ *                         buffer has been filled.
+ *  @retval -ENOENT        The sensor doesn't have the given setting.
+ *  @retval -EACCES        The setting can't be written to.
+ *  @retval -EALREADY      A blocking request is already in progress.
+ *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ *                         not configured.
+ *  @retval -EAGAIN        The device has not been provisioned.
+ */
+int bt_mesh_sensor_cli_setting_set(
+	struct bt_mesh_sensor_cli *cli, struct bt_mesh_msg_ctx *ctx,
+	struct bt_mesh_sensor_type *sensor,
+	const struct bt_mesh_sensor_type *setting,
+	const struct sensor_value *value,
+	struct bt_mesh_sensor_setting_status *rsp);
+
+/** @brief Set a setting value for a sensor without requesting a response.
+ *
+ *  @param[in] cli     Sensor client instance.
+ *  @param[in] ctx     Message context parameters, or NULL to use the configured
+ *                     publish parameters.
+ *  @param[in] sensor  Sensor instance present on the targeted sensor server.
+ *  @param[in] setting Setting to change.
+ *  @param[in] value   New setting value. Must contain values for all channels
+ *                     described by @c setting.
+ *
+ *  @retval 0              Successfully changed the setting.
+ *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ *                         not configured.
+ *  @retval -EAGAIN        The device has not been provisioned.
+ */
+int bt_mesh_sensor_cli_setting_set_unack(
+	struct bt_mesh_sensor_cli *cli, struct bt_mesh_msg_ctx *ctx,
+	struct bt_mesh_sensor_type *sensor,
+	const struct bt_mesh_sensor_type *setting,
+	const struct sensor_value *value);
+
+/** @brief Read sensor data from a sensor instance.
+ *
+ *  This call is blocking if the @c rsp buffer is non-NULL. Otherwise, this
+ *  function will return, and the response will be passed to the
+ *  @ref bt_mesh_sensor_cli_handlers::data callback.
+ *
+ *  @param[in]  cli    Sensor client instance.
+ *  @param[in]  ctx    Message context parameters, or NULL to use the configured
+ *                     publish parameters.
+ *  @param[in]  sensor Sensor instance present on the targeted sensor server.
+ *  @param[out] rsp    Response value buffer, or NULL to keep from blocking.
+ *                     Must be able to fit all channels described by the sensor
+ *                     type.
+ *
+ *  @retval 0              Successfully received the sensor data.
+ *  @retval -ENODEV        The sensor server doesn't have the given sensor.
+ *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ *                         not configured.
+ *  @retval -EAGAIN        The device has not been provisioned.
+ */
+int bt_mesh_sensor_cli_get(
+	struct bt_mesh_sensor_cli *cli, struct bt_mesh_msg_ctx *ctx,
+	struct bt_mesh_sensor_type *sensor,
+	struct sensor_value *rsp);
+
+/** @brief Read a single sensor series data entry.
+ *
+ *  This call is blocking if the @c rsp buffer is non-NULL. Otherwise, this
+ *  function will return, and the response will be passed to the
+ *  @ref bt_mesh_sensor_cli_handlers::series_entries callback as a list of
+ *  sensor descriptors.
+ *
+ *  @param[in]  cli    Sensor client instance.
+ *  @param[in]  ctx    Message context parameters, or NULL to use the configured
+ *                     publish parameters.
+ *  @param[in]  sensor Sensor instance present on the targeted sensor server.
+ *  @param[in]  column Column to read. The start value must match the start
+ *                     value of a series column on the sensor. The end value is
+ *                     ignored.
+ *  @param[out] rsp    Response value buffer, or NULL to keep from blocking.
+ *                     Must be able to fit all channels described by the sensor
+ *                     type.
+ *
+ *  @retval 0              Successfully received the sensor data.
+ *  @retval -ENODEV        The sensor server doesn't have the given sensor.
+ *  @retval -ENOENT        The sensor doesn't have the given column.
+ *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ *                         not configured.
+ *  @retval -EAGAIN        The device has not been provisioned.
+ */
+int bt_mesh_sensor_cli_series_entry_get(
+	struct bt_mesh_sensor_cli *cli, struct bt_mesh_msg_ctx *ctx,
+	struct bt_mesh_sensor_type *sensor,
+	const struct bt_mesh_sensor_column *column,
+	struct bt_mesh_sensor_series_entry *rsp);
+
+/** @brief Get multiple sensor series data entries.
+ *
+ *  Retrieves all data series columns starting within the given range
+ *  (inclusive), or all data series entries if @c range is NULL. For instance,
+ *  requesting range [1, 5] from a sensor with columns
+ *  [0, 2], [1, 4], [4, 5] and [5, 8] will return all columns except [0, 2].
+ *
+ *  If a @c rsp array is provided and the client received a response, the array
+ *  will be filled with as many of the response columns as it can fit, even if
+ *  the buffer isn't big enough. If the call fails in a way that results in no
+ *  response, @c count is set to 0.
+ *
+ *  This call is blocking if the @c rsp buffer is non-NULL. Otherwise, this
+ *  function will return, and the response will be passed to the
+ *  @ref bt_mesh_sensor_cli_handlers::series_entries callback as a list of
+ *  sensor descriptors.
+ *
+ *  @param[in]     cli    Sensor client instance.
+ *  @param[in]     ctx    Message context parameters, or NULL to use the
+ *                        configured publish parameters.
+ *  @param[in]     sensor Sensor instance present on the targeted sensor server.
+ *  @param[in]     range  Range of columns to get, or NULL to get all columns.
+ *  @param[out]    rsp    Array of entries to copy the response into, or NULL
+ *                        to keep from blocking.
+ *  @param[in,out] count  The number of entries in @c rsp. Is changed to reflect
+ *                        the number of entries in the response.
+ *
+ *  @retval 0              Successfully received the full list of sensor series
+ *                         columns. The @c rsp array and @c count has been
+ *                         changed to reflect the response contents.
+ *  @retval -ENODEV        The sensor server doesn't have the given sensor.
+ *  @retval -E2BIG         The list of sensor columns in the response was too
+ *                         big to fit in the @c rsp array. The @c rsp array has
+ *                         been filled up to the original @c count, and @c count
+ *                         has been changed to the number of columns in the
+ *                         response.
+ *  @retval -ENOTSUP       The sensor doesn't support series data.
+ *  @retval -ENODEV        The sensor server doesn't have the given sensor.
+ *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ *                         not configured.
+ *  @retval -EAGAIN        The device has not been provisioned.
+ */
+int bt_mesh_sensor_cli_series_entries_get(
+	struct bt_mesh_sensor_cli *cli, struct bt_mesh_msg_ctx *ctx,
+	struct bt_mesh_sensor_type *sensor,
+	const struct bt_mesh_sensor_column *range,
+	struct bt_mesh_sensor_series_entry *rsp, u32_t *count);
+
+/** @cond INTERNAL_HIDDEN */
+extern const struct bt_mesh_model_op _bt_mesh_sensor_cli_op[];
+extern const struct bt_mesh_model_cb _bt_mesh_sensor_cli_cb;
+/** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+
+#endif /* BT_MESH_SENSOR_CLI_H__ */

--- a/include/bluetooth/mesh/sensor_models.rst
+++ b/include/bluetooth/mesh/sensor_models.rst
@@ -1,0 +1,128 @@
+.. _bt_mesh_sensor_models:
+
+Sensor models
+#############
+
+The :ref:`bt_mesh_sensors_readme` are accessed through the Sensor models.
+
+There are two Sensor models:
+
+* :ref:`bt_mesh_sensor_srv_readme`
+* :ref:`bt_mesh_sensor_cli_readme`
+
+.. _bt_mesh_sensor_srv_readme:
+
+Sensor Server
+=============
+
+The Sensor Server model holds a list of sensors, and exposes them to the mesh network. There may be multiple Sensor Server models on a single mesh node, and each model may hold up to 47 sensors.
+
+The Sensor Server Model adds two model instances in the composition data:
+
+* A Sensor Server
+* A Sensor Setup Server
+
+The two model instances share the states of the Sensor Server, but accept different messages. This allows fine-grained control of the access rights for the Sensor Server states, as the two model instances can be bound to different application keys.
+
+The Sensor Server is the "user facing" model in the pair, and provides access to the Sensor Descriptors, the Sensor Data and Sensor Series, all of which are read-only states.
+
+The Sensor Setup Server provides access to the Sensor Cadence and Sensor Settings, allowing configurator devices to set up the publish rate and parameters for each sensor.
+
+Usage
+*****
+
+The Sensor Server model requires a list of :cpp:type:`bt_mesh_sensor` pointers at compile time.
+The list of sensors may not be changed at runtime, and only one of each type of sensor may be held by a Sensor Server.
+To expose multiple sensors of the same type, multiple Sensor Servers must be instantiated on different elements.
+
+Initialization of the Sensor Server may typically look like this:
+
+.. code-block:: c
+
+   extern struct bt_mesh_sensor temperature_sensor;
+   extern struct bt_mesh_sensor motion_sensor;
+   extern struct bt_mesh_sensor light_sensor;
+
+   static struct bt_mesh_sensor* const sensors[] = {
+       &temperature_sensor,
+       &motion_sensor,
+       &light_sensor,
+   };
+   static struct bt_mesh_sensor_srv sensor_srv = BT_MESH_SENSOR_SRV_INIT(sensors, ARRAY_SIZE(sensors));
+
+Each sensor may be implemented in its own separate module by exposing the sensor instance as an extern variable and pointing to it in the server's sensor list.
+Note that the list of pointers may be ``const``, while the sensor instances themselves may not.
+
+All sensors exposed by the Sensor Server must be present in the Server's list.
+Passing unlisted sensor instances to the Server API results in undefined behavior.
+
+States
+******
+
+The Sensor Server does not hold any states on its own, but instead exposes the states of all its sensors.
+
+Extended models
+***************
+
+None.
+
+Persistent Storage
+******************
+
+The Sensor Server stores the cadence state of each sensor instance persistently, including the minimum interval, delta thresholds, fast period divisor and fast cadence range.
+Any other data, such as sensor settings or sample data is managed by the application, and must be stored separately.
+
+API documentation
+*****************
+
+| Header file: :file:`include/bluetooth/mesh/sensor_srv.h`
+| Source file: :file:`subsys/bluetooth/mesh/sensor_srv.c`
+
+.. doxygengroup:: bt_mesh_sensor_srv
+   :project: nrf
+   :members:
+
+----
+
+.. _bt_mesh_sensor_cli_readme:
+
+Sensor Client
+=============
+
+The Sensor Client model reads and configures the sensors exposed by Sensor Server models.
+
+Contrary to the Server model, the Client only creates a single model instance in the mesh composition data.
+The Sensor Client may send messages to both the Sensor Server and the Sensor Setup Server, as long as it has the right application keys.
+
+Usage
+*****
+
+The Sensor Client will receive data from the Sensor Servers asynchronously, and in most cases, the incoming data needs to be interpreted differently based on the type of sensor that produced it.
+When parsing incoming messages, the Sensor Client is required to do a lookup of the sensor type of the data so it can decode it correctly.
+For this purpose, the list of known sensor types is centralized in the :ref:`bt_mesh_sensor_types` module.
+By default, all sensor types are available when the Sensor Client model is compiled in, but this behavior can be overridden to reduce flash consumption by explicitly disabling :option:`CONFIG_BT_MESH_SENSOR_ALL_TYPES`.
+In this case, only the referenced sensor types will be available.
+Whenever the Sensor Client receives a sensor type it is unable to interpret, it calls its :cpp:member:`bt_mesh_sensor_cli_handlers::unknown_type` callback.
+The Sensor Client API is designed to force the application to reference any sensor types it wants to communicate with, so this issue will commonly not occur.
+
+The Sensor Client API supports both blocking functions and asynchronous callbacks for accessing the Sensor Server data.
+
+Extended models
+***************
+
+None.
+
+Persistent Storage
+******************
+
+None.
+
+API documentation
+*****************
+
+| Header file: :file:`include/bluetooth/mesh/sensor_cli.h`
+| Source file: :file:`subsys/bluetooth/mesh/sensor_cli.c`
+
+.. doxygengroup:: bt_mesh_sensor_cli
+   :project: nrf
+   :members:

--- a/include/bluetooth/mesh/sensor_srv.h
+++ b/include/bluetooth/mesh/sensor_srv.h
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/** @file
+ *  @defgroup bt_mesh_sensor_srv Sensor Server model
+ *  @{
+ *  @brief API for the Sensor Server.
+ */
+
+#ifndef BT_MESH_SENSOR_SRV_H__
+#define BT_MESH_SENSOR_SRV_H__
+
+#include <bluetooth/mesh/sensor.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct bt_mesh_sensor_srv;
+
+/** @def BT_MESH_SENSOR_SRV_INIT
+ *
+ *  @brief Initialization parameters for @ref bt_mesh_sensor_srv.
+ *
+ *  @note A sensor server can only represent one sensor instance of each
+ *        sensor type. Duplicate sensors will be ignored.
+ *
+ *  @param[in] _sensors Array of pointers to sensors owned by this server.
+ *  @param[in] _count Number of sensors in the array. Can at most be @ref
+ *                    CONFIG_BT_MESH_SENSOR_SRV_SENSORS_MAX.
+ */
+#define BT_MESH_SENSOR_SRV_INIT(_sensors, _count)                              \
+	{                                                                      \
+		.sensor_array = _sensors,                                      \
+		.sensor_count =                                                \
+			MIN(CONFIG_BT_MESH_SENSOR_SRV_SENSORS_MAX, _count),    \
+		.pub = { .update = _bt_mesh_sensor_srv_update_handler,         \
+			 .msg = NET_BUF_SIMPLE(                                \
+				 BT_MESH_SENSOR_SRV_PUB_MAXLEN(_count)) },     \
+		.setup_pub = {                                                 \
+			.msg = NET_BUF_SIMPLE(                                 \
+				BT_MESH_SENSOR_SETUP_SRV_PUB_MAXLEN),          \
+		},                                                             \
+	}
+
+/** @def BT_MESH_MODEL_SENSOR_SRV
+ *
+ *  @brief Sensor Server model composition data entry.
+ *
+ *  @param[in] _srv Pointer to a @ref bt_mesh_sensor_srv instance.
+ */
+#define BT_MESH_MODEL_SENSOR_SRV(_srv)                                         \
+	BT_MESH_MODEL_CB(BT_MESH_MODEL_ID_SENSOR_SRV, _bt_mesh_sensor_srv_op,  \
+			 &(_srv)->pub,                                         \
+			 BT_MESH_MODEL_USER_DATA(struct bt_mesh_sensor_srv,    \
+						 _srv),                        \
+			 &_bt_mesh_sensor_srv_cb),                             \
+	BT_MESH_MODEL(BT_MESH_MODEL_ID_SENSOR_SETUP_SRV,                       \
+		      _bt_mesh_sensor_setup_srv_op,                            \
+		      &(_srv)->setup_pub,                                      \
+		      BT_MESH_MODEL_USER_DATA(struct bt_mesh_sensor_srv,       \
+					      _srv))
+
+/** Sensor server instance. */
+struct bt_mesh_sensor_srv {
+	/** Sensors owned by this server. */
+	struct bt_mesh_sensor *const *sensor_array;
+	/** Ordered linked list of sensors. */
+	sys_slist_t sensors;
+	/** Publish sequence counter */
+	u16_t seq;
+	/** Number of sensors. */
+	u8_t sensor_count;
+
+	/** Publish parameters. */
+	struct bt_mesh_model_pub pub;
+	/** Publish parameters for the setup server. */
+	struct bt_mesh_model_pub setup_pub;
+	/** Composition data model pointer. */
+	struct bt_mesh_model *model;
+};
+
+/** @brief Publish a sensor value.
+ *
+ *  Immediately publishes the given sensor value, without checking thresholds
+ *  or intervals.
+ *
+ *  @see bt_mesh_sensor_srv_pub
+ *
+ *  @param[in] srv    Sensor server instance.
+ *  @param[in] ctx    Message context to publish with, or NULL to publish on the
+ *                    configured publish parameters.
+ *  @param[in] sensor Sensor to publish with.
+ *  @param[in] value  Sensor value to publish, interpreted as an array of sensor
+ *                    channel values matching the sensor channels specified by
+ *                    the sensor type. The length of the array must match the
+ *                    sensor channel count.
+ *
+ *  @return 0 on success, or (negative) error code otherwise.
+ */
+int bt_mesh_sensor_srv_pub(struct bt_mesh_sensor_srv *srv,
+			   struct bt_mesh_msg_ctx *ctx,
+			   struct bt_mesh_sensor *sensor,
+			   const struct sensor_value *value);
+
+
+/** @brief Make the server to take a sample of the sensor, and publish if the
+ *         value changed sufficiently.
+ *
+ *  Works the same way as @ref bt_mesh_sensor_srv_pub(), except that the server
+ *  makes a decision on whether to publish the value based on the delta from the
+ *  previous publication and the sensor's threshold parameters. Only single
+ *  channel sensor values will be considered.
+ *
+ *  @param[in] srv    Sensor server instance.
+ *  @param[in] sensor Sensor instance to sample.
+ *
+ *  @retval 0              The sensor value was published.
+ *  @retval -EBUSY         Failed sampling the sensor value.
+ *  @retval -EALREADY      The sensor value has not changed sufficiently to
+ *                         require a publication.
+ *  @retval -EADDRNOTAVAIL A message context was not provided and publishing is
+ *                         not configured.
+ *  @retval -EAGAIN        The device has not been provisioned.
+ */
+int bt_mesh_sensor_srv_sample(struct bt_mesh_sensor_srv *srv,
+			      struct bt_mesh_sensor *sensor);
+
+/** @cond INTERNAL_HIDDEN */
+extern const struct bt_mesh_model_cb _bt_mesh_sensor_srv_cb;
+extern const struct bt_mesh_model_op _bt_mesh_sensor_srv_op[];
+extern const struct bt_mesh_model_op _bt_mesh_sensor_setup_srv_op[];
+int _bt_mesh_sensor_srv_update_handler(struct bt_mesh_model *mod);
+/** @endcond */
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+
+#endif /* BT_MESH_SENSOR_SRV_H__ */

--- a/include/bluetooth/mesh/sensor_types.h
+++ b/include/bluetooth/mesh/sensor_types.h
@@ -1,0 +1,1032 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+/** @file
+ *  @defgroup bt_mesh_sensor_types Sensor types
+ *  @{
+ *  @brief All available sensor types from the Mesh Device Properties
+ *        Specification.
+ */
+
+#ifndef BT_MESH_SENSOR_TYPES_H__
+#define BT_MESH_SENSOR_TYPES_H__
+
+#include <bluetooth/mesh/sensor.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @def BT_MESH_SENSOR_TYPE_FORCE
+ *
+ *  @brief Force the given sensor type to be included in the build.
+ *
+ *  If @ref CONFIG_BT_MESH_SENSOR_FORCE_ALL is disabled, only referenced sensor
+ *  types will be included in the build, and the node will be unable to
+ *  interpret the rest. Use this macro inside a function to force the type to be
+ *  included in the build:
+ *
+ *  @code{.c}
+ *  void some_function(void)
+ *  {
+ *      BT_MESH_SENSOR_TYPE_FORCE(bt_mesh_sensor_time_since_motion_sensed);
+ *      BT_MESH_SENSOR_TYPE_FORCE(bt_mesh_sensor_motion_threshold);
+ *  }
+ *  @endcode
+ *
+ *  @param[in] _type Sensor type to force into the build.
+ */
+#define BT_MESH_SENSOR_TYPE_FORCE(_type)                                       \
+	{                                                                      \
+		const struct bt_mesh_sensor_type *volatile __unused val =      \
+			&_type;                                                \
+	}
+/** @defgroup bt_mesh_sensor_types_occupancy Occupancy sensor types
+ *  @{
+ */
+
+/** Motion sensed
+ *
+ *  Channels:
+ *  - Motion sensed
+ *    - Unit: Percent
+ *    - Encoding: 8 bit unsigned scalar (Resolution: 0.5 %)
+ *    - Range: 0 to 100.0
+ */
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_motion_sensed;
+
+/** Motion threshold
+ *
+ *  This sensor type should be used as a sensor setting.
+ *
+ *  Channels:
+ *  - Motion threshold
+ *    - Unit: Percent
+ *    - Encoding: 8 bit unsigned scalar (Resolution: 0.5 %)
+ *    - Range: 0 to 100.0
+ */
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_motion_threshold;
+
+/** People count
+ *
+ *  Channels:
+ *  - People count
+ *    - Unit: _unitless_
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 1)
+ *    - Range: 0 to 65533
+ */
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_people_count;
+
+/** Presence detected
+ *
+ *  Channels:
+ *  - Presence detected
+ *    - Unit: _unitless_
+ *    - Encoding: boolean
+ */
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_presence_detected;
+
+/** Time since motion sensed
+ *
+ *  Channels:
+ *  - Time since motion detected
+ *    - Unit: Seconds
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 1 second)
+ *    - Range: 0 to 65533
+ */
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_time_since_motion_sensed;
+
+/** Time since presence detected
+ *
+ *  Channels:
+ *  - Time since presence detected
+ *    - Unit: Seconds
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 1 second)
+ *    - Range: 0 to 65533
+ */
+extern const struct bt_mesh_sensor_type
+	bt_mesh_sensor_time_since_presence_detected;
+
+/** @} */
+
+/** @defgroup bt_mesh_sensor_types_ambient_temperature Ambient temperature
+ *  sensor types
+ *  @{
+ */
+
+/** Average ambient temperature in a period of day
+ *
+ *  This sensor type supports series access.
+ *  The series X-axis is measured in Hours.
+ *
+ *  Channels:
+ *  - Temperature
+ *    - Unit: Celsius
+ *    - Encoding: 8 bit signed scalar (Resolution: 0.5 C)
+ *    - Range: -64.0 to 63.5
+ *  - Start time
+ *    - Unit: Hours
+ *    - Encoding: 8 bit unsigned scalar (Resolution: 0.1 hours)
+ *    - Range: 0 to 24.0
+ *  - End time
+ *    - Unit: Hours
+ *    - Encoding: 8 bit unsigned scalar (Resolution: 0.1 hours)
+ *    - Range: 0 to 24.0
+ */
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_avg_amb_temp_in_day;
+
+/** Indoor ambient temperature statistical values
+ *
+ *  Channels:
+ *  - Average
+ *    - Unit: Celsius
+ *    - Encoding: 8 bit signed scalar (Resolution: 0.5 C)
+ *    - Range: -64.0 to 63.5
+ *  - Standard deviation value
+ *    - Unit: Celsius
+ *    - Encoding: 8 bit signed scalar (Resolution: 0.5 C)
+ *    - Range: -64.0 to 63.5
+ *  - Minimum value
+ *    - Unit: Celsius
+ *    - Encoding: 8 bit signed scalar (Resolution: 0.5 C)
+ *    - Range: -64.0 to 63.5
+ *  - Maximum value
+ *    - Unit: Celsius
+ *    - Encoding: 8 bit signed scalar (Resolution: 0.5 C)
+ *    - Range: -64.0 to 63.5
+ *  - Sensing duration
+ *    - Unit: Seconds
+ *    - Encoding: 8 bit unsigned exponential time (pow(1.1, N - 64) seconds)
+ *    - Range: 0 to 73216705
+ */
+extern const struct bt_mesh_sensor_type
+	bt_mesh_sensor_indoor_amb_temp_stat_values;
+
+/** Outdoor statistical values
+ *
+ *  Channels:
+ *  - Average
+ *    - Unit: Celsius
+ *    - Encoding: 8 bit signed scalar (Resolution: 0.5 C)
+ *    - Range: -64.0 to 63.5
+ *  - Standard deviation value
+ *    - Unit: Celsius
+ *    - Encoding: 8 bit signed scalar (Resolution: 0.5 C)
+ *    - Range: -64.0 to 63.5
+ *  - Minimum value
+ *    - Unit: Celsius
+ *    - Encoding: 8 bit signed scalar (Resolution: 0.5 C)
+ *    - Range: -64.0 to 63.5
+ *  - Maximum value
+ *    - Unit: Celsius
+ *    - Encoding: 8 bit signed scalar (Resolution: 0.5 C)
+ *    - Range: -64.0 to 63.5
+ *  - Sensing duration
+ *    - Unit: Seconds
+ *    - Encoding: 8 bit unsigned exponential time (pow(1.1, N - 64) seconds)
+ *    - Range: 0 to 73216705
+ */
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_outdoor_stat_values;
+
+/** Present ambient temperature
+ *
+ *  Channels:
+ *  - Present ambient temperature
+ *    - Unit: Celsius
+ *    - Encoding: 8 bit signed scalar (Resolution: 0.5 C)
+ *    - Range: -64.0 to 63.5
+ */
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_present_amb_temp;
+
+/** Present indoor ambient temperature
+ *
+ *  Channels:
+ *  - Present indoor ambient temperature
+ *    - Unit: Celsius
+ *    - Encoding: 8 bit signed scalar (Resolution: 0.5 C)
+ *    - Range: -64.0 to 63.5
+ */
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_present_indoor_amb_temp;
+
+/** Present outdoor ambient temperature
+ *
+ *  Channels:
+ *  - Present outdoor ambient temperature
+ *    - Unit: Celsius
+ *    - Encoding: 8 bit signed scalar (Resolution: 0.5 C)
+ *    - Range: -64.0 to 63.5
+ */
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_present_outdoor_amb_temp;
+
+/** Desired ambient temperature
+ *
+ *  Channels:
+ *  - Desired ambient temperature
+ *    - Unit: Celsius
+ *    - Encoding: 8 bit signed scalar (Resolution: 0.5 C)
+ *    - Range: -64.0 to 63.5
+ */
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_desired_amb_temp;
+
+/** Lumen maintenance factor
+ *
+ *  Channels:
+ *  - Lumen Maintenance Factor
+ *    - Unit: Percent
+ *    - Encoding: 8 bit unsigned scalar (Resolution: 0.5 %)
+ *    - Range: 0 to 100.0
+ */
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_lumen_maintenance_factor;
+
+/** Luminous efficacy
+ *
+ *  Channels:
+ *  - Luminous Efficacy
+ *    - Unit: Lumen per Watt
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 0.1 lm/W)
+ *    - Range: 0 to 6553.3
+ */
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_luminous_efficacy;
+
+/** Luminous energy since turn on
+ *
+ *  Channels:
+ *  - Luminous Energy Since Turn On
+ *    - Unit: Lumen hours
+ *    - Encoding: 24 bit unsigned scalar (Resolution: 1000 lmh)
+ *    - Range: 0 to 16777213000
+ */
+extern const struct bt_mesh_sensor_type
+	bt_mesh_sensor_luminous_energy_since_turn_on;
+
+/** Luminous exposure
+ *
+ *  Channels:
+ *  - Luminous Exposure
+ *    - Unit: Lux hours
+ *    - Encoding: 24 bit unsigned scalar (Resolution: 1000 lxh)
+ *    - Range: 0 to 16777213000
+ */
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_luminous_exposure;
+
+/** Luminous flux range
+ *
+ *  Channels:
+ *  - Minimum Luminous Flux
+ *    - Unit: Lumen
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 1 lm)
+ *    - Range: 0 to 65533
+ *  - Maximum Luminous Flux
+ *    - Unit: Lumen
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 1 lm)
+ *    - Range: 0 to 65533
+ */
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_luminous_flux_range;
+
+/** @} */
+
+/** @defgroup bt_mesh_sensor_types_environmental Environmental sensor types
+ *  @{
+ */
+
+/** Present Ambient Relative Humidity
+ *
+ *  Channels:
+ *  - Present Ambient Relative Humidity
+ *    - Unit: Percent
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 0.01 %)
+ *    - Range: 0 to 100.0
+ */
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_present_amb_rel_humidity;
+
+/** Present Ambient Carbon Dioxide Concentration
+ *
+ *  Channels:
+ *  - Present Ambient Carbon Dioxide Concentration
+ *    - Unit: Parts per million
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 1 ppm)
+ *    - Range: 0 to 65533
+ */
+extern const struct bt_mesh_sensor_type
+	bt_mesh_sensor_present_amb_co2_concentration;
+
+/** Present Ambient Volatile Organic Compounds Concentration
+ *
+ *  Channels:
+ *  - Present Ambient Volatile Organic Compounds Concentration
+ *    - Unit: Parts per billion
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 1 ppb)
+ *    - Range: 0 to 65533
+ */
+extern const struct bt_mesh_sensor_type
+	bt_mesh_sensor_present_amb_voc_concentration;
+
+/** Present Ambient Noise
+ *
+ *  Channels:
+ *  - Present Ambient Noise
+ *    - Unit: Decibel
+ *    - Encoding: 8 bit unsigned scalar (Resolution: 1 dB)
+ *    - Range: 0 to 253
+ */
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_present_amb_noise;
+
+/** @} */
+
+/** @defgroup bt_mesh_sensor_types_device_operating_temperature Device operating
+ *  temperature sensor types
+ *  @{
+ */
+
+/** Device operating temperature range specification
+ *
+ *  Channels:
+ *  - Minimum Temperature
+ *    - Unit: Celsius
+ *    - Encoding: 16 bit signed scalar (Resolution: 0.01 C)
+ *    - Range: -327.68 to 327.67
+ *  - Maximum Temperature
+ *    - Unit: Celsius
+ *    - Encoding: 16 bit signed scalar (Resolution: 0.01 C)
+ *    - Range: -327.68 to 327.67
+ */
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_dev_op_temp_range_spec;
+
+/** Device operating temperature statistical values
+ *
+ *  Channels:
+ *  - Average Temperature
+ *    - Unit: Celsius
+ *    - Encoding: 16 bit signed scalar (Resolution: 0.01 C)
+ *    - Range: -327.68 to 327.67
+ *  - Standard Deviation Temperature
+ *    - Unit: Celsius
+ *    - Encoding: 16 bit signed scalar (Resolution: 0.01 C)
+ *    - Range: -327.68 to 327.67
+ *  - Minimum Temperature
+ *    - Unit: Celsius
+ *    - Encoding: 16 bit signed scalar (Resolution: 0.01 C)
+ *    - Range: -327.68 to 327.67
+ *  - Maximum Temperature
+ *    - Unit: Celsius
+ *    - Encoding: 16 bit signed scalar (Resolution: 0.01 C)
+ *    - Range: -327.68 to 327.67
+ *  - Sensing duration
+ *    - Unit: Seconds
+ *    - Encoding: 8 bit unsigned exponential time (pow(1.1, N - 64) seconds)
+ *    - Range: 0 to 73216705
+ */
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_dev_op_temp_stat_values;
+
+/** Present device operating temperature
+ *
+ *  Channels:
+ *  - Temperature
+ *    - Unit: Celsius
+ *    - Encoding: 16 bit signed scalar (Resolution: 0.01 C)
+ *    - Range: -327.68 to 327.67
+ */
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_present_dev_op_temp;
+
+/** Relative runtime in a device operating temperature range
+ *
+ *  This sensor type supports series access.
+ *  The series X-axis is measured in Celsius.
+ *
+ *  Channels:
+ *  - Relative Value
+ *    - Unit: Percent
+ *    - Encoding: 8 bit unsigned scalar (Resolution: 0.5 %)
+ *    - Range: 0 to 100.0
+ *  - Minimum Temperature Value
+ *    - Unit: Celsius
+ *    - Encoding: 16 bit signed scalar (Resolution: 0.01 C)
+ *    - Range: -327.68 to 327.67
+ *  - Maximum Temperature Value
+ *    - Unit: Celsius
+ *    - Encoding: 16 bit signed scalar (Resolution: 0.01 C)
+ *    - Range: -327.68 to 327.67
+ */
+extern const struct bt_mesh_sensor_type
+	bt_mesh_sensor_rel_runtime_in_a_dev_op_temp_range;
+
+/** @} */
+
+/** @defgroup bt_mesh_sensor_types_electrical_input Electrical input sensor
+ *  types
+ *  @{
+ */
+
+/** Average input current
+ *
+ *  Channels:
+ *  - Electric Current Value
+ *    - Unit: Ampere
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 0.01 A)
+ *    - Range: 0 to 655.33
+ *  - Sensing duration
+ *    - Unit: Seconds
+ *    - Encoding: 8 bit unsigned exponential time (pow(1.1, N - 64) seconds)
+ *    - Range: 0 to 73216705
+ */
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_avg_input_current;
+
+/** Average input voltage
+ *
+ *  Channels:
+ *  - Voltage Value
+ *    - Unit: Volt
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 1/64 V)
+ *    - Range: 0 to 1023.95
+ *  - Sensing duration
+ *    - Unit: Seconds
+ *    - Encoding: 8 bit unsigned exponential time (pow(1.1, N - 64) seconds)
+ *    - Range: 0 to 73216705
+ */
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_avg_input_voltage;
+
+/** Input current range specification
+ *
+ *  Channels:
+ *  - Minimum Electric Current Value
+ *    - Unit: Ampere
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 0.01 A)
+ *    - Range: 0 to 655.33
+ *  - Maximum Electric Current Value
+ *    - Unit: Ampere
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 0.01 A)
+ *    - Range: 0 to 655.33
+ *  - Typical Electric Current Value
+ *    - Unit: Ampere
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 0.01 A)
+ *    - Range: 0 to 655.33
+ */
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_input_current_range_spec;
+
+/** Input current statistics
+ *
+ *  Channels:
+ *  - Average Electric Current Value
+ *    - Unit: Ampere
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 0.01 A)
+ *    - Range: 0 to 655.33
+ *  - Standard Deviation Electric Current Value
+ *    - Unit: Ampere
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 0.01 A)
+ *    - Range: 0 to 655.33
+ *  - Minimum Electric Current Value
+ *    - Unit: Ampere
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 0.01 A)
+ *    - Range: 0 to 655.33
+ *  - Maximum Electric Current Value
+ *    - Unit: Ampere
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 0.01 A)
+ *    - Range: 0 to 655.33
+ *  - Sensing Duration
+ *    - Unit: Seconds
+ *    - Encoding: 8 bit unsigned exponential time (pow(1.1, N - 64) seconds)
+ *    - Range: 0 to 73216705
+ */
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_input_current_stat;
+
+/** Input voltage range specification
+ *
+ *  Channels:
+ *  - Minimum Voltage Value
+ *    - Unit: Volt
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 1/64 V)
+ *    - Range: 0 to 1023.95
+ *  - Maximum Voltage Value
+ *    - Unit: Volt
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 1/64 V)
+ *    - Range: 0 to 1023.95
+ *  - Typical Voltage Value
+ *    - Unit: Volt
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 1/64 V)
+ *    - Range: 0 to 1023.95
+ */
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_input_voltage_range_spec;
+
+/** Input voltage statistics
+ *
+ *  Channels:
+ *  - Average Voltage Value
+ *    - Unit: Volt
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 1/64 V)
+ *    - Range: 0 to 1023.95
+ *  - Standard Deviation Voltage Value
+ *    - Unit: Volt
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 1/64 V)
+ *    - Range: 0 to 1023.95
+ *  - Minimum Voltage Value
+ *    - Unit: Volt
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 1/64 V)
+ *    - Range: 0 to 1023.95
+ *  - Maximum Voltage Value
+ *    - Unit: Volt
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 1/64 V)
+ *    - Range: 0 to 1023.95
+ *  - Sensing Duration
+ *    - Unit: Seconds
+ *    - Encoding: 8 bit unsigned exponential time (pow(1.1, N - 64) seconds)
+ *    - Range: 0 to 73216705
+ */
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_input_voltage_stat;
+
+/** Present input current
+ *
+ *  Channels:
+ *  - Present Input Current
+ *    - Unit: Ampere
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 0.01 A)
+ *    - Range: 0 to 655.33
+ */
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_present_input_current;
+
+/** Present input ripple voltage
+ *
+ *  Channels:
+ *  - Present Input Ripple Voltage
+ *    - Unit: Percent
+ *    - Encoding: 8 bit unsigned scalar (Resolution: 0.5 %)
+ *    - Range: 0 to 100.0
+ */
+extern const struct bt_mesh_sensor_type
+	bt_mesh_sensor_present_input_ripple_voltage;
+
+/** Present input voltage
+ *
+ *  Channels:
+ *  - Present Input Voltage
+ *    - Unit: Volt
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 1/64 V)
+ *    - Range: 0 to 1023.95
+ */
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_present_input_voltage;
+
+/** Precise Present Ambient Temperature
+ *
+ *  Channels:
+ *  - Precise Present Ambient Temperature
+ *    - Unit: Celsius
+ *    - Encoding: 16 bit signed scalar (Resolution: 0.01 C)
+ *    - Range: -327.68 to 327.67
+ */
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_precise_present_amb_temp;
+
+/** Relative runtime in an input current range
+ *
+ *  This sensor type supports series access.
+ *  The series X-axis is measured in Ampere.
+ *
+ *  Channels:
+ *  - Relative Runtime Value
+ *    - Unit: Percent
+ *    - Encoding: 8 bit unsigned scalar (Resolution: 0.5 %)
+ *    - Range: 0 to 100.0
+ *  - Minimum Current
+ *    - Unit: Ampere
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 0.01 A)
+ *    - Range: 0 to 655.33
+ *  - Maximum Current
+ *    - Unit: Ampere
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 0.01 A)
+ *    - Range: 0 to 655.33
+ */
+extern const struct bt_mesh_sensor_type
+	bt_mesh_sensor_rel_runtime_in_an_input_current_range;
+
+/** Relative runtime in an input voltage range
+ *
+ *  This sensor type supports series access.
+ *  The series X-axis is measured in Volt.
+ *
+ *  Channels:
+ *  - Relative Runtime Value
+ *    - Unit: Percent
+ *    - Encoding: 8 bit unsigned scalar (Resolution: 0.5 %)
+ *    - Range: 0 to 100.0
+ *  - Minimum Voltage
+ *    - Unit: Volt
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 1/64 V)
+ *    - Range: 0 to 1023.95
+ *  - Maximum Voltage
+ *    - Unit: Volt
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 1/64 V)
+ *    - Range: 0 to 1023.95
+ */
+extern const struct bt_mesh_sensor_type
+	bt_mesh_sensor_rel_runtime_in_an_input_voltage_range;
+
+/** @} */
+
+/** @defgroup bt_mesh_sensor_types_energy_management Energy management sensor
+ *  types
+ *  @{
+ */
+
+/** Present device input power
+ *
+ *  Channels:
+ *  - Present Device Input Power
+ *    - Unit: Watt
+ *    - Encoding: 24 bit unsigned scalar (Resolution: 0.1 W)
+ *    - Range: 0 to 1677721.3
+ */
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_present_dev_input_power;
+
+/** Present device operating efficiency
+ *
+ *  Channels:
+ *  - Present Device Operating Efficiency
+ *    - Unit: Percent
+ *    - Encoding: 8 bit unsigned scalar (Resolution: 0.5 %)
+ *    - Range: 0 to 100.0
+ */
+extern const struct bt_mesh_sensor_type
+	bt_mesh_sensor_present_dev_op_efficiency;
+
+/** Total device energy use
+ *
+ *  Channels:
+ *  - Total Device Energy Use
+ *    - Unit: Kwh
+ *    - Encoding: 24 bit unsigned scalar (Resolution: 1 kWh)
+ *    - Range: 0 to 16777213
+ */
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_tot_dev_energy_use;
+
+/** Device energy use since turn on
+ *
+ *  Channels:
+ *  - Device Energy Use Since Turn On
+ *    - Unit: Kwh
+ *    - Encoding: 24 bit unsigned scalar (Resolution: 1 kWh)
+ *    - Range: 0 to 16777213
+ */
+extern const struct bt_mesh_sensor_type
+	bt_mesh_sensor_dev_energy_use_since_turn_on;
+
+/** Precise Total Device Energy Use
+ *
+ *  Channels:
+ *  - Total Device Energy Use
+ *    - Unit: Kwh
+ *    - Encoding: 32 bit unsigned scalar (Resolution: 0.01 kWh)
+ *    - Range: 0 to 4294967.293
+ */
+extern const struct bt_mesh_sensor_type
+	bt_mesh_sensor_precise_tot_dev_energy_use;
+
+/** Power Factor
+ *
+ *  This sensor type should be used as a sensor setting.
+ *
+ *  Channels:
+ *  - Cosine Of the Angle
+ *    - Unit: _unitless_
+ *    - Encoding: 8 bit signed scalar (Resolution: 1)
+ *    - Range: -256 to 100
+ */
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_power_factor;
+
+/** Relative device energy use in a period of day
+ *
+ *  This sensor type supports series access.
+ *  The series X-axis is measured in Hours.
+ *
+ *  Channels:
+ *  - Energy Value
+ *    - Unit: Kwh
+ *    - Encoding: 24 bit unsigned scalar (Resolution: 1 kWh)
+ *    - Range: 0 to 16777213
+ *  - Start Time
+ *    - Unit: Hours
+ *    - Encoding: 8 bit unsigned scalar (Resolution: 0.1 hours)
+ *    - Range: 0 to 24.0
+ *  - End Time
+ *    - Unit: Hours
+ *    - Encoding: 8 bit unsigned scalar (Resolution: 0.1 hours)
+ *    - Range: 0 to 24.0
+ */
+extern const struct bt_mesh_sensor_type
+	bt_mesh_sensor_rel_dev_energy_use_in_a_period_of_day;
+
+/** Relative device runtime in a generic level range
+ *
+ *  This sensor type supports series access.
+ *  The series X-axis is unitless.
+ *
+ *  Channels:
+ *  - Relative Value
+ *    - Unit: Percent
+ *    - Encoding: 8 bit unsigned scalar (Resolution: 0.5 %)
+ *    - Range: 0 to 100.0
+ *  - Minimum Generic Level
+ *    - Unit: _unitless_
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 1)
+ *    - Range: 0 to 65535
+ *  - Maximum Generic Level
+ *    - Unit: _unitless_
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 1)
+ *    - Range: 0 to 65535
+ */
+extern const struct bt_mesh_sensor_type
+	bt_mesh_sensor_rel_dev_runtime_in_a_generic_level_range;
+
+/** @} */
+
+/** @defgroup bt_mesh_sensor_types_photometry Photometry sensor types
+ *  @{
+ */
+
+/** Present ambient light level
+ *
+ *  Channels:
+ *  - Present Ambient Light Level
+ *    - Unit: Lux
+ *    - Encoding: 24 bit unsigned scalar (Resolution: 0.01 lx)
+ *    - Range: 0 to 167772.13
+ */
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_present_amb_light_level;
+
+/** Present CIE-1931 chromaticity coordinates
+ *
+ *  Channels:
+ *  - Chromaticity x-coordinate
+ *    - Unit: _unitless_
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 1/65536)
+ *    - Range: 0 to 0.99998
+ *  - Chromaticity y-coordinate
+ *    - Unit: _unitless_
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 1/65536)
+ *    - Range: 0 to 0.99998
+ */
+extern const struct bt_mesh_sensor_type
+	bt_mesh_sensor_present_cie_1931_chromaticity_coords;
+
+/** Present correlated color temperature
+ *
+ *  Channels:
+ *  - Present Correlated Color Temperature
+ *    - Unit: Kelvin
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 1 K)
+ *    - Range: 0 to 65533
+ */
+extern const struct bt_mesh_sensor_type
+	bt_mesh_sensor_present_correlated_col_temp;
+
+/** Present illuminance
+ *
+ *  Channels:
+ *  - Present Illuminance
+ *    - Unit: Lux
+ *    - Encoding: 24 bit unsigned scalar (Resolution: 0.01 lx)
+ *    - Range: 0 to 167772.13
+ */
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_present_illuminance;
+
+/** Present luminous flux
+ *
+ *  Channels:
+ *  - Present Luminous Flux
+ *    - Unit: Lumen
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 1 lm)
+ *    - Range: 0 to 65533
+ */
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_present_luminous_flux;
+
+/** Present planckian distance
+ *
+ *  Channels:
+ *  - Present Planckian Distance
+ *    - Unit: _unitless_
+ *    - Encoding: 16 bit signed scalar (Resolution: 1/100000)
+ *    - Range: -0.05 to 0.05
+ */
+extern const struct bt_mesh_sensor_type
+	bt_mesh_sensor_present_planckian_distance;
+
+/** Relative exposure time in an illuminance range
+ *
+ *  This sensor type supports series access.
+ *  The series X-axis is measured in Lux.
+ *
+ *  Channels:
+ *  - Relative value
+ *    - Unit: Percent
+ *    - Encoding: 8 bit unsigned scalar (Resolution: 0.5 %)
+ *    - Range: 0 to 100.0
+ *  - Minimum Illuminance
+ *    - Unit: Lux
+ *    - Encoding: 24 bit unsigned scalar (Resolution: 0.01 lx)
+ *    - Range: 0 to 167772.13
+ *  - Maximum Illuminance
+ *    - Unit: Lux
+ *    - Encoding: 24 bit unsigned scalar (Resolution: 0.01 lx)
+ *    - Range: 0 to 167772.13
+ */
+extern const struct bt_mesh_sensor_type
+	bt_mesh_sensor_rel_exposure_time_in_an_illuminance_range;
+
+/** Total light exposure time
+ *
+ *  Channels:
+ *  - Total Light Exposure Time
+ *    - Unit: Hours
+ *    - Encoding: 24 bit unsigned scalar (Resolution: 0.1 hours)
+ *    - Range: 0 to 1677721.3
+ */
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_tot_light_exposure_time;
+
+/** @} */
+
+/** @defgroup bt_mesh_sensor_types_power_supply_output Power supply output
+ *  sensor types
+ *  @{
+ */
+
+/** Average output current
+ *
+ *  Channels:
+ *  - Electric Current Value
+ *    - Unit: Ampere
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 0.01 A)
+ *    - Range: 0 to 655.33
+ *  - Sensing duration
+ *    - Unit: Seconds
+ *    - Encoding: 8 bit unsigned exponential time (pow(1.1, N - 64) seconds)
+ *    - Range: 0 to 73216705
+ */
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_avg_output_current;
+
+/** Average output voltage
+ *
+ *  Channels:
+ *  - Voltage Value
+ *    - Unit: Volt
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 1/64 V)
+ *    - Range: 0 to 1023.95
+ *  - Sensing duration
+ *    - Unit: Seconds
+ *    - Encoding: 8 bit unsigned exponential time (pow(1.1, N - 64) seconds)
+ *    - Range: 0 to 73216705
+ */
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_avg_output_voltage;
+
+/** Output current range
+ *
+ *  This sensor type should be used as a sensor setting.
+ *
+ *  Channels:
+ *  - Minimum Electric Current Value
+ *    - Unit: Ampere
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 0.01 A)
+ *    - Range: 0 to 655.33
+ *  - Maximum Electric Current Value
+ *    - Unit: Ampere
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 0.01 A)
+ *    - Range: 0 to 655.33
+ */
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_output_current_range;
+
+/** Output current statistics
+ *
+ *  Channels:
+ *  - Average Electric Current Value
+ *    - Unit: Ampere
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 0.01 A)
+ *    - Range: 0 to 655.33
+ *  - Standard Deviation Electric Current Value
+ *    - Unit: Ampere
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 0.01 A)
+ *    - Range: 0 to 655.33
+ *  - Minimum Electric Current Value
+ *    - Unit: Ampere
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 0.01 A)
+ *    - Range: 0 to 655.33
+ *  - Maximum Electric Current Value
+ *    - Unit: Ampere
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 0.01 A)
+ *    - Range: 0 to 655.33
+ *  - Sensing Duration
+ *    - Unit: Seconds
+ *    - Encoding: 8 bit unsigned exponential time (pow(1.1, N - 64) seconds)
+ *    - Range: 0 to 73216705
+ */
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_output_current_stat;
+
+/** Output ripple voltage specification
+ *
+ *  Channels:
+ *  - Output Ripple Voltage
+ *    - Unit: Percent
+ *    - Encoding: 8 bit unsigned scalar (Resolution: 0.5 %)
+ *    - Range: 0 to 100.0
+ */
+extern const struct bt_mesh_sensor_type
+	bt_mesh_sensor_output_ripple_voltage_spec;
+
+/** Output voltage range
+ *
+ *  This sensor type should be used as a sensor setting.
+ *
+ *  Channels:
+ *  - Minimum Voltage Value
+ *    - Unit: Volt
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 1/64 V)
+ *    - Range: 0 to 1023.95
+ *  - Maximum Voltage Value
+ *    - Unit: Volt
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 1/64 V)
+ *    - Range: 0 to 1023.95
+ */
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_output_voltage_range;
+
+/** Output voltage statistics
+ *
+ *  Channels:
+ *  - Average Voltage Value
+ *    - Unit: Volt
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 1/64 V)
+ *    - Range: 0 to 1023.95
+ *  - Standard Deviation Voltage Value
+ *    - Unit: Volt
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 1/64 V)
+ *    - Range: 0 to 1023.95
+ *  - Minimum Voltage Value
+ *    - Unit: Volt
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 1/64 V)
+ *    - Range: 0 to 1023.95
+ *  - Maximum Voltage Value
+ *    - Unit: Volt
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 1/64 V)
+ *    - Range: 0 to 1023.95
+ *  - Sensing Duration
+ *    - Unit: Seconds
+ *    - Encoding: 8 bit unsigned exponential time (pow(1.1, N - 64) seconds)
+ *    - Range: 0 to 73216705
+ */
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_output_voltage_stat;
+
+/** Present output current
+ *
+ *  Channels:
+ *  - Present Output Current
+ *    - Unit: Ampere
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 0.01 A)
+ *    - Range: 0 to 655.33
+ */
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_present_output_current;
+
+/** Present output voltage
+ *
+ *  Channels:
+ *  - Present Output Voltage
+ *    - Unit: Volt
+ *    - Encoding: 16 bit unsigned scalar (Resolution: 1/64 V)
+ *    - Range: 0 to 1023.95
+ */
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_present_output_voltage;
+
+/** Present relative output ripple voltage
+ *
+ *  Channels:
+ *  - Output Ripple Voltage
+ *    - Unit: Percent
+ *    - Encoding: 8 bit unsigned scalar (Resolution: 0.5 %)
+ *    - Range: 0 to 100.0
+ */
+extern const struct bt_mesh_sensor_type
+	bt_mesh_sensor_present_rel_output_ripple_voltage;
+
+/** @} */
+
+/** @defgroup bt_mesh_sensor_types_warranty_and_service Warranty and service
+ *  sensor types
+ *  @{
+ */
+
+/** Sensor Gain
+ *
+ *  This sensor type should be used as a sensor setting.
+ *
+ *  Channels:
+ *  - Sensor Gain
+ *    - Unit: _unitless_
+ *    - Encoding: 32 bit float
+ */
+extern const struct bt_mesh_sensor_type bt_mesh_sensor_gain;
+
+/** @} */
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BT_MESH_SENSOR_TYPES_H__ */

--- a/include/bluetooth/mesh/sensor_types.rst
+++ b/include/bluetooth/mesh/sensor_types.rst
@@ -1,0 +1,118 @@
+.. _bt_mesh_sensor_types_readme:
+
+Bluetooth Mesh sensor types
+###########################
+
+All sensor types are collected in :file:`include/bluetooth/mesh/sensor_types.h`, and are divided into the following categories:
+
+* :ref:`bt_mesh_sensor_types_occupancy_readme`
+* :ref:`bt_mesh_sensor_types_ambient_temperature_readme`
+* :ref:`bt_mesh_sensor_types_environmental_readme`
+* :ref:`bt_mesh_sensor_types_device_operating_temperature_readme`
+* :ref:`bt_mesh_sensor_types_electrical_input_readme`
+* :ref:`bt_mesh_sensor_types_energy_management_readme`
+* :ref:`bt_mesh_sensor_types_photometry_readme`
+* :ref:`bt_mesh_sensor_types_power_supply_output_readme`
+* :ref:`bt_mesh_sensor_types_warranty_and_service_readme`
+
+To keep the total flash usage down, the sensor types are only instantiated if they're referenced by the application.
+This behavior can be overridden by enabling :option:`CONFIG_BT_MESH_SENSOR_ALL_TYPES`.
+Note that if the Sensor Client is enabled, :option:`CONFIG_BT_MESH_SENSOR_ALL_TYPES` is enabled by default.
+
+Sensor types can be forced into the build by the :c:macro:`BT_MESH_SENSOR_TYPE_FORCE` macro.
+
+Sensor types may only be declared in the ``bt_mesh_sensor_types`` static linker section, and any additional, proprietary sensor types should be added to sensor_types.c, following the existing pattern.
+
+.. doxygengroup:: bt_mesh_sensor_types
+   :project: nrf
+   :content-only:
+
+.. _bt_mesh_sensor_types_occupancy_readme:
+
+Occupancy sensor types
+**********************
+
+.. doxygengroup:: bt_mesh_sensor_types_occupancy
+   :project: nrf
+   :members:
+   :content-only:
+
+.. _bt_mesh_sensor_types_ambient_temperature_readme:
+
+Ambient temperature sensor types
+********************************
+
+.. doxygengroup:: bt_mesh_sensor_types_ambient_temperature
+   :project: nrf
+   :members:
+   :content-only:
+
+.. _bt_mesh_sensor_types_environmental_readme:
+
+Environmental sensor types
+**************************
+
+.. doxygengroup:: bt_mesh_sensor_types_environmental
+   :project: nrf
+   :members:
+   :content-only:
+
+.. _bt_mesh_sensor_types_device_operating_temperature_readme:
+
+Device operating temperature sensor types
+*****************************************
+
+.. doxygengroup:: bt_mesh_sensor_types_device_operating_temperature
+   :project: nrf
+   :members:
+   :content-only:
+
+.. _bt_mesh_sensor_types_electrical_input_readme:
+
+Electrical input sensor types
+*****************************
+
+.. doxygengroup:: bt_mesh_sensor_types_electrical_input
+   :project: nrf
+   :members:
+   :content-only:
+
+.. _bt_mesh_sensor_types_energy_management_readme:
+
+Energy management sensor types
+******************************
+
+.. doxygengroup:: bt_mesh_sensor_types_energy_management
+   :project: nrf
+   :members:
+   :content-only:
+
+.. _bt_mesh_sensor_types_photometry_readme:
+
+Photometry sensor types
+***********************
+
+.. doxygengroup:: bt_mesh_sensor_types_photometry
+   :project: nrf
+   :members:
+   :content-only:
+
+.. _bt_mesh_sensor_types_power_supply_output_readme:
+
+Power supply output sensor types
+********************************
+
+.. doxygengroup:: bt_mesh_sensor_types_power_supply_output
+   :project: nrf
+   :members:
+   :content-only:
+
+.. _bt_mesh_sensor_types_warranty_and_service_readme:
+
+Warranty and Service sensor types
+*********************************
+
+.. doxygengroup:: bt_mesh_sensor_types_warranty_and_service
+   :project: nrf
+   :members:
+   :content-only:

--- a/subsys/bluetooth/mesh/CMakeLists.txt
+++ b/subsys/bluetooth/mesh/CMakeLists.txt
@@ -34,3 +34,11 @@ zephyr_library_sources_ifdef(CONFIG_BT_MESH_LIGHTNESS_SRV lightness_srv.c)
 zephyr_library_sources_ifdef(CONFIG_BT_MESH_LIGHTNESS_CLI lightness_cli.c)
 
 zephyr_library_sources_ifdef(CONFIG_BT_MESH_DK_PROV dk_prov.c)
+
+zephyr_library_sources_ifdef(CONFIG_BT_MESH_SENSOR_SRV sensor_srv.c)
+zephyr_library_sources_ifdef(CONFIG_BT_MESH_SENSOR_CLI sensor_cli.c)
+
+zephyr_library_sources_ifdef(CONFIG_BT_MESH_SENSOR sensor_types.c)
+zephyr_library_sources_ifdef(CONFIG_BT_MESH_SENSOR sensor.c)
+
+zephyr_linker_sources(SECTIONS sensor_types.ld)

--- a/subsys/bluetooth/mesh/Kconfig.models
+++ b/subsys/bluetooth/mesh/Kconfig.models
@@ -192,4 +192,42 @@ endchoice
 endmenu
 endif
 
+
+menuconfig BT_MESH_SENSOR_SRV
+	bool "Sensor Server"
+	select BT_MESH_NRF_MODELS
+	select BT_MESH_SENSOR
+	help
+	  Enable Mesh Sensor Server model.
+
+if BT_MESH_SENSOR_SRV
+
+config BT_MESH_SENSOR_SRV_SENSORS_MAX
+	int "Max number of sensors per server"
+	default 4
+	range 1 189
+	help
+	  The upper boundary of a Sensor Server's sensor count.
+
+
+config BT_MESH_SENSOR_SRV_SETTINGS_MAX
+	int "Max setting parameters per sensor in a server"
+	default 8
+	range 0 189
+	help
+	  Max number of settings parameters each sensor in the
+	  server can have. Only affects the stack allocated response buffer
+	  for the Settings Get message.
+
+endif
+
+config BT_MESH_SENSOR_CLI
+	bool "Sensor Client"
+	select BT_MESH_NRF_MODELS
+	select BT_MESH_SENSOR
+	help
+	  Enable Mesh Sensor Client model.
+
+rsource "Kconfig.sensor"
+
 endmenu

--- a/subsys/bluetooth/mesh/Kconfig.sensor
+++ b/subsys/bluetooth/mesh/Kconfig.sensor
@@ -1,0 +1,41 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+config BT_MESH_SENSOR
+	bool
+
+menu "Bluetooth Mesh Sensors"
+	visible if BT_MESH_SENSOR
+
+config BT_MESH_SENSOR_LABELS
+	bool "Enable Sensor labels"
+	help
+	  Controls the availability of sensor labels for channels and units
+
+config BT_MESH_SENSOR_ALL_TYPES
+	bool "Force all sensor types to be known"
+	default y if BT_MESH_SENSOR_CLI
+	help
+	  Forces all sensor types to be included in the build. This is
+	  useful if the set of sensor types that will be used is unknown at
+	  compile time, but increases ROM usage by about 3.5kB (4kB if labels
+	  are enabled).
+
+config BT_MESH_SENSOR_CHANNELS_MAX
+	int "Max sensor channels"
+	default 5
+	help
+	  Max number of channels in a single sensor. Matches the largest known
+	  number by default.
+
+config BT_MESH_SENSOR_CHANNEL_ENCODED_SIZE_MAX
+	int "Max sensor channel encoded length"
+	default 4
+	help
+	  Longest encoded representation of a single sensor channel.
+	  Matches the largest known size by default.
+
+endmenu

--- a/subsys/bluetooth/mesh/sensor.c
+++ b/subsys/bluetooth/mesh/sensor.c
@@ -1,0 +1,501 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+#include <bluetooth/mesh/sensor.h>
+#include <bluetooth/mesh/properties.h>
+#include "sensor.h"
+#include <stdlib.h>
+#include <string.h>
+
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_MESH_DEBUG_MODEL)
+#define LOG_MODULE_NAME bt_mesh_sensor
+#include "common/log.h"
+
+/** Scale away the sensor_value fraction, to allow integer math */
+#define SENSOR_MILL(_val) ((1000000LL * (_val)->val1) + (_val)->val2)
+
+static enum bt_mesh_sensor_cadence
+sensor_cadence(const struct bt_mesh_sensor_threshold *threshold,
+	       const struct sensor_value *curr)
+{
+	s64_t high_mill = SENSOR_MILL(&threshold->range.high);
+	s64_t low_mill = SENSOR_MILL(&threshold->range.low);
+
+	if (high_mill == low_mill) {
+		return BT_MESH_SENSOR_CADENCE_NORMAL;
+	}
+
+	s64_t curr_mill = SENSOR_MILL(curr);
+	bool in_range = (curr_mill >= MIN(low_mill, high_mill) &&
+			 curr_mill <= MAX(low_mill, high_mill));
+
+	return in_range ? threshold->range.cadence : !threshold->range.cadence;
+}
+
+bool bt_mesh_sensor_delta_threshold(const struct bt_mesh_sensor *sensor,
+				    const struct sensor_value *curr)
+{
+	struct sensor_value delta = {
+		curr->val1 - sensor->state.prev.val1,
+		curr->val2 - sensor->state.prev.val2,
+	};
+	s64_t delta_mill = SENSOR_MILL(&delta);
+	s64_t thrsh_mill;
+
+	if (delta_mill < 0) {
+		delta_mill = -delta_mill;
+		thrsh_mill = SENSOR_MILL(&sensor->state.threshold.delta.down);
+	} else {
+		thrsh_mill = SENSOR_MILL(&sensor->state.threshold.delta.up);
+	}
+
+	/* If the threshold value is a perentage, we should calculate the actual
+	 * threshold value relative to the previous value.
+	 */
+	if (sensor->state.threshold.delta.type ==
+	    BT_MESH_SENSOR_DELTA_PERCENT) {
+		s64_t prev_mill = abs(SENSOR_MILL(&sensor->state.prev));
+
+		thrsh_mill = (prev_mill * thrsh_mill) / (100LL * 1000000LL);
+	}
+
+	BT_DBG("Delta: %u (%d - %d) thrsh: %u", (u32_t)(delta_mill / 1000000L),
+	       (s32_t)curr->val1, (s32_t)sensor->state.prev.val1,
+	       (u32_t)(thrsh_mill / 1000000L));
+
+	return (delta_mill > thrsh_mill);
+}
+
+void bt_mesh_sensor_cadence_set(struct bt_mesh_sensor *sensor,
+				enum bt_mesh_sensor_cadence cadence)
+{
+	sensor->state.fast_pub = (cadence == BT_MESH_SENSOR_CADENCE_FAST);
+}
+
+int sensor_status_id_encode(struct net_buf_simple *buf, u8_t len, u16_t id)
+{
+	if ((len > 0 && len <= 16) && id < 2048) {
+		if (net_buf_simple_tailroom(buf) < 2 + len) {
+			return -ENOMEM;
+		}
+
+		net_buf_simple_add_le16(buf, ((len - 1) << 1) | (id << 5));
+	} else {
+		if (net_buf_simple_tailroom(buf) < 3 + len) {
+			return -ENOMEM;
+		}
+
+		net_buf_simple_add_u8(buf, BIT(0) | (((len - 1) & BIT_MASK(7))
+						     << 1));
+		net_buf_simple_add_le16(buf, id);
+	}
+
+	return 0;
+}
+
+void sensor_status_id_decode(struct net_buf_simple *buf, u8_t *len, u16_t *id)
+{
+	u8_t first = net_buf_simple_pull_u8(buf);
+
+	if (first & BIT(0)) { /* long format */
+		*len = (first >> 1) + 1;
+		*id = net_buf_simple_pull_le16(buf);
+	} else {
+		*len = ((first >> 1) & BIT_MASK(4)) + 1;
+		*id = (first >> 5) | (net_buf_simple_pull_u8(buf) << 3);
+	}
+}
+
+int sensor_value_encode(struct net_buf_simple *buf,
+			const struct bt_mesh_sensor_type *type,
+			const struct sensor_value *values)
+{
+	for (u32_t i = 0; i < type->channel_count; ++i) {
+		int err;
+
+		err = sensor_ch_encode(buf, type->channels[i].format,
+				       &values[i]);
+		if (err) {
+			return err;
+		}
+	}
+
+	return 0;
+}
+
+int sensor_value_decode(struct net_buf_simple *buf,
+			const struct bt_mesh_sensor_type *type,
+			struct sensor_value *values)
+{
+	int err;
+
+	for (u32_t i = 0; i < type->channel_count; ++i) {
+		err = sensor_ch_decode(buf, type->channels[i].format,
+				       &values[i]);
+		if (err) {
+			return err;
+		}
+	}
+
+	return 0;
+}
+
+int sensor_ch_encode(struct net_buf_simple *buf,
+		     const struct bt_mesh_sensor_format *format,
+		     const struct sensor_value *value)
+{
+	return format->encode(format, value, buf);
+}
+
+int sensor_ch_decode(struct net_buf_simple *buf,
+		     const struct bt_mesh_sensor_format *format,
+		     struct sensor_value *value)
+{
+	return format->decode(format, buf, value);
+}
+
+int sensor_status_encode(struct net_buf_simple *buf,
+			 const struct bt_mesh_sensor *sensor,
+			 const struct sensor_value *values)
+{
+	const struct bt_mesh_sensor_type *type = sensor->type;
+	size_t size = 0;
+	int err;
+
+	for (u32_t i = 0; i < type->channel_count; ++i) {
+		size += type->channels[i].format->size;
+	}
+
+	err = sensor_status_id_encode(buf, size, type->id);
+	if (err) {
+		return err;
+	}
+
+	return sensor_value_encode(buf, type, values);
+}
+
+const struct bt_mesh_sensor_format *
+bt_mesh_sensor_column_format_get(const struct bt_mesh_sensor_type *type)
+{
+	if (type->flags & BT_MESH_SENSOR_TYPE_FLAG_SERIES &&
+	    type->channel_count >= 2) {
+		return type->channels[1].format;
+	}
+
+	return &bt_mesh_sensor_format_time_decihour_8;
+}
+
+int sensor_column_encode(struct net_buf_simple *buf,
+			 struct bt_mesh_sensor *sensor,
+			 struct bt_mesh_msg_ctx *ctx,
+			 const struct bt_mesh_sensor_column *col)
+{
+	struct sensor_value values[CONFIG_BT_MESH_SENSOR_CHANNELS_MAX];
+	const struct bt_mesh_sensor_format *col_format;
+	const u64_t width_million =
+		(col->end.val1 - col->start.val1) * 1000000L +
+		(col->end.val2 - col->start.val2);
+	const struct sensor_value width = {
+		.val1 = width_million / 1000000L,
+		.val2 = width_million % 1000000L,
+	};
+	int err;
+
+	BT_DBG("Column width: %s", bt_mesh_sensor_ch_str(&width));
+
+	col_format = bt_mesh_sensor_column_format_get(sensor->type);
+	if (!col_format) {
+		return -ENOTSUP;
+	}
+
+	err = sensor_ch_encode(buf, col_format, &col->start);
+	if (err) {
+		return err;
+	}
+
+	/* The sensor columns are transmitted as start+width, not start+end: */
+	err = sensor_ch_encode(buf, col_format, &width);
+	if (err) {
+		return err;
+	}
+
+	err = sensor->series.get(sensor, ctx, col, values);
+	if (err) {
+		return err;
+	}
+
+	return sensor_value_encode(buf, sensor->type, values);
+}
+
+int sensor_column_decode(
+	struct net_buf_simple *buf, const struct bt_mesh_sensor_type *type,
+	struct bt_mesh_sensor_column *col,
+	struct sensor_value value[CONFIG_BT_MESH_SENSOR_CHANNELS_MAX])
+{
+	const struct bt_mesh_sensor_format *col_format;
+	int err;
+
+	col_format = bt_mesh_sensor_column_format_get(type);
+	err = sensor_ch_decode(buf, col_format, &col->start);
+	if (err) {
+		return err;
+	}
+
+	err = sensor_ch_decode(buf, col_format, &col->end);
+	if (err) {
+		return err;
+	}
+
+	return sensor_value_decode(buf, type, value);
+}
+
+u8_t sensor_value_len(const struct bt_mesh_sensor_type *type)
+{
+	u8_t sum = 0;
+
+	for (int i = 0; i < type->channel_count; ++i) {
+		sum += type->channels[i].format->size;
+	}
+
+	return sum;
+}
+
+/* Several timer values in sensors are encoded in the following scheme:
+ *
+ *     time = pow(1.1 seconds, encoded - 64)
+ *
+ * To keep the lookup table size and processing time down, this is implemented
+ * as a lookup table of the raw value corresponding to every 16th encoded value
+ * and a table of multiplicators. The values of the lookup table are
+ * pow(1.1, (index * 16) - 64) nanoseconds. The values of the multiplicator
+ * array are pow(1.1, index) * 100000. When multiplied by the values in
+ * the lookup, the result is pow(1.1, encoded - 64), because of the following
+ * property of powers:
+ *
+ *     pow(A, B + C) = pow(A, B) * pow(A, C)
+ *
+ * Where in our case, A is 1.1, B is floor((encoded-64), 16) and C is
+ * (encoded % 16).
+ */
+static const u64_t powtime_lookup[] = {
+	2243,	      10307,	    47362,	   217629,
+	1000000,      4594972,	    21113776,	   97017233,
+	445791568,    2048400214,   9412343651,	   43249464815,
+	198730122503, 913159544478, 4195943439113, 19280246755010,
+};
+
+static const u32_t powtime_mul[] = {
+	100000, 110000, 121000, 133100, 146410, 161051, 177156, 194871,
+	214358, 235794, 259374, 285311, 313842, 345227, 379749, 417724,
+};
+
+u8_t sensor_powtime_encode(u64_t raw)
+{
+	if (raw == 0) {
+		return 0;
+	}
+
+	/* Search through the lookup table to find the highest encoding lower
+	 * than the raw value.
+	 */
+	u64_t raw_ns = raw * 1000;
+
+	if (raw_ns < powtime_lookup[0]) {
+		return 1;
+	}
+
+	const u64_t *seed = &powtime_lookup[0];
+
+	for (int i = 1; i < ARRAY_SIZE(powtime_lookup); ++i) {
+		if (raw_ns < powtime_lookup[i]) {
+			seed = &powtime_lookup[i - 1];
+			break;
+		}
+	}
+
+	int i;
+
+	for (i = 0; (i < ARRAY_SIZE(powtime_mul) &&
+		     raw_ns >= (*seed * powtime_mul[i]) / 100000);
+	     i++) {
+	}
+
+	return ARRAY_SIZE(powtime_mul) * (seed - &powtime_lookup[0]) + i - 1;
+}
+
+u64_t sensor_powtime_decode_ns(u8_t val)
+{
+	if (val == 0) {
+		return 0;
+	}
+
+	return (powtime_lookup[val / ARRAY_SIZE(powtime_mul)] *
+		powtime_mul[val % ARRAY_SIZE(powtime_mul)]) /
+	       100000L;
+}
+
+u64_t sensor_powtime_decode(u8_t val)
+{
+	return sensor_powtime_decode_ns(val) / 1000L;
+}
+
+int sensor_cadence_encode(struct net_buf_simple *buf,
+			  const struct bt_mesh_sensor_type *sensor_type,
+			  u8_t fast_period_div, u8_t min_int,
+			  const struct bt_mesh_sensor_threshold *threshold)
+{
+	net_buf_simple_add_u8(buf, ((!!threshold->delta.type) << 7) |
+					   (BIT_MASK(7) & fast_period_div));
+
+	const struct bt_mesh_sensor_format *delta_format =
+		(threshold->delta.type == BT_MESH_SENSOR_DELTA_PERCENT) ?
+			&bt_mesh_sensor_format_percentage_16 :
+			sensor_type->channels[0].format;
+	int err;
+
+	err = sensor_ch_encode(buf, delta_format, &threshold->delta.down);
+	if (err) {
+		return err;
+	}
+
+	err = sensor_ch_encode(buf, delta_format, &threshold->delta.up);
+	if (err) {
+		return err;
+	}
+
+	net_buf_simple_add_u8(buf, min_int);
+
+	/* Flip the order if the cadence is fast outside. */
+	const struct sensor_value *first, *second;
+
+	if (threshold->range.cadence == BT_MESH_SENSOR_CADENCE_FAST) {
+		first = &threshold->range.low;
+		second = &threshold->range.high;
+	} else {
+		first = &threshold->range.high;
+		second = &threshold->range.low;
+	}
+
+	err = sensor_ch_encode(buf, sensor_type->channels[0].format, first);
+	if (err) {
+		return err;
+	}
+
+	return sensor_ch_encode(buf, sensor_type->channels[0].format, second);
+}
+
+int sensor_cadence_decode(struct net_buf_simple *buf,
+			  const struct bt_mesh_sensor_type *sensor_type,
+			  u8_t *fast_period_div, u8_t *min_int,
+			  struct bt_mesh_sensor_threshold *threshold)
+{
+	const struct bt_mesh_sensor_format *delta_format;
+	u8_t div_and_type;
+	int err;
+
+	div_and_type = net_buf_simple_pull_u8(buf);
+	threshold->delta.type = div_and_type >> 7;
+	*fast_period_div = div_and_type & BIT_MASK(7);
+	if (*fast_period_div > BT_MESH_SENSOR_PERIOD_DIV_MAX) {
+		return -EINVAL;
+	}
+
+	delta_format = (threshold->delta.type == BT_MESH_SENSOR_DELTA_PERCENT) ?
+			       &bt_mesh_sensor_format_percentage_16 :
+			       sensor_type->channels[0].format;
+
+	err = sensor_ch_decode(buf, delta_format, &threshold->delta.down);
+	if (err) {
+		return err;
+	}
+
+	err = sensor_ch_decode(buf, delta_format, &threshold->delta.up);
+	if (err) {
+		return err;
+	}
+
+	*min_int = net_buf_simple_pull_u8(buf);
+	if (*min_int > BT_MESH_SENSOR_INTERVAL_MAX) {
+		return -EINVAL;
+	}
+
+	err = sensor_ch_decode(buf, sensor_type->channels[0].format,
+			       &threshold->range.low);
+	if (err) {
+		return err;
+	}
+
+	err = sensor_ch_decode(buf, sensor_type->channels[0].format,
+				&threshold->range.high);
+	if (err) {
+		return err;
+	}
+
+	/* According to the Bluetooth Mesh Model Specification v1.0.1, Section
+	 * 4.1.3.6, if range.high is lower than range.low, the cadence is fast
+	 * outside the range. Swap the two in this case.
+	 */
+	if (threshold->range.high.val1 < threshold->range.low.val1 ||
+	    (threshold->range.high.val1 == threshold->range.low.val1 &&
+	     threshold->range.high.val2 < threshold->range.low.val2)) {
+		struct sensor_value temp;
+
+		temp = threshold->range.high;
+		threshold->range.high = threshold->range.low;
+		threshold->range.low = temp;
+
+		threshold->range.cadence = BT_MESH_SENSOR_CADENCE_NORMAL;
+	} else {
+		threshold->range.cadence = BT_MESH_SENSOR_CADENCE_FAST;
+	}
+
+	return 0;
+}
+
+u8_t sensor_pub_div_get(const struct bt_mesh_sensor *s, u32_t base_period)
+{
+	u8_t div = s->state.pub_div * s->state.fast_pub;
+
+	while (div != 0 && (base_period >> div) < (1 << s->state.min_int)) {
+		div--;
+	}
+
+	return div;
+}
+
+bool bt_mesh_sensor_value_in_column(const struct sensor_value *value,
+				    const struct bt_mesh_sensor_column *col)
+{
+	return (value->val1 > col->start.val1 ||
+		(value->val1 == col->start.val1 &&
+		 value->val2 >= col->start.val2)) &&
+	       (value->val1 < col->end.val1 ||
+		(value->val1 == col->end.val1 && value->val2 <= col->end.val2));
+}
+
+void sensor_cadence_update(struct bt_mesh_sensor *sensor,
+			   const struct sensor_value *value)
+{
+	enum bt_mesh_sensor_cadence new;
+
+	new = sensor_cadence(&sensor->state.threshold, value);
+
+	if (sensor->state.fast_pub != new) {
+		BT_DBG("0x%04x new cadence: %s", sensor->type->id,
+		       (new == BT_MESH_SENSOR_CADENCE_FAST) ? "fast" :
+							      "normal");
+	}
+
+	sensor->state.fast_pub = new;
+}
+
+const char *bt_mesh_sensor_ch_str_real(const struct sensor_value *ch)
+{
+	static char str[BT_MESH_SENSOR_CH_STR_LEN];
+
+	bt_mesh_sensor_ch_to_str(ch, str, sizeof(str));
+
+	return str;
+}

--- a/subsys/bluetooth/mesh/sensor.h
+++ b/subsys/bluetooth/mesh/sensor.h
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+/**
+ * @file
+ * @brief Internal sensor API
+ */
+
+#ifndef BT_MESH_INTERNAL_SENSOR_H__
+#define BT_MESH_INTERNAL_SENSOR_H__
+
+#include <bluetooth/mesh/sensor.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @defgroup BT_MESH_SENSOR_FORMATS Sensor channel formats
+ * @brief All available sensor channel formats in the Mesh Device Properties
+ *        Specification.
+ * @{
+ */
+
+/* Percentage formats */
+extern const struct bt_mesh_sensor_format bt_mesh_sensor_format_percentage_8;
+extern const struct bt_mesh_sensor_format bt_mesh_sensor_format_percentage_16;
+
+/* Environmental formats */
+extern const struct bt_mesh_sensor_format bt_mesh_sensor_format_temp_8;
+extern const struct bt_mesh_sensor_format bt_mesh_sensor_format_temp;
+extern const struct bt_mesh_sensor_format bt_mesh_sensor_format_humidity;
+extern const struct bt_mesh_sensor_format
+	bt_mesh_sensor_format_co2_concentration;
+extern const struct bt_mesh_sensor_format
+	bt_mesh_sensor_format_voc_concentration;
+extern const struct bt_mesh_sensor_format bt_mesh_sensor_format_noise;
+
+/* Time formats */
+extern const struct bt_mesh_sensor_format bt_mesh_sensor_format_time_decihour_8;
+extern const struct bt_mesh_sensor_format bt_mesh_sensor_format_time_hour_24;
+extern const struct bt_mesh_sensor_format bt_mesh_sensor_format_time_second_16;
+extern const struct bt_mesh_sensor_format bt_mesh_sensor_format_time_exp_8;
+
+/* Electrical formats */
+extern const struct bt_mesh_sensor_format
+	bt_mesh_sensor_format_electric_current;
+extern const struct bt_mesh_sensor_format bt_mesh_sensor_format_voltage;
+extern const struct bt_mesh_sensor_format bt_mesh_sensor_format_energy;
+extern const struct bt_mesh_sensor_format bt_mesh_sensor_format_energy32;
+extern const struct bt_mesh_sensor_format bt_mesh_sensor_format_power;
+
+/* Lighting formats */
+extern const struct bt_mesh_sensor_format
+	bt_mesh_sensor_format_chromatic_distance;
+extern const struct bt_mesh_sensor_format
+	bt_mesh_sensor_format_chromaticity_coordinate;
+extern const struct bt_mesh_sensor_format
+	bt_mesh_sensor_format_correlated_color_temp;
+extern const struct bt_mesh_sensor_format bt_mesh_sensor_format_illuminance;
+extern const struct bt_mesh_sensor_format
+	bt_mesh_sensor_format_luminous_efficacy;
+extern const struct bt_mesh_sensor_format bt_mesh_sensor_format_luminous_energy;
+extern const struct bt_mesh_sensor_format
+	bt_mesh_sensor_format_luminous_exposure;
+extern const struct bt_mesh_sensor_format bt_mesh_sensor_format_luminous_flux;
+
+/* Miscellaneous formats */
+extern const struct bt_mesh_sensor_format bt_mesh_sensor_format_count_16;
+extern const struct bt_mesh_sensor_format bt_mesh_sensor_format_gen_lvl;
+extern const struct bt_mesh_sensor_format
+	bt_mesh_sensor_format_cos_of_the_angle;
+extern const struct bt_mesh_sensor_format bt_mesh_sensor_format_boolean;
+extern const struct bt_mesh_sensor_format bt_mesh_sensor_format_coefficient;
+
+/** @} */
+
+/**
+ * @defgroup BT_MESH_SENSOR_UNITS Sensor value units
+ * @brief All available sensor value units in the Mesh Device Properties
+ *        Specification.
+ * @{
+ */
+extern const struct bt_mesh_sensor_unit bt_mesh_sensor_unit_hours;
+extern const struct bt_mesh_sensor_unit bt_mesh_sensor_unit_seconds;
+extern const struct bt_mesh_sensor_unit bt_mesh_sensor_unit_celsius;
+extern const struct bt_mesh_sensor_unit bt_mesh_sensor_unit_kelvin;
+extern const struct bt_mesh_sensor_unit bt_mesh_sensor_unit_percent;
+extern const struct bt_mesh_sensor_unit bt_mesh_sensor_unit_ppm;
+extern const struct bt_mesh_sensor_unit bt_mesh_sensor_unit_ppb;
+extern const struct bt_mesh_sensor_unit bt_mesh_sensor_unit_volt;
+extern const struct bt_mesh_sensor_unit bt_mesh_sensor_unit_ampere;
+extern const struct bt_mesh_sensor_unit bt_mesh_sensor_unit_watt;
+extern const struct bt_mesh_sensor_unit bt_mesh_sensor_unit_kwh;
+extern const struct bt_mesh_sensor_unit bt_mesh_sensor_unit_db;
+extern const struct bt_mesh_sensor_unit bt_mesh_sensor_unit_lux;
+extern const struct bt_mesh_sensor_unit bt_mesh_sensor_unit_lux_hour;
+extern const struct bt_mesh_sensor_unit bt_mesh_sensor_unit_lumen;
+extern const struct bt_mesh_sensor_unit bt_mesh_sensor_unit_lumen_per_watt;
+extern const struct bt_mesh_sensor_unit bt_mesh_sensor_unit_lumen_hour;
+extern const struct bt_mesh_sensor_unit bt_mesh_sensor_unit_gram_per_sec;
+extern const struct bt_mesh_sensor_unit bt_mesh_sensor_unit_litre_per_sec;
+extern const struct bt_mesh_sensor_unit bt_mesh_sensor_unit_unitless;
+
+/** @} */
+
+int sensor_status_encode(struct net_buf_simple *buf,
+			 const struct bt_mesh_sensor *sensor,
+			 const struct sensor_value *values);
+
+int sensor_status_id_encode(struct net_buf_simple *buf, u8_t len, u16_t id);
+void sensor_status_id_decode(struct net_buf_simple *buf, u8_t *len, u16_t *id);
+
+int sensor_value_encode(struct net_buf_simple *buf,
+			const struct bt_mesh_sensor_type *type,
+			const struct sensor_value *values);
+int sensor_value_decode(struct net_buf_simple *buf,
+			const struct bt_mesh_sensor_type *type,
+			struct sensor_value *values);
+
+int sensor_ch_encode(struct net_buf_simple *buf,
+		     const struct bt_mesh_sensor_format *format,
+		     const struct sensor_value *value);
+int sensor_ch_decode(struct net_buf_simple *buf,
+		     const struct bt_mesh_sensor_format *format,
+		     struct sensor_value *value);
+
+int sensor_column_encode(struct net_buf_simple *buf,
+			 struct bt_mesh_sensor *sensor,
+			 struct bt_mesh_msg_ctx *ctx,
+			 const struct bt_mesh_sensor_column *col);
+int sensor_column_decode(
+	struct net_buf_simple *buf, const struct bt_mesh_sensor_type *type,
+	struct bt_mesh_sensor_column *col,
+	struct sensor_value value[CONFIG_BT_MESH_SENSOR_CHANNELS_MAX]);
+
+int sensor_cadence_encode(struct net_buf_simple *buf,
+			  const struct bt_mesh_sensor_type *sensor_type,
+			  u8_t fast_period_div, u8_t min_int,
+			  const struct bt_mesh_sensor_threshold *threshold);
+int sensor_cadence_decode(struct net_buf_simple *buf,
+			  const struct bt_mesh_sensor_type *sensor_type,
+			  u8_t *fast_period_div, u8_t *min_int,
+			  struct bt_mesh_sensor_threshold *threshold);
+u8_t sensor_value_len(const struct bt_mesh_sensor_type *type);
+
+u8_t sensor_powtime_encode(u64_t raw);
+u64_t sensor_powtime_decode(u8_t encoded);
+u64_t sensor_powtime_decode_ns(u8_t val);
+
+u8_t sensor_pub_div_get(const struct bt_mesh_sensor *s, u32_t base_period);
+
+void sensor_cadence_update(struct bt_mesh_sensor *sensor,
+			   const struct sensor_value *value);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BT_MESH_INTERNAL_SENSOR_H__ */

--- a/subsys/bluetooth/mesh/sensor_cli.c
+++ b/subsys/bluetooth/mesh/sensor_cli.c
@@ -1,0 +1,922 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#include <stdlib.h>
+#include <bluetooth/mesh/sensor_cli.h>
+#include <bluetooth/mesh/properties.h>
+#include "model_utils.h"
+#include "sensor.h"
+
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_MESH_DEBUG_MODEL)
+#define LOG_MODULE_NAME bt_mesh_sensor_cli
+#include "common/log.h"
+
+struct list_rsp {
+	struct bt_mesh_sensor_info *sensors;
+	u32_t count;
+};
+
+struct settings_rsp {
+	u16_t id;
+	u16_t *ids;
+	u32_t count;
+};
+
+struct setting_rsp {
+	u16_t id;
+	u16_t setting_id;
+	struct bt_mesh_sensor_setting_status *setting;
+};
+
+struct sensor_data_rsp {
+	u16_t id;
+	struct sensor_value *value;
+};
+
+struct series_data_rsp {
+	struct bt_mesh_sensor_series_entry *entries;
+	const struct bt_mesh_sensor_column *col;
+	u16_t id;
+	u32_t count;
+};
+
+struct cadence_rsp {
+	u16_t id;
+	struct bt_mesh_sensor_cadence_status *cadence;
+};
+
+static void tolerance_decode(u16_t encoded, struct sensor_value *tolerance)
+{
+	u32_t toll_mill = (encoded * 100ULL * 1000000ULL) / 4095ULL;
+
+	tolerance->val1 = toll_mill / 1000000ULL;
+	tolerance->val2 = toll_mill % 1000000ULL;
+}
+
+static void unknown_type(struct bt_mesh_sensor_cli *cli,
+			 struct bt_mesh_msg_ctx *ctx, u16_t id, u32_t op)
+{
+	if (cli->cb && cli->cb->unknown_type) {
+		cli->cb->unknown_type(cli, ctx, id, op);
+	}
+}
+
+static void handle_descriptor_status(struct bt_mesh_model *mod,
+				     struct bt_mesh_msg_ctx *ctx,
+				     struct net_buf_simple *buf)
+{
+	if (buf->len != 2 && buf->len % 8) {
+		return;
+	}
+
+	struct bt_mesh_sensor_cli *cli = mod->user_data;
+	struct list_rsp *ack_ctx = cli->ack.user_data;
+	u32_t count = 0;
+	bool is_rsp;
+
+	is_rsp = model_ack_match(&cli->ack, BT_MESH_SENSOR_OP_DESCRIPTOR_STATUS,
+				 ctx);
+
+	/* A packet with only the sensor ID means that the given sensor doesn't
+	 * exist on the sensor server.
+	 */
+	if (buf->len == 2) {
+		ack_ctx->count = 0;
+		goto yield_ack;
+	}
+
+	struct bt_mesh_sensor_info sensor;
+
+	while (buf->len >= 8) {
+		u32_t tolerances;
+
+		sensor.id = net_buf_simple_pull_le16(buf);
+		tolerances = net_buf_simple_pull_le24(buf);
+		tolerance_decode(tolerances & BIT_MASK(12),
+				 &sensor.descriptor.tolerance.positive);
+		tolerance_decode(tolerances >> 12,
+				 &sensor.descriptor.tolerance.negative);
+		sensor.descriptor.sampling_type = net_buf_simple_pull_u8(buf);
+		sensor.descriptor.period =
+			sensor_powtime_decode(net_buf_simple_pull_u8(buf));
+		sensor.descriptor.update_interval =
+			sensor_powtime_decode(net_buf_simple_pull_u8(buf));
+
+		if (cli->cb && cli->cb->sensor) {
+			cli->cb->sensor(cli, ctx, &sensor);
+		}
+
+		if (is_rsp && count < ack_ctx->count) {
+			ack_ctx->sensors[count++] = sensor;
+		}
+	}
+
+yield_ack:
+	if (is_rsp) {
+		ack_ctx->count = count;
+		model_ack_rx(&cli->ack);
+	}
+}
+
+static void handle_status(struct bt_mesh_model *mod,
+			  struct bt_mesh_msg_ctx *ctx,
+			  struct net_buf_simple *buf)
+{
+	struct bt_mesh_sensor_cli *cli = mod->user_data;
+	struct sensor_data_rsp *rsp = cli->ack.user_data;
+	bool is_rsp;
+	int err;
+
+	is_rsp = model_ack_match(&cli->ack, BT_MESH_SENSOR_OP_STATUS, ctx);
+
+	while (buf->len > 3) {
+		const struct bt_mesh_sensor_type *type;
+		u8_t length;
+		u16_t id;
+
+		sensor_status_id_decode(buf, &length, &id);
+		if (length == 0) {
+			if (is_rsp && rsp->id == id) {
+				rsp->value = NULL;
+				rsp->id = BT_MESH_PROP_ID_PROHIBITED;
+				model_ack_rx(&cli->ack);
+			}
+
+			continue;
+		}
+
+		type = bt_mesh_sensor_type_get(id);
+		if (!type) {
+			net_buf_simple_pull(buf, length);
+			unknown_type(cli, ctx, id, BT_MESH_SENSOR_OP_STATUS);
+			continue;
+		}
+
+		u8_t expected_len = sensor_value_len(type);
+
+		if (length != expected_len) {
+			BT_WARN("Invalid length for 0x%04x: %u (expected %u)",
+				id, length, expected_len);
+			return;
+		}
+
+		struct sensor_value value[CONFIG_BT_MESH_SENSOR_CHANNELS_MAX];
+
+		err = sensor_value_decode(buf, type, value);
+		if (err) {
+			return; /* Invalid format, should ignore message */
+		}
+
+		if (cli->cb && cli->cb->data) {
+			cli->cb->data(cli, ctx, type, value);
+		}
+
+		if (is_rsp && rsp->id == id) {
+			memcpy(rsp->value, value,
+			       sizeof(struct sensor_value) *
+				       type->channel_count);
+			rsp->id = BT_MESH_PROP_ID_PROHIBITED;
+			model_ack_rx(&cli->ack);
+		}
+	}
+}
+
+static int parse_series_entry(const struct bt_mesh_sensor_type *type,
+			      const struct bt_mesh_sensor_format *col_format,
+			      struct net_buf_simple *buf,
+			      struct bt_mesh_sensor_series_entry *entry)
+{
+	int err;
+
+	err = sensor_ch_decode(buf, col_format, &entry->column.start);
+	if (err) {
+		return err;
+	}
+
+	if (buf->len == 0) {
+		BT_WARN("The requested column didn't exist: %s",
+			bt_mesh_sensor_ch_str(&entry->column.start));
+		return -ENOENT;
+	}
+
+	struct sensor_value width;
+
+	err = sensor_ch_decode(buf, col_format, &width);
+	if (err) {
+		return err;
+	}
+
+	u64_t end_mill = (entry->column.start.val1 + width.val1) * 1000000L +
+			 (entry->column.start.val2 + width.val2);
+
+	entry->column.end.val1 = end_mill / 1000000L;
+	entry->column.end.val2 = end_mill % 1000000L;
+
+	return sensor_value_decode(buf, type, entry->value);
+}
+
+static void handle_column_status(struct bt_mesh_model *mod,
+				 struct bt_mesh_msg_ctx *ctx,
+				 struct net_buf_simple *buf)
+{
+	struct bt_mesh_sensor_cli *cli = mod->user_data;
+	struct series_data_rsp *rsp = cli->ack.user_data;
+	const struct bt_mesh_sensor_format *col_format;
+	const struct bt_mesh_sensor_type *type;
+	int err;
+
+	u16_t id = net_buf_simple_pull_le16(buf);
+
+	type = bt_mesh_sensor_type_get(id);
+	if (!type) {
+		unknown_type(cli, ctx, id, BT_MESH_SENSOR_OP_COLUMN_STATUS);
+		return;
+	}
+
+	col_format = bt_mesh_sensor_column_format_get(type);
+	if (!col_format) {
+		BT_WARN("Received unsupported column format 0x%04x", id);
+		return;
+	}
+
+	struct bt_mesh_sensor_series_entry entry;
+
+	err = parse_series_entry(type, col_format, buf, &entry);
+	if (err == -ENOENT) {
+		/* The entry doesn't exist */
+		goto yield_ack;
+	}
+
+	if (err) {
+		return; /* Invalid format, should ignore message */
+	}
+
+	if (cli->cb && cli->cb->series_entry) {
+		cli->cb->series_entry(cli, ctx, type, 0, 1, &entry);
+	}
+
+yield_ack:
+	if (model_ack_match(&cli->ack, BT_MESH_SENSOR_OP_COLUMN_STATUS, ctx) &&
+	    rsp->col->start.val1 == entry.column.start.val1 &&
+	    rsp->col->start.val2 == entry.column.start.val2) {
+		if (err) {
+			rsp->count = 0;
+		} else {
+			rsp->entries[0] = entry;
+			rsp->count = 1;
+		}
+		model_ack_rx(&cli->ack);
+	}
+}
+
+static void handle_series_status(struct bt_mesh_model *mod,
+				 struct bt_mesh_msg_ctx *ctx,
+				 struct net_buf_simple *buf)
+{
+	struct bt_mesh_sensor_cli *cli = mod->user_data;
+	const struct bt_mesh_sensor_format *col_format;
+	const struct bt_mesh_sensor_type *type;
+	struct series_data_rsp *rsp = NULL;
+
+	u16_t id = net_buf_simple_pull_le16(buf);
+
+	type = bt_mesh_sensor_type_get(id);
+	if (!type) {
+		unknown_type(cli, ctx, id, BT_MESH_SENSOR_OP_SERIES_STATUS);
+		return;
+	}
+
+	if (model_ack_match(&cli->ack, BT_MESH_SENSOR_OP_SERIES_STATUS, ctx) &&
+	    rsp->id == id) {
+		rsp = cli->ack.user_data;
+	}
+
+	col_format = bt_mesh_sensor_column_format_get(type);
+	if (!col_format) {
+		BT_WARN("Received unsupported column format 0x%04x", id);
+
+		if (rsp) {
+			rsp->count = 0;
+			model_ack_rx(&cli->ack);
+		}
+
+		return;
+	}
+
+	u8_t count = buf->len / col_format->size * 2 + sensor_value_len(type);
+
+	for (u8_t i = 0; i < count; i++) {
+		struct bt_mesh_sensor_series_entry entry;
+
+		(void)parse_series_entry(type, col_format, buf, &entry);
+
+		if (cli->cb && cli->cb->series_entry) {
+			cli->cb->series_entry(cli, ctx, type, i, count, &entry);
+		}
+
+		if (rsp && i < rsp->count) {
+			rsp->entries[i] = entry;
+		}
+	}
+
+	if (rsp) {
+		rsp->count = count;
+		model_ack_rx(&cli->ack);
+	}
+}
+
+static void handle_cadence_status(struct bt_mesh_model *mod,
+				  struct bt_mesh_msg_ctx *ctx,
+				  struct net_buf_simple *buf)
+{
+	struct bt_mesh_sensor_cli *cli = mod->user_data;
+	struct cadence_rsp *rsp = cli->ack.user_data;
+	int err;
+
+	u16_t id = net_buf_simple_pull_le16(buf);
+	const struct bt_mesh_sensor_type *type = bt_mesh_sensor_type_get(id);
+
+	if (!type) {
+		unknown_type(cli, ctx, id, BT_MESH_SENSOR_OP_CADENCE_STATUS);
+		return;
+	}
+
+	if (buf->len == 0 || type->channel_count != 1) {
+		BT_WARN("Type 0x%04x doesn't support cadence", id);
+		err = -ENOTSUP;
+		goto yield_ack;
+	}
+
+	struct bt_mesh_sensor_cadence_status cadence;
+
+	err = sensor_cadence_decode(buf, type, &cadence.fast_period_div,
+				    &cadence.min_int, &cadence.threshold);
+	if (err) {
+		return;
+	}
+
+	if (cli->cb && cli->cb->cadence) {
+		cli->cb->cadence(cli, ctx, type, &cadence);
+	}
+
+yield_ack:
+	if (model_ack_match(&cli->ack, BT_MESH_SENSOR_OP_CADENCE_STATUS, ctx) &&
+	    rsp->id == id) {
+		if (err) {
+			rsp->cadence = NULL;
+		} else {
+			*rsp->cadence = cadence;
+		}
+
+		model_ack_rx(&cli->ack);
+	}
+}
+
+static void handle_settings_status(struct bt_mesh_model *mod,
+				   struct bt_mesh_msg_ctx *ctx,
+				   struct net_buf_simple *buf)
+{
+	struct bt_mesh_sensor_cli *cli = mod->user_data;
+	struct settings_rsp *rsp = cli->ack.user_data;
+
+	if (buf->len % 2) {
+		return;
+	}
+
+	u16_t id = net_buf_simple_pull_le16(buf);
+	const struct bt_mesh_sensor_type *type = bt_mesh_sensor_type_get(id);
+
+	if (!type) {
+		unknown_type(cli, ctx, id, BT_MESH_SENSOR_OP_SETTINGS_STATUS);
+		return;
+	}
+
+	/* The list may be unaligned: */
+	u16_t ids[(CONFIG_BT_MESH_RX_SDU_MAX -
+		   BT_MESH_MODEL_OP_LEN(BT_MESH_SENSOR_OP_SETTINGS_STATUS) -
+		   2) /
+		  sizeof(u16_t)];
+	u32_t count = buf->len / 2;
+
+	memcpy(ids, net_buf_simple_pull_mem(buf, buf->len),
+	       count * sizeof(ids));
+
+	if (cli->cb && cli->cb->settings) {
+		cli->cb->settings(cli, ctx, type, ids, count);
+	}
+
+	if (model_ack_match(&cli->ack, BT_MESH_SENSOR_OP_SETTINGS_STATUS,
+			    ctx) &&
+	    rsp->id == id) {
+		memcpy(rsp->ids, ids, sizeof(u16_t) * MIN(count, rsp->count));
+		rsp->count = count;
+		model_ack_rx(&cli->ack);
+	}
+}
+
+static void handle_setting_status(struct bt_mesh_model *mod,
+				  struct bt_mesh_msg_ctx *ctx,
+				  struct net_buf_simple *buf)
+{
+	struct bt_mesh_sensor_cli *cli = mod->user_data;
+	struct setting_rsp *rsp = cli->ack.user_data;
+	int err;
+
+	u16_t id = net_buf_simple_pull_le16(buf);
+	u16_t setting_id = net_buf_simple_pull_le16(buf);
+	struct bt_mesh_sensor_setting_status setting;
+	u8_t access;
+
+	if (buf->len == 0) {
+		setting.type = NULL;
+		goto yield_ack;
+	}
+
+	access = net_buf_simple_pull_u8(buf);
+	if (access != 0x01 && access != 0x03) {
+		return;
+	}
+
+	const struct bt_mesh_sensor_type *type = bt_mesh_sensor_type_get(id);
+
+	if (!type) {
+		unknown_type(cli, ctx, id, BT_MESH_SENSOR_OP_SETTING_STATUS);
+		return;
+	}
+
+
+	setting.type = bt_mesh_sensor_type_get(setting_id);
+	if (!setting.type) {
+		unknown_type(
+			cli, ctx, setting_id, BT_MESH_SENSOR_OP_SETTING_STATUS);
+		return;
+	}
+
+	setting.writable = (access == 0x03);
+
+	/* If we attempted setting an unwritable value, the server omits the
+	 * setting value. This is a legal response, but it should make the set()
+	 * function return -EACCES.
+	 */
+	if (buf->len == 0 && !setting.writable) {
+		goto yield_ack;
+	}
+
+	err = sensor_value_decode(buf, setting.type, setting.value);
+	if (err) {
+		return;
+	}
+
+	if (cli->cb && cli->cb->setting_status) {
+		cli->cb->setting_status(cli, ctx, type, &setting);
+	}
+
+yield_ack:
+	if (model_ack_match(&cli->ack, BT_MESH_SENSOR_OP_SETTING_STATUS, ctx) &&
+	    rsp->id == id && rsp->setting_id == setting_id) {
+		*rsp->setting = setting;
+		model_ack_rx(&cli->ack);
+	}
+}
+
+const struct bt_mesh_model_op _bt_mesh_sensor_cli_op[] = {
+	{ BT_MESH_SENSOR_OP_DESCRIPTOR_STATUS,
+	  BT_MESH_SENSOR_MSG_MINLEN_DESCRIPTOR_STATUS,
+	  handle_descriptor_status },
+	{ BT_MESH_SENSOR_OP_STATUS, BT_MESH_SENSOR_MSG_MINLEN_STATUS,
+	  handle_status },
+	{ BT_MESH_SENSOR_OP_COLUMN_STATUS,
+	  BT_MESH_SENSOR_MSG_MINLEN_COLUMN_STATUS, handle_column_status },
+	{ BT_MESH_SENSOR_OP_SERIES_STATUS,
+	  BT_MESH_SENSOR_MSG_MINLEN_SERIES_STATUS, handle_series_status },
+	{ BT_MESH_SENSOR_OP_CADENCE_STATUS,
+	  BT_MESH_SENSOR_MSG_MINLEN_CADENCE_STATUS, handle_cadence_status },
+	{ BT_MESH_SENSOR_OP_SETTINGS_STATUS,
+	  BT_MESH_SENSOR_MSG_MINLEN_SETTINGS_STATUS, handle_settings_status },
+	{ BT_MESH_SENSOR_OP_SETTING_STATUS,
+	  BT_MESH_SENSOR_MSG_MINLEN_SETTING_STATUS, handle_setting_status },
+};
+
+static int sensor_cli_init(struct bt_mesh_model *mod)
+{
+	struct bt_mesh_sensor_cli *cli = mod->user_data;
+
+	cli->mod = mod;
+
+	net_buf_simple_init(cli->pub.msg, 0);
+
+	return 0;
+}
+
+const struct bt_mesh_model_cb _bt_mesh_sensor_cli_cb = {
+	.init = sensor_cli_init,
+};
+
+int bt_mesh_sensor_cli_list_get(struct bt_mesh_sensor_cli *cli,
+				struct bt_mesh_msg_ctx *ctx,
+				struct bt_mesh_sensor_info *sensors,
+				u32_t *count)
+{
+	int err;
+
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_SENSOR_OP_DESCRIPTOR_GET, 0);
+	bt_mesh_model_msg_init(&msg, BT_MESH_SENSOR_OP_DESCRIPTOR_GET);
+
+	struct list_rsp list_rsp = {
+		.sensors = sensors,
+		.count = *count,
+	};
+
+	err = model_ackd_send(cli->mod, ctx, &msg, sensors ? &cli->ack : NULL,
+			      BT_MESH_SENSOR_OP_DESCRIPTOR_STATUS, &list_rsp);
+
+	*count = list_rsp.count;
+	return err;
+}
+
+int bt_mesh_sensor_cli_desc_get(struct bt_mesh_sensor_cli *cli,
+				struct bt_mesh_msg_ctx *ctx,
+				struct bt_mesh_sensor_type *sensor,
+				struct bt_mesh_sensor_descriptor *rsp)
+{
+	int err;
+
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_SENSOR_OP_DESCRIPTOR_GET, 2);
+	bt_mesh_model_msg_init(&msg, BT_MESH_SENSOR_OP_DESCRIPTOR_GET);
+
+	net_buf_simple_add_le16(&msg, sensor->id);
+
+	struct bt_mesh_sensor_info info = {
+		sensor->id,
+	};
+	struct list_rsp list_rsp = {
+		.sensors = &info,
+		.count = 1,
+	};
+
+	err = model_ackd_send(cli->mod, ctx, &msg, rsp ? &cli->ack : NULL,
+			      BT_MESH_SENSOR_OP_DESCRIPTOR_STATUS, &list_rsp);
+	if (err) {
+		return err;
+	}
+
+	if (list_rsp.count == 0) {
+		return -ENOTSUP;
+	}
+
+	if (rsp) {
+		*rsp = info.descriptor;
+	}
+
+	return 0;
+}
+
+int bt_mesh_sensor_cli_cadence_get(struct bt_mesh_sensor_cli *cli,
+				   struct bt_mesh_msg_ctx *ctx,
+				   struct bt_mesh_sensor_type *sensor,
+				   struct bt_mesh_sensor_cadence_status *rsp)
+{
+	if (sensor->channel_count != 1) {
+		return -ENOTSUP;
+	}
+
+	int err;
+
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_SENSOR_OP_CADENCE_GET, 2);
+	bt_mesh_model_msg_init(&msg, BT_MESH_SENSOR_OP_CADENCE_GET);
+
+	net_buf_simple_add_le16(&msg, sensor->id);
+
+	struct cadence_rsp rsp_data = {
+		.id = sensor->id,
+		.cadence = rsp,
+	};
+
+	err = model_ackd_send(cli->mod, ctx, &msg, rsp ? &cli->ack : NULL,
+			       BT_MESH_SENSOR_OP_CADENCE_STATUS, &rsp_data);
+	if (err) {
+		return err;
+	}
+
+	/* Status handler clears the cadence member if server indicates that
+	 * cadence isn't supported.
+	 */
+	if (rsp && !rsp_data.cadence) {
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+int bt_mesh_sensor_cli_cadence_set(
+	struct bt_mesh_sensor_cli *cli, struct bt_mesh_msg_ctx *ctx,
+	struct bt_mesh_sensor_type *sensor,
+	const struct bt_mesh_sensor_cadence_status *cadence,
+	struct bt_mesh_sensor_cadence_status *rsp)
+{
+	if (sensor->channel_count != 1) {
+		return -ENOTSUP;
+	}
+
+	int err;
+
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_SENSOR_OP_CADENCE_SET,
+				 BT_MESH_SENSOR_MSG_MAXLEN_CADENCE_SET);
+	bt_mesh_model_msg_init(&msg, BT_MESH_SENSOR_OP_CADENCE_SET);
+
+	net_buf_simple_add_le16(&msg, sensor->id);
+
+	struct cadence_rsp rsp_data = {
+		.id = sensor->id,
+		.cadence = rsp,
+	};
+
+	err = sensor_cadence_encode(&msg, sensor, cadence->fast_period_div,
+				    cadence->min_int, &cadence->threshold);
+	if (err) {
+		return err;
+	}
+
+	err = model_ackd_send(cli->mod, ctx, &msg, rsp ? &cli->ack : NULL,
+			      BT_MESH_SENSOR_OP_CADENCE_STATUS, &rsp_data);
+	if (err) {
+		return err;
+	}
+
+	/* Status handler clears the cadence member if server indicates that
+	 * cadence isn't supported.
+	 */
+	if (rsp && !rsp_data.cadence) {
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+int bt_mesh_sensor_cli_cadence_set_unack(
+	struct bt_mesh_sensor_cli *cli, struct bt_mesh_msg_ctx *ctx,
+	struct bt_mesh_sensor_type *sensor,
+	const struct bt_mesh_sensor_cadence_status *cadence)
+{
+	if (sensor->channel_count != 1) {
+		return -ENOTSUP;
+	}
+
+	int err;
+
+	BT_MESH_MODEL_BUF_DEFINE(msg,
+				 BT_MESH_SENSOR_OP_CADENCE_SET_UNACKNOWLEDGED,
+				 BT_MESH_SENSOR_MSG_MAXLEN_CADENCE_SET);
+	bt_mesh_model_msg_init(&msg,
+			       BT_MESH_SENSOR_OP_CADENCE_SET_UNACKNOWLEDGED);
+
+	net_buf_simple_add_le16(&msg, sensor->id);
+
+	err = sensor_cadence_encode(&msg, sensor, cadence->fast_period_div,
+				    cadence->min_int, &cadence->threshold);
+	if (err) {
+		return err;
+	}
+
+	return model_send(cli->mod, ctx, &msg);
+}
+
+int bt_mesh_sensor_cli_settings_get(struct bt_mesh_sensor_cli *cli,
+				    struct bt_mesh_msg_ctx *ctx,
+				    struct bt_mesh_sensor_type *sensor,
+				    u16_t *ids, u32_t *count)
+{
+	int err;
+
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_SENSOR_OP_SETTINGS_GET,
+				 BT_MESH_SENSOR_MSG_LEN_SETTINGS_GET);
+	bt_mesh_model_msg_init(&msg, BT_MESH_SENSOR_OP_SETTINGS_GET);
+
+	net_buf_simple_add_le16(&msg, sensor->id);
+
+	struct settings_rsp rsp = {
+		.id = sensor->id,
+		.ids = ids,
+		.count = *count,
+	};
+
+	err = model_ackd_send(cli->mod, ctx, &msg, ids ? &cli->ack : NULL,
+			      BT_MESH_SENSOR_OP_SETTINGS_STATUS, &rsp);
+
+	if (ids && !err) {
+		*count = rsp.count;
+	}
+
+	return err;
+}
+
+int bt_mesh_sensor_cli_setting_get(struct bt_mesh_sensor_cli *cli,
+				   struct bt_mesh_msg_ctx *ctx,
+				   struct bt_mesh_sensor_type *sensor,
+				   const struct bt_mesh_sensor_type *setting,
+				   struct bt_mesh_sensor_setting_status *rsp)
+{
+	int err;
+
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_SENSOR_OP_SETTING_GET,
+				 BT_MESH_SENSOR_MSG_LEN_SETTING_GET);
+	bt_mesh_model_msg_init(&msg, BT_MESH_SENSOR_OP_SETTING_GET);
+
+	net_buf_simple_add_le16(&msg, sensor->id);
+	net_buf_simple_add_le16(&msg, setting->id);
+
+	struct setting_rsp rsp_data = {
+		.id = sensor->id,
+		.setting_id = setting->id,
+		.setting = rsp,
+	};
+
+	err = model_ackd_send(cli->mod, ctx, &msg, rsp ? &cli->ack : NULL,
+			      BT_MESH_SENSOR_OP_SETTING_STATUS, &rsp_data);
+	if (err) {
+		return err;
+	}
+
+	if (!rsp->type) {
+		return -ENOENT;
+	}
+
+	return 0;
+}
+
+int bt_mesh_sensor_cli_setting_set(struct bt_mesh_sensor_cli *cli,
+				   struct bt_mesh_msg_ctx *ctx,
+				   struct bt_mesh_sensor_type *sensor,
+				   const struct bt_mesh_sensor_type *setting,
+				   const struct sensor_value *value,
+				   struct bt_mesh_sensor_setting_status *rsp)
+{
+	int err;
+
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_SENSOR_OP_SETTING_SET,
+				 BT_MESH_SENSOR_MSG_MAXLEN_SETTING_SET);
+	bt_mesh_model_msg_init(&msg, BT_MESH_SENSOR_OP_SETTING_SET);
+
+	net_buf_simple_add_le16(&msg, sensor->id);
+	net_buf_simple_add_le16(&msg, setting->id);
+	err = sensor_value_encode(&msg, setting, value);
+	if (err) {
+		return err;
+	}
+
+	struct setting_rsp rsp_data = {
+		.id = sensor->id,
+		.setting_id = setting->id,
+		.setting = rsp,
+	};
+
+	err = model_ackd_send(cli->mod, ctx, &msg, rsp ? &cli->ack : NULL,
+			       BT_MESH_SENSOR_OP_SETTING_STATUS, &rsp_data);
+	if (err) {
+		return err;
+	}
+
+	if (!rsp->type)  {
+		return -ENOENT;
+	}
+
+	if (!rsp->writable) {
+		return -EACCES;
+	}
+
+	return 0;
+}
+
+int bt_mesh_sensor_cli_setting_set_unack(
+	struct bt_mesh_sensor_cli *cli, struct bt_mesh_msg_ctx *ctx,
+	struct bt_mesh_sensor_type *sensor,
+	const struct bt_mesh_sensor_type *setting,
+	const struct sensor_value *value)
+{
+	int err;
+
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_SENSOR_OP_SETTING_GET,
+				 BT_MESH_SENSOR_MSG_LEN_SETTING_GET);
+	bt_mesh_model_msg_init(&msg, BT_MESH_SENSOR_OP_SETTING_GET);
+
+	net_buf_simple_add_le16(&msg, sensor->id);
+	net_buf_simple_add_le16(&msg, setting->id);
+	err = sensor_value_encode(&msg, setting, value);
+	if (err) {
+		return err;
+	}
+
+	return model_send(cli->mod, ctx, &msg);
+}
+
+int bt_mesh_sensor_cli_get(
+	struct bt_mesh_sensor_cli *cli, struct bt_mesh_msg_ctx *ctx,
+	struct bt_mesh_sensor_type *sensor,
+	struct sensor_value *rsp)
+{
+	int err;
+
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_SENSOR_OP_GET,
+				 BT_MESH_SENSOR_MSG_MAXLEN_GET);
+	bt_mesh_model_msg_init(&msg, BT_MESH_SENSOR_OP_GET);
+	net_buf_simple_add_le16(&msg, sensor->id);
+
+	struct sensor_data_rsp rsp_data = { .id = sensor->id, .value = rsp };
+
+	err = model_ackd_send(cli->mod, ctx, &msg, rsp ? &cli->ack : NULL,
+			       BT_MESH_SENSOR_OP_STATUS, &rsp_data);
+	if (err) {
+		return err;
+	}
+
+	if (!rsp_data.value) {
+		return -ENODEV;
+	}
+
+	return 0;
+}
+
+int bt_mesh_sensor_cli_series_entry_get(
+	struct bt_mesh_sensor_cli *cli, struct bt_mesh_msg_ctx *ctx,
+	struct bt_mesh_sensor_type *sensor,
+	const struct bt_mesh_sensor_column *column,
+	struct bt_mesh_sensor_series_entry *rsp)
+{
+	int err;
+
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_SENSOR_OP_COLUMN_GET,
+				 BT_MESH_SENSOR_MSG_MAXLEN_COLUMN_GET);
+	bt_mesh_model_msg_init(&msg, BT_MESH_SENSOR_OP_COLUMN_GET);
+	net_buf_simple_add_le16(&msg, sensor->id);
+	err = sensor_ch_encode(&msg, bt_mesh_sensor_column_format_get(sensor),
+			       &column->start);
+	if (err) {
+		return err;
+	}
+
+	struct series_data_rsp rsp_data = {
+		.entries = rsp,
+		.id = sensor->id,
+		.count = 1,
+		.col = column,
+	};
+
+	err = model_ackd_send(cli->mod, ctx, &msg, rsp ? &cli->ack : NULL,
+			      BT_MESH_SENSOR_OP_COLUMN_STATUS, &rsp_data);
+	if (err) {
+		return err;
+	}
+
+	if (rsp && rsp_data.count == 0) {
+		return -ENOENT;
+	}
+
+	return 0;
+}
+
+int bt_mesh_sensor_cli_series_entries_get(
+	struct bt_mesh_sensor_cli *cli, struct bt_mesh_msg_ctx *ctx,
+	struct bt_mesh_sensor_type *sensor,
+	const struct bt_mesh_sensor_column *range,
+	struct bt_mesh_sensor_series_entry *rsp, u32_t *count)
+{
+	const struct bt_mesh_sensor_format *col_format;
+	int err;
+
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_SENSOR_OP_SERIES_GET,
+				 BT_MESH_SENSOR_MSG_MAXLEN_SERIES_GET);
+	bt_mesh_model_msg_init(&msg, BT_MESH_SENSOR_OP_SERIES_GET);
+
+	net_buf_simple_add_le16(&msg, sensor->id);
+
+	col_format = bt_mesh_sensor_column_format_get(sensor);
+
+	err = sensor_ch_encode(&msg, col_format, &range->start);
+	if (err) {
+		return err;
+	}
+
+	err = sensor_ch_encode(&msg, col_format, &range->end);
+	if (err) {
+		return err;
+	}
+
+	struct series_data_rsp rsp_data = {
+		.entries = rsp,
+		.id = sensor->id,
+		.count = *count,
+	};
+
+	err = model_ackd_send(cli->mod, ctx, &msg, rsp ? &cli->ack : NULL,
+			       BT_MESH_SENSOR_OP_SERIES_STATUS, &rsp_data);
+	if (err) {
+		return err;
+	}
+
+	*count = rsp_data.count;
+
+	return 0;
+}

--- a/subsys/bluetooth/mesh/sensor_srv.c
+++ b/subsys/bluetooth/mesh/sensor_srv.c
@@ -1,0 +1,971 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#include <string.h>
+#include <stdlib.h>
+#include <bluetooth/mesh/sensor_srv.h>
+#include <bluetooth/mesh/properties.h>
+#include "mesh/net.h"
+#include "mesh/access.h"
+#include "mesh/transport.h"
+#include "model_utils.h"
+#include "sensor.h"
+
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_MESH_DEBUG_MODEL)
+#define LOG_MODULE_NAME bt_mesh_sensor_srv
+#include "common/log.h"
+
+#define SENSOR_FOR_EACH(_list, _node)                                          \
+	SYS_SLIST_FOR_EACH_CONTAINER(_list, _node, state.node)
+
+static struct bt_mesh_sensor *sensor_get(struct bt_mesh_sensor_srv *srv,
+					 u16_t id)
+{
+	struct bt_mesh_sensor *sensor;
+
+	SENSOR_FOR_EACH(&srv->sensors, sensor)
+	{
+		if (sensor->type->id == id) {
+			return sensor;
+		}
+	}
+
+	return NULL;
+}
+
+static u16_t tolerance_encode(const struct sensor_value *tol)
+{
+	u64_t tol_mill = 1000000L * tol->val1 + tol->val2;
+
+	if (tol_mill > (1000000L * 100L)) {
+		return 0;
+	}
+
+	return (tol_mill * 4095L) / (1000000L * 100L);
+}
+
+static void cadence_store(const struct bt_mesh_sensor_srv *srv)
+{
+	/* Cadence is stored as a sequence of cadence status messages */
+	NET_BUF_SIMPLE_DEFINE(buf, (CONFIG_BT_MESH_SENSOR_SRV_SENSORS_MAX *
+				    BT_MESH_SENSOR_MSG_MAXLEN_CADENCE_STATUS));
+
+	for (int i = 0; i < srv->sensor_count; ++i) {
+		const struct bt_mesh_sensor *s = srv->sensor_array[i];
+		int err;
+
+		net_buf_simple_add_le16(&buf, s->type->id);
+		err = sensor_cadence_encode(&buf, s->type, s->state.pub_div,
+					    s->state.min_int,
+					    &s->state.threshold);
+		if (err) {
+			return;
+		}
+	}
+
+	if (bt_mesh_model_data_store(srv->model, false, buf.data, buf.len)) {
+		BT_ERR("Sensor server data store failed");
+	}
+}
+
+static void sensor_descriptor_encode(struct net_buf_simple *buf,
+				     struct bt_mesh_sensor *sensor)
+{
+	net_buf_simple_add_le16(buf, sensor->type->id);
+
+	const struct bt_mesh_sensor_descriptor dummy = { 0 };
+	const struct bt_mesh_sensor_descriptor *d =
+		sensor->descriptor ? sensor->descriptor : &dummy;
+
+	u16_t tol_pos = tolerance_encode(&d->tolerance.positive);
+	u16_t tol_neg = tolerance_encode(&d->tolerance.negative);
+
+	net_buf_simple_add_u8(buf, tol_pos & 0xff);
+	net_buf_simple_add_u8(buf,
+			      ((tol_pos >> 8) & BIT_MASK(4)) | (tol_neg << 4));
+	net_buf_simple_add_u8(buf, tol_neg >> 4);
+	net_buf_simple_add_u8(buf, d->sampling_type);
+
+	net_buf_simple_add_u8(buf, sensor_powtime_encode(d->period));
+	net_buf_simple_add_u8(buf, sensor_powtime_encode(d->update_interval));
+}
+
+static int value_get(struct bt_mesh_sensor *sensor, struct bt_mesh_msg_ctx *ctx,
+		     struct sensor_value *value)
+{
+	int err;
+
+	if (!sensor->get) {
+		return -ENOTSUP;
+	}
+
+	err = sensor->get(sensor, ctx, value);
+	if (err) {
+		BT_WARN("Value get for 0x%04x: %d", sensor->type->id, err);
+		return err;
+	}
+
+	sensor_cadence_update(sensor, value);
+
+	return 0;
+}
+
+static int buf_status_add(struct bt_mesh_sensor *sensor,
+			  struct bt_mesh_msg_ctx *ctx,
+			  struct net_buf_simple *buf)
+{
+	struct sensor_value value[CONFIG_BT_MESH_SENSOR_CHANNELS_MAX];
+	int err;
+
+	err = value_get(sensor, ctx, value);
+	if (err) {
+		sensor_status_id_encode(buf, 0, sensor->type->id);
+		return err;
+	}
+
+	err = sensor_status_encode(buf, sensor, value);
+	if (err) {
+		BT_WARN("Sensor value encode for 0x%04x: %d", sensor->type->id,
+			err);
+		sensor_status_id_encode(buf, 0, sensor->type->id);
+	}
+
+	return err;
+}
+
+static void handle_descriptor_get(struct bt_mesh_model *mod,
+				  struct bt_mesh_msg_ctx *ctx,
+				  struct net_buf_simple *buf)
+{
+	struct bt_mesh_sensor_srv *srv = mod->user_data;
+
+	if (buf->len != 0 && buf->len != 2) {
+		return;
+	}
+
+	NET_BUF_SIMPLE_DEFINE(rsp, BT_MESH_TX_SDU_MAX);
+	bt_mesh_model_msg_init(&rsp, BT_MESH_SENSOR_OP_DESCRIPTOR_STATUS);
+
+	struct bt_mesh_sensor *sensor;
+
+	if (buf->len == 2) {
+		u16_t id = net_buf_simple_pull_le16(buf);
+
+		if (id == BT_MESH_PROP_ID_PROHIBITED) {
+			return;
+		}
+
+		sensor = sensor_get(srv, id);
+		if (sensor) {
+			sensor_descriptor_encode(&rsp, sensor);
+		} else {
+			net_buf_simple_add_le16(&rsp, id);
+		}
+
+		goto respond;
+	}
+
+	SENSOR_FOR_EACH(&srv->sensors, sensor) {
+		BT_DBG("Reporting ID 0x%04x", sensor->type->id);
+
+		if (net_buf_simple_tailroom(&rsp) < (8 + BT_MESH_MIC_SHORT)) {
+			BT_WARN("Not enough room for all descriptors");
+			break;
+		}
+
+		sensor_descriptor_encode(&rsp, sensor);
+	}
+
+respond:
+	bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
+}
+
+static void handle_get(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+		       struct net_buf_simple *buf)
+{
+	struct bt_mesh_sensor_srv *srv = mod->user_data;
+
+	if (buf->len != 0 && buf->len != 2) {
+		return;
+	}
+
+	NET_BUF_SIMPLE_DEFINE(rsp, BT_MESH_TX_SDU_MAX);
+	bt_mesh_model_msg_init(&rsp, BT_MESH_SENSOR_OP_STATUS);
+
+	struct bt_mesh_sensor *sensor;
+
+	if (buf->len == 2) {
+		u16_t id = net_buf_simple_pull_le16(buf);
+
+		if (id == BT_MESH_PROP_ID_PROHIBITED) {
+			return;
+		}
+
+		sensor = sensor_get(srv, id);
+		if (sensor) {
+			buf_status_add(sensor, ctx, &rsp);
+		} else {
+			BT_WARN("Unknown sensor ID 0x%04x", id);
+			sensor_status_id_encode(&rsp, 0, id);
+		}
+
+		goto respond;
+	}
+
+	SENSOR_FOR_EACH(&srv->sensors, sensor) {
+		buf_status_add(sensor, ctx, &rsp);
+	}
+
+respond:
+	bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
+}
+
+static const struct bt_mesh_sensor_column *
+column_get(const struct bt_mesh_sensor_series *series,
+	   const struct sensor_value *val)
+{
+	for (u32_t i = 0; i < series->column_count; ++i) {
+		if (series->columns[i].start.val1 == val->val1 &&
+		    series->columns[i].start.val2 == val->val2) {
+			return &series->columns[i];
+		}
+	}
+
+	return NULL;
+}
+
+static void handle_column_get(struct bt_mesh_model *mod,
+			      struct bt_mesh_msg_ctx *ctx,
+			      struct net_buf_simple *buf)
+{
+	struct bt_mesh_sensor_srv *srv = mod->user_data;
+	int err;
+
+	if (buf->len < 2) {
+		return;
+	}
+
+	u16_t id = net_buf_simple_pull_le16(buf);
+
+	if (id == BT_MESH_PROP_ID_PROHIBITED) {
+		return;
+	}
+
+	struct bt_mesh_sensor *sensor = sensor_get(srv, id);
+
+	BT_MESH_MODEL_BUF_DEFINE(rsp, BT_MESH_SENSOR_OP_COLUMN_STATUS,
+				 BT_MESH_SENSOR_MSG_MAXLEN_COLUMN_STATUS);
+	bt_mesh_model_msg_init(&rsp, BT_MESH_SENSOR_OP_COLUMN_STATUS);
+	net_buf_simple_add_le16(&rsp, id);
+
+	if (!sensor) {
+		goto respond;
+	}
+
+	const struct bt_mesh_sensor_format *col_format;
+	const struct bt_mesh_sensor_column *col;
+	struct sensor_value col_x;
+
+	col_format = bt_mesh_sensor_column_format_get(sensor->type);
+	if (!col_format || !sensor->series.columns || !sensor->series.get) {
+		BT_WARN("No series support in 0x%04x", sensor->type->id);
+		goto respond;
+	}
+
+	err = sensor_ch_decode(buf, col_format, &col_x);
+	if (err) {
+		return;
+	}
+
+	BT_DBG("Column %s", bt_mesh_sensor_ch_str(&col_x));
+
+	col = column_get(&sensor->series, &col_x);
+	if (!col) {
+		BT_WARN("Unknown column");
+		sensor_ch_encode(&rsp, col_format, &col_x);
+		goto respond;
+	}
+
+	err = sensor_column_encode(&rsp, sensor, ctx, col);
+	if (err) {
+		BT_WARN("Failed encoding sensor column: %d", err);
+		return;
+	}
+
+respond:
+	bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
+}
+
+static void handle_series_get(struct bt_mesh_model *mod,
+			      struct bt_mesh_msg_ctx *ctx,
+			      struct net_buf_simple *buf)
+{
+	struct bt_mesh_sensor_srv *srv = mod->user_data;
+	const struct bt_mesh_sensor_format *col_format;
+
+	if (buf->len < 2) {
+		return;
+	}
+
+	u16_t id = net_buf_simple_pull_le16(buf);
+
+	if (id == BT_MESH_PROP_ID_PROHIBITED) {
+		return;
+	}
+
+	struct bt_mesh_sensor *sensor = sensor_get(srv, id);
+
+	NET_BUF_SIMPLE_DEFINE(rsp, BT_MESH_TX_SDU_MAX);
+	bt_mesh_model_msg_init(&rsp, BT_MESH_SENSOR_OP_SERIES_STATUS);
+	net_buf_simple_add_le16(&rsp, id);
+
+	if (!sensor) {
+		goto respond;
+	}
+
+	col_format = bt_mesh_sensor_column_format_get(sensor->type);
+	if (!col_format || !sensor->series.columns || !sensor->series.get) {
+		BT_WARN("No series support in 0x%04x", sensor->type->id);
+		goto respond;
+	}
+
+	struct bt_mesh_sensor_column range;
+	bool ranged = (buf->len != 0);
+
+	if (buf->len == col_format->size * 2) {
+		int err;
+
+		err = sensor_ch_decode(buf, col_format, &range.start);
+		if (err) {
+			BT_WARN("Range start decode failed: %d", err);
+			return;
+		}
+
+		err = sensor_ch_decode(buf, col_format, &range.end);
+		if (err) {
+			BT_WARN("Range end decode failed: %d", err);
+			return;
+		}
+	} else if (buf->len != 0) {
+		/* invalid length */
+		BT_WARN("Invalid length (%u)", buf->len);
+		return;
+	}
+
+	for (u32_t i = 0; i < sensor->series.column_count; ++i) {
+		const struct bt_mesh_sensor_column *col =
+			&sensor->series.columns[i];
+
+		if (ranged &&
+		    !bt_mesh_sensor_value_in_column(&col->start, &range)) {
+			continue;
+		}
+
+		BT_DBG("Column #%u", i);
+
+		int err = sensor_column_encode(&rsp, sensor, ctx, col);
+
+		if (err) {
+			BT_WARN("Failed encoding: %d", err);
+			return;
+		}
+	}
+
+respond:
+	bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
+}
+
+const struct bt_mesh_model_op _bt_mesh_sensor_srv_op[] = {
+	{ BT_MESH_SENSOR_OP_DESCRIPTOR_GET,
+	  BT_MESH_SENSOR_MSG_MINLEN_DESCRIPTOR_GET, handle_descriptor_get },
+	{ BT_MESH_SENSOR_OP_GET, BT_MESH_SENSOR_MSG_MINLEN_GET, handle_get },
+	{ BT_MESH_SENSOR_OP_COLUMN_GET, BT_MESH_SENSOR_MSG_MINLEN_COLUMN_GET,
+	  handle_column_get },
+	{ BT_MESH_SENSOR_OP_SERIES_GET, BT_MESH_SENSOR_MSG_MINLEN_SERIES_GET,
+	  handle_series_get },
+};
+
+static void handle_cadence_get(struct bt_mesh_model *mod,
+			       struct bt_mesh_msg_ctx *ctx,
+			       struct net_buf_simple *buf)
+{
+	struct bt_mesh_sensor_srv *srv = mod->user_data;
+	struct bt_mesh_sensor *sensor;
+	u16_t id;
+	int err;
+
+	BT_MESH_MODEL_BUF_DEFINE(rsp, BT_MESH_SENSOR_OP_CADENCE_STATUS,
+				 BT_MESH_SENSOR_MSG_MAXLEN_CADENCE_STATUS);
+	bt_mesh_model_msg_init(&rsp, BT_MESH_SENSOR_OP_CADENCE_STATUS);
+
+	id = net_buf_simple_pull_le16(buf);
+	if (id == BT_MESH_PROP_ID_PROHIBITED) {
+		return;
+	}
+
+	net_buf_simple_add_le16(&rsp, id);
+
+	sensor = sensor_get(srv, id);
+	if (!sensor || sensor->type->channel_count != 1) {
+		BT_WARN("Cadence not supported");
+		goto respond;
+	}
+
+	err = sensor_cadence_encode(&rsp, sensor->type, sensor->state.pub_div,
+				    sensor->state.min_int,
+				    &sensor->state.threshold);
+	if (err) {
+		return;
+	}
+
+respond:
+	bt_mesh_model_send(srv->model, ctx, &rsp, NULL, NULL);
+}
+
+static void cadence_set(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+			struct net_buf_simple *buf, bool ack)
+{
+	struct bt_mesh_sensor_srv *srv = mod->user_data;
+	struct bt_mesh_sensor *sensor;
+	u16_t id;
+
+	BT_MESH_MODEL_BUF_DEFINE(rsp, BT_MESH_SENSOR_OP_CADENCE_STATUS,
+				 BT_MESH_SENSOR_MSG_MAXLEN_CADENCE_STATUS);
+	bt_mesh_model_msg_init(&rsp, BT_MESH_SENSOR_OP_CADENCE_STATUS);
+
+	id = net_buf_simple_pull_le16(buf);
+	if (id == BT_MESH_PROP_ID_PROHIBITED) {
+		return;
+	}
+
+	net_buf_simple_add_le16(&rsp, id);
+
+	sensor = sensor_get(srv, id);
+	if (!sensor || sensor->type->channel_count != 1) {
+		BT_WARN("Cadence not supported");
+		goto respond;
+	}
+
+	struct bt_mesh_sensor_threshold threshold;
+	u8_t period_div, min_int;
+	int err;
+
+	err = sensor_cadence_decode(buf, sensor->type, &period_div, &min_int,
+				    &threshold);
+	if (err) {
+		BT_WARN("Invalid cadence");
+		goto respond;
+	}
+
+	BT_DBG("Min int: %u div: %u "
+	       "delta: %s to %s "
+	       "range: %s to %s (%s)",
+	       min_int, period_div,
+	       bt_mesh_sensor_ch_str(&threshold.delta.down),
+	       bt_mesh_sensor_ch_str(&threshold.delta.up),
+	       bt_mesh_sensor_ch_str(&threshold.range.low),
+	       bt_mesh_sensor_ch_str(&threshold.range.high),
+	       (threshold.range.cadence == BT_MESH_SENSOR_CADENCE_FAST ?
+			"fast" :
+			"slow"));
+
+	sensor->state.min_int = min_int;
+	sensor->state.pub_div = period_div;
+	sensor->state.threshold = threshold;
+
+	cadence_store(srv);
+
+	err = sensor_cadence_encode(&rsp, sensor->type, sensor->state.pub_div,
+				    sensor->state.min_int,
+				    &sensor->state.threshold);
+	if (err) {
+		return;
+	}
+
+	model_send(mod, NULL, &rsp);
+
+respond:
+	if (ack) {
+		bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
+	}
+}
+
+static void handle_cadence_set(struct bt_mesh_model *mod,
+			       struct bt_mesh_msg_ctx *ctx,
+			       struct net_buf_simple *buf)
+{
+	cadence_set(mod, ctx, buf, true);
+}
+
+static void handle_cadence_set_unack(struct bt_mesh_model *mod,
+				     struct bt_mesh_msg_ctx *ctx,
+				     struct net_buf_simple *buf)
+{
+	cadence_set(mod, ctx, buf, false);
+}
+
+static void handle_settings_get(struct bt_mesh_model *mod,
+				struct bt_mesh_msg_ctx *ctx,
+				struct net_buf_simple *buf)
+{
+	struct bt_mesh_sensor_srv *srv = mod->user_data;
+
+	u16_t id = net_buf_simple_pull_le16(buf);
+
+	if (id == BT_MESH_PROP_ID_PROHIBITED) {
+		return;
+	}
+
+	BT_DBG("0x%04x", id);
+
+	BT_MESH_MODEL_BUF_DEFINE(
+		rsp, BT_MESH_SENSOR_OP_SETTINGS_STATUS,
+		2 + 2 * CONFIG_BT_MESH_SENSOR_SRV_SETTINGS_MAX);
+	bt_mesh_model_msg_init(&rsp, BT_MESH_SENSOR_OP_SETTINGS_STATUS);
+	net_buf_simple_add_le16(&rsp, id);
+
+	struct bt_mesh_sensor *sensor = sensor_get(srv, id);
+
+	if (!sensor) {
+		goto respond;
+	}
+
+	for (u32_t i = 0; i < MIN(CONFIG_BT_MESH_SENSOR_SRV_SETTINGS_MAX,
+				  sensor->settings.count);
+	     ++i) {
+		net_buf_simple_add_le16(&rsp,
+					sensor->settings.list[i].type->id);
+	}
+
+respond:
+	bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
+}
+
+static const struct bt_mesh_sensor_setting *
+setting_get(struct bt_mesh_sensor *sensor, u16_t setting_id)
+{
+	for (u32_t i = 0; i < sensor->settings.count; i++) {
+		if (sensor->settings.list[i].type->id == setting_id) {
+			return &sensor->settings.list[i];
+		}
+	}
+	return NULL;
+}
+
+static void handle_setting_get(struct bt_mesh_model *mod,
+			       struct bt_mesh_msg_ctx *ctx,
+			       struct net_buf_simple *buf)
+{
+	struct bt_mesh_sensor_srv *srv = mod->user_data;
+	u16_t id = net_buf_simple_pull_le16(buf);
+	u16_t setting_id = net_buf_simple_pull_le16(buf);
+	int err;
+
+	if (id == BT_MESH_PROP_ID_PROHIBITED ||
+	    setting_id == BT_MESH_PROP_ID_PROHIBITED) {
+		return;
+	}
+
+	BT_MESH_MODEL_BUF_DEFINE(rsp, BT_MESH_SENSOR_OP_SETTING_STATUS,
+				 BT_MESH_SENSOR_MSG_MAXLEN_SETTING_STATUS);
+	bt_mesh_model_msg_init(&rsp, BT_MESH_SENSOR_OP_SETTING_STATUS);
+	net_buf_simple_add_le16(&rsp, id);
+	net_buf_simple_add_le16(&rsp, setting_id);
+
+	const struct bt_mesh_sensor_setting *setting;
+	struct bt_mesh_sensor *sensor = sensor_get(srv, id);
+
+	if (!sensor) {
+		goto respond;
+	}
+
+	setting = setting_get(sensor, setting_id);
+	if (!setting || !setting->get) {
+		goto respond;
+	}
+
+	u8_t minlen = rsp.len;
+
+	net_buf_simple_add_u8(&rsp, setting->set ? 0x03 : 0x01);
+
+	struct sensor_value values[CONFIG_BT_MESH_SENSOR_CHANNELS_MAX];
+
+	setting->get(sensor, setting, ctx, values);
+
+	err = sensor_value_encode(&rsp, setting->type, values);
+	if (err) {
+		BT_WARN("Failed encoding sensor setting 0x%04x: %d",
+			setting->type->id, err);
+
+		/* Undo the access field */
+		rsp.len = minlen;
+	}
+
+respond:
+	bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
+}
+
+static void setting_set(struct bt_mesh_model *mod, struct bt_mesh_msg_ctx *ctx,
+			struct net_buf_simple *buf, bool ack)
+{
+	struct bt_mesh_sensor_srv *srv = mod->user_data;
+	u16_t id = net_buf_simple_pull_le16(buf);
+	u16_t setting_id = net_buf_simple_pull_le16(buf);
+	int err;
+
+	if (id == BT_MESH_PROP_ID_PROHIBITED ||
+	    setting_id == BT_MESH_PROP_ID_PROHIBITED) {
+		return;
+	}
+
+	BT_MESH_MODEL_BUF_DEFINE(rsp, BT_MESH_SENSOR_OP_SETTING_STATUS,
+				 BT_MESH_SENSOR_MSG_MAXLEN_SETTING_STATUS);
+	bt_mesh_model_msg_init(&rsp, BT_MESH_SENSOR_OP_SETTING_STATUS);
+	net_buf_simple_add_le16(&rsp, id);
+	net_buf_simple_add_le16(&rsp, setting_id);
+
+	const struct bt_mesh_sensor_setting *setting;
+	struct bt_mesh_sensor *sensor;
+
+	sensor = sensor_get(srv, id);
+	if (!sensor) {
+		goto respond;
+	}
+
+	setting = setting_get(sensor, setting_id);
+	if (!setting || !setting->set) {
+		goto respond;
+	}
+
+	struct sensor_value values[CONFIG_BT_MESH_SENSOR_CHANNELS_MAX];
+
+	err = sensor_value_decode(buf, setting->type, values);
+	if (err) {
+		BT_WARN("Error decoding sensor setting 0x%04x: %d",
+			setting->type->id, err);
+
+		/* Invalid parameters: ignore this message */
+		return;
+	}
+
+	setting->set(sensor, setting, ctx, values);
+
+	u8_t minlen = rsp.len;
+
+	net_buf_simple_add_u8(&rsp, 0x03); /* RW */
+
+	err = sensor_value_encode(&rsp, setting->type, values);
+	if (err) {
+		BT_WARN("Error encoding sensor setting 0x%04x: %d",
+			setting->type->id, err);
+
+		/* Undo the access field */
+		rsp.len = minlen;
+		goto respond;
+	}
+
+	BT_DBG("0x%04x: 0x%04x", id, setting_id);
+
+	model_send(mod, NULL, &rsp);
+
+respond:
+	if (ack) {
+		bt_mesh_model_send(mod, ctx, &rsp, NULL, NULL);
+	}
+}
+
+static void handle_setting_set(struct bt_mesh_model *mod,
+			       struct bt_mesh_msg_ctx *ctx,
+			       struct net_buf_simple *buf)
+{
+	setting_set(mod, ctx, buf, true);
+}
+
+static void handle_setting_set_unack(struct bt_mesh_model *mod,
+				     struct bt_mesh_msg_ctx *ctx,
+				     struct net_buf_simple *buf)
+{
+	setting_set(mod, ctx, buf, false);
+}
+
+const struct bt_mesh_model_op _bt_mesh_sensor_setup_srv_op[] = {
+
+	{ BT_MESH_SENSOR_OP_CADENCE_GET, BT_MESH_SENSOR_MSG_LEN_CADENCE_GET,
+	  handle_cadence_get },
+	{ BT_MESH_SENSOR_OP_CADENCE_SET, BT_MESH_SENSOR_MSG_MINLEN_CADENCE_SET,
+	  handle_cadence_set },
+	{ BT_MESH_SENSOR_OP_CADENCE_SET_UNACKNOWLEDGED,
+	  BT_MESH_SENSOR_MSG_MINLEN_CADENCE_SET, handle_cadence_set_unack },
+	{ BT_MESH_SENSOR_OP_SETTINGS_GET, BT_MESH_SENSOR_MSG_LEN_SETTINGS_GET,
+	  handle_settings_get },
+	{ BT_MESH_SENSOR_OP_SETTING_GET, BT_MESH_SENSOR_MSG_LEN_SETTING_GET,
+	  handle_setting_get },
+	{ BT_MESH_SENSOR_OP_SETTING_SET, BT_MESH_SENSOR_MSG_MINLEN_SETTING_SET,
+	  handle_setting_set },
+	{ BT_MESH_SENSOR_OP_SETTING_SET_UNACKNOWLEDGED,
+	  BT_MESH_SENSOR_MSG_MINLEN_SETTING_SET, handle_setting_set_unack },
+};
+
+static int sensor_srv_init(struct bt_mesh_model *mod)
+{
+	struct bt_mesh_sensor_srv *srv = mod->user_data;
+
+	sys_slist_init(&srv->sensors);
+
+	/* Establish a sorted list of sensors, as this is a requirement when
+	 * sending multiple sensor values in one message.
+	 */
+	u16_t min_id = 0;
+
+	for (int count = 0; count < srv->sensor_count; ++count) {
+		struct bt_mesh_sensor *best = NULL;
+
+		for (int j = 0; j < srv->sensor_count; ++j) {
+			if (srv->sensor_array[j]->type->id >= min_id &&
+			    (!best ||
+			     srv->sensor_array[j]->type->id < best->type->id)) {
+				best = srv->sensor_array[j];
+			}
+		}
+
+		if (!best) {
+			BT_ERR("Duplicate sensor ID");
+			srv->sensor_count = count;
+			break;
+		}
+
+		sys_slist_append(&srv->sensors, &best->state.node);
+		BT_DBG("Sensor 0x%04x", best->type->id);
+		min_id = best->type->id + 1;
+	}
+
+	srv->model = mod;
+
+	net_buf_simple_init(srv->pub.msg, 0);
+	net_buf_simple_init(srv->setup_pub.msg, 0);
+
+	return 0;
+}
+
+static int sensor_srv_settings_set(struct bt_mesh_model *mod, size_t len_rd,
+				   settings_read_cb read_cb, void *cb_arg)
+{
+	struct bt_mesh_sensor_srv *srv = mod->user_data;
+	int err = 0;
+
+	NET_BUF_SIMPLE_DEFINE(buf, (CONFIG_BT_MESH_SENSOR_SRV_SENSORS_MAX *
+				    BT_MESH_SENSOR_MSG_MAXLEN_CADENCE_STATUS));
+
+	ssize_t len = read_cb(cb_arg, net_buf_simple_add(&buf, len_rd), len_rd);
+
+	if (len == 0) {
+		return 0;
+	}
+
+	if (len != len_rd) {
+		BT_ERR("Failed: %d (expected length %u)", len, len_rd);
+		return -EINVAL;
+	}
+
+	while (buf.len) {
+		struct bt_mesh_sensor *s;
+		u8_t pub_div;
+		u16_t id = net_buf_simple_pull_le16(&buf);
+
+		s = sensor_get(srv, id);
+		if (!s) {
+			err = -ENODEV;
+			break;
+		}
+
+		err = sensor_cadence_decode(&buf, s->type, &pub_div,
+					    &s->state.min_int,
+					    &s->state.threshold);
+		if (err) {
+			break;
+		}
+
+		s->state.pub_div = pub_div;
+	}
+
+	if (err) {
+		BT_ERR("Failed: %d", err);
+	}
+
+	return err;
+}
+
+const struct bt_mesh_model_cb _bt_mesh_sensor_srv_cb = {
+	.init = sensor_srv_init,
+	.settings_set = sensor_srv_settings_set,
+};
+
+/** @brief Get the sensor publication interval (in number of publish messages).
+ *
+ *  @param sensor      Sensor instance
+ *  @param period_div  Server's period divisor
+ *
+ *  @return The publish interval of the sensor measured in number of published
+ *          messages by the server.
+ */
+static u16_t pub_int_get(const struct bt_mesh_sensor *sensor, u8_t period_div)
+{
+	u8_t div = (sensor->state.pub_div * sensor->state.fast_pub);
+
+	return (1U << MAX(0, period_div - div));
+}
+
+/** @brief Get the sensor minimum interval (in number of publish messages).
+ *
+ *  @param sensor      Sensor instance
+ *  @param period_div  Server's period divisor
+ *  @param base_period Server's base period
+ *
+ *  @return The minimum interval of the sensor measured in number of published
+ *          messages by the server.
+ */
+static u16_t min_int_get(const struct bt_mesh_sensor *sensor, u8_t period_div,
+			 u32_t base_period)
+{
+	u32_t pub_int = (base_period >> period_div);
+	u32_t min_int = (1 << sensor->state.min_int);
+
+	return ceiling_fraction(min_int, pub_int);
+}
+
+/** @brief Conditionally add a sensor value to a publication.
+ *
+ *  A sensor message will be added to the publication if its minimum interval
+ *  has expired and the value is outside its delta threshold or the
+ *  publication interval has expired.
+ *
+ *  @param srv         Server sending the publication.
+ *  @param s           Sensor to add data of.
+ *  @param period_div  Server's original period divisor.
+ *  @param base_period Server's original base period.
+ */
+static void pub_msg_add(struct bt_mesh_sensor_srv *srv,
+			struct bt_mesh_sensor *s, u8_t period_div,
+			u32_t base_period)
+{
+	u16_t min_int = min_int_get(s, period_div, base_period);
+	int err;
+
+	if (srv->seq - s->state.seq < min_int) {
+		return;
+	}
+
+	struct sensor_value value[CONFIG_BT_MESH_SENSOR_CHANNELS_MAX];
+
+	err = value_get(s, NULL, value);
+	if (err) {
+		return;
+	}
+
+	bool delta_triggered = bt_mesh_sensor_delta_threshold(s, value);
+	u16_t interval = pub_int_get(s, period_div);
+
+	if (!delta_triggered && srv->seq - s->state.seq < interval) {
+		return;
+	}
+
+	err = sensor_status_encode(srv->pub.msg, s, value);
+	if (err) {
+		return;
+	}
+
+	s->state.prev = value[0];
+	s->state.seq = srv->seq;
+}
+
+int _bt_mesh_sensor_srv_update_handler(struct bt_mesh_model *mod)
+{
+	struct bt_mesh_sensor_srv *srv = mod->user_data;
+	struct bt_mesh_sensor *s;
+
+	bt_mesh_model_msg_init(srv->pub.msg, BT_MESH_SENSOR_OP_STATUS);
+
+	u32_t original_len = srv->pub.msg->len;
+	u8_t period_div = srv->pub.period_div;
+
+	BT_DBG("#%u Period: %u ms Divisor: %u (%s)", srv->seq,
+	       bt_mesh_model_pub_period_get(mod), period_div,
+	       srv->pub.fast_period ? "fast" : "normal");
+
+	srv->pub.period_div = 0;
+	srv->pub.fast_period = 0;
+
+	u32_t base_period = bt_mesh_model_pub_period_get(mod);
+
+	SENSOR_FOR_EACH(&srv->sensors, s)
+	{
+		pub_msg_add(srv, s, period_div, base_period);
+
+		if (s->state.fast_pub) {
+			srv->pub.fast_period = true;
+			srv->pub.period_div =
+				MAX(srv->pub.period_div, s->state.pub_div);
+		}
+	}
+
+	if (period_div != srv->pub.period_div) {
+		BT_DBG("New interval: %u",
+		       bt_mesh_model_pub_period_get(srv->model));
+	}
+
+	srv->seq++;
+
+	return (srv->pub.msg->len > original_len) ? 0 : -ENOENT;
+}
+
+int bt_mesh_sensor_srv_pub(struct bt_mesh_sensor_srv *srv,
+			   struct bt_mesh_msg_ctx *ctx,
+			   struct bt_mesh_sensor *sensor,
+			   const struct sensor_value *value)
+{
+	int err;
+
+	BT_MESH_MODEL_BUF_DEFINE(msg, BT_MESH_SENSOR_OP_STATUS,
+				 BT_MESH_SENSOR_STATUS_MAXLEN);
+	bt_mesh_model_msg_init(&msg, BT_MESH_SENSOR_OP_STATUS);
+
+	err = sensor_status_encode(&msg, sensor, value);
+	if (err) {
+		return err;
+	}
+
+	sensor_cadence_update(sensor, value);
+
+	err = model_send(srv->model, ctx, &msg);
+	if (err) {
+		return err;
+	}
+
+	sensor->state.prev = value[0];
+	return 0;
+}
+
+int bt_mesh_sensor_srv_sample(struct bt_mesh_sensor_srv *srv,
+			      struct bt_mesh_sensor *sensor)
+{
+	struct sensor_value value[CONFIG_BT_MESH_SENSOR_CHANNELS_MAX];
+	int err;
+
+	err = value_get(sensor, NULL, value);
+	if (err) {
+		return -EBUSY;
+	}
+
+	if (sensor->type->channel_count == 1 &&
+	    !bt_mesh_sensor_delta_threshold(sensor, value)) {
+		BT_WARN("Outside threshold");
+		return -EALREADY;
+	}
+
+	BT_DBG("Publishing 0x%04x", sensor->type->id);
+
+	return bt_mesh_sensor_srv_pub(srv, NULL, sensor, value);
+}

--- a/subsys/bluetooth/mesh/sensor_types.c
+++ b/subsys/bluetooth/mesh/sensor_types.c
@@ -1,0 +1,952 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+#include <string.h>
+#include <stdio.h>
+#include "sensor.h"
+#include <toolchain/common.h>
+#include <bluetooth/mesh/properties.h>
+#include <bluetooth/mesh/sensor_types.h>
+
+/* Various shorthand macros to improve readability and maintainability of this
+ * file:
+ */
+
+#define UNIT(name) const struct bt_mesh_sensor_unit bt_mesh_sensor_unit_##name
+
+#define CHANNELS(...)                                                          \
+	.channels = ((const struct bt_mesh_sensor_channel[]){ __VA_ARGS__ }),  \
+	.channel_count = ARRAY_SIZE(                                           \
+		((const struct bt_mesh_sensor_channel[]){ __VA_ARGS__ }))
+
+#define FORMAT(_name)                                                          \
+	const struct bt_mesh_sensor_format bt_mesh_sensor_format_##_name
+
+#define SENSOR_TYPE(name)                                                      \
+	const Z_STRUCT_SECTION_ITERABLE(bt_mesh_sensor_type,                   \
+					bt_mesh_sensor_##name)
+
+#ifdef CONFIG_BT_MESH_SENSOR_LABELS
+
+#define CHANNEL(_name, _format)                                                \
+	{                                                                      \
+		.format = &bt_mesh_sensor_format_##_format, .name = _name      \
+	}
+#else
+
+#define CHANNEL(_name, _format)                                                \
+	{                                                                      \
+		.format = &bt_mesh_sensor_format_##_format,                    \
+	}
+
+#endif
+
+/*******************************************************************************
+ * Units
+ ******************************************************************************/
+UNIT(hours) = { "Hours", "h" };
+UNIT(seconds) = { "Seconds", "s" };
+UNIT(celsius) = { "Celsius", "C" };
+UNIT(kelvin) = { "Kelvin", "K" };
+UNIT(percent) = { "Percent", "%" };
+UNIT(ppm) = { "Parts per million", "ppm" };
+UNIT(ppb) = { "Parts per billion", "ppb" };
+UNIT(volt) = { "Volt", "V" };
+UNIT(ampere) = { "Ampere", "A" };
+UNIT(watt) = { "Watt", "W" };
+UNIT(kwh) = { "Kilo Watt hours", "kWh" };
+UNIT(db) = { "Decibel", "dB" };
+UNIT(lux) = { "Lux", "lx" };
+UNIT(lux_hour) = { "Lux hours", "lxh" };
+UNIT(lumen) = { "Lumen", "lm" };
+UNIT(lumen_per_watt) = { "Lumen per Watt", "lm/W" };
+UNIT(lumen_hour) = { "Lumen hours", "lmh" };
+UNIT(unitless) = { "Unitless" };
+/*******************************************************************************
+ * Encoders and decoders
+ ******************************************************************************/
+#define BRANCHLESS_ABS8(x) (((x) + ((x) >> 7)) ^ ((x) >> 7))
+
+#define SCALAR(mul, bin)                                                       \
+	((double)(mul) *                                                       \
+	 (double)((bin) >= 0 ? (1ULL << BRANCHLESS_ABS8(bin)) :                \
+			       (1.0 / (1ULL << BRANCHLESS_ABS8(bin)))))
+
+#define SCALAR_IS_DIV(_scalar) ((_scalar) > -1.0 && (_scalar) < 1.0)
+
+#define SCALAR_REPR_RANGED(_scalar, _flags, _max)                              \
+	{                                                                      \
+		.flags = ((_flags) | (SCALAR_IS_DIV(_scalar) ? DIVIDE : 0)),   \
+		.max = _max,                                                   \
+		.value = (s64_t)((SCALAR_IS_DIV(_scalar) ? (1.0 / (_scalar)) : \
+							   (_scalar)) +        \
+				 0.5),                                         \
+	}
+
+#define SCALAR_REPR(_scalar, _flags) SCALAR_REPR_RANGED(_scalar, _flags, 0)
+
+#ifdef CONFIG_BT_MESH_SENSOR_LABELS
+
+#define SCALAR_FORMAT_MAX(_size, _flags, _unit, _scalar, _max)                 \
+	{                                                                      \
+		.unit = &bt_mesh_sensor_unit_##_unit,                          \
+		.encode = scalar_encode, .decode = scalar_decode,              \
+		.size = _size,                                                 \
+		.user_data = (void *)&(                                        \
+			(const struct scalar_repr)SCALAR_REPR_RANGED(          \
+				_scalar, ((_flags) | HAS_MAX), _max)),         \
+	}
+
+#define SCALAR_FORMAT(_size, _flags, _unit, _scalar)                           \
+	{                                                                      \
+		.unit = &bt_mesh_sensor_unit_##_unit,                          \
+		.encode = scalar_encode, .decode = scalar_decode,              \
+		.size = _size,                                                 \
+		.user_data = (void *)&((const struct scalar_repr)SCALAR_REPR(  \
+			_scalar, _flags)),                                     \
+	}
+#else
+
+#define SCALAR_FORMAT_MAX(_size, _flags, _unit, _scalar, _max)                 \
+	{                                                                      \
+		.encode = scalar_encode, .decode = scalar_decode,              \
+		.size = _size,                                                 \
+		.user_data = (void *)&(                                        \
+			(const struct scalar_repr)SCALAR_REPR_RANGED(          \
+				_scalar, ((_flags) | HAS_MAX), _max)),         \
+	}
+
+#define SCALAR_FORMAT(_size, _flags, _unit, _scalar)                           \
+	{                                                                      \
+		.encode = scalar_encode, .decode = scalar_decode,              \
+		.size = _size,                                                 \
+		.user_data = (void *)&((const struct scalar_repr)SCALAR_REPR(  \
+			_scalar, _flags)),                                     \
+	}
+#endif
+
+enum scalar_repr_flags {
+	UNSIGNED = 0,
+	SIGNED = BIT(1),
+	DIVIDE = BIT(2),
+	/** The highest encoded value represents "undefined" */
+	HAS_UNDEFINED = BIT(3),
+	/**
+	 * The second highest encoded value represents
+	 * "value is higher than xxx".
+	 */
+	HAS_HIGHER_THAN = (BIT(4)),
+	/** The second highest encoded value represents "value is invalid" */
+	HAS_INVALID = (BIT(5)),
+	HAS_MAX = BIT(6),
+};
+
+struct scalar_repr {
+	enum scalar_repr_flags flags;
+	u32_t max; /**< Highest encoded value */
+	s64_t value;
+};
+
+static s64_t mul_scalar(s64_t val, const struct scalar_repr *repr)
+{
+	return (repr->flags & DIVIDE) ? (val / repr->value) :
+	       (val * repr->value);
+}
+
+static s64_t div_scalar(s64_t val, const struct scalar_repr *repr)
+{
+	return (repr->flags & DIVIDE) ? (val * repr->value) :
+	       (val / repr->value);
+}
+
+static u32_t scalar_max(const struct bt_mesh_sensor_format *format)
+{
+	const struct scalar_repr *repr = format->user_data;
+
+	if (repr->flags & HAS_MAX) {
+		return repr->max;
+	}
+
+	if (repr->flags & SIGNED) {
+		return BIT64(8 * format->size - 1) - 1;
+	}
+
+	u32_t max_value = BIT64(8 * format->size) - 1;
+
+	if (repr->flags & (HAS_HIGHER_THAN | HAS_INVALID)) {
+		max_value -= 2;
+	} else if (repr->flags & HAS_UNDEFINED) {
+		max_value -= 1;
+	}
+
+	return max_value;
+}
+
+static s32_t scalar_min(const struct bt_mesh_sensor_format *format)
+{
+	const struct scalar_repr *repr = format->user_data;
+
+	if (repr->flags & SIGNED) {
+		return -BIT64(8 * format->size - 1);
+	}
+
+	return 0;
+}
+
+static int scalar_encode(const struct bt_mesh_sensor_format *format,
+			 const struct sensor_value *val,
+			 struct net_buf_simple *buf)
+{
+	const struct scalar_repr *repr = format->user_data;
+
+	if (net_buf_simple_tailroom(buf) < format->size) {
+		return -ENOMEM;
+	}
+
+	s64_t raw = div_scalar(val->val1, repr) +
+		    div_scalar(val->val2, repr) / 1000000LL;
+
+	u32_t max_value = scalar_max(format);
+	s32_t min_value = scalar_min(format);
+
+	if (raw > max_value || raw < min_value) {
+		u32_t type_max = BIT64(8 * format->size) - 1;
+
+		if (repr->flags & (HAS_HIGHER_THAN | HAS_INVALID)) {
+			raw = type_max - 2;
+		} else if (repr->flags & HAS_UNDEFINED) {
+			raw = type_max - 1;
+		} else {
+			return -ERANGE;
+		}
+	}
+
+	switch (format->size) {
+	case 1:
+		net_buf_simple_add_u8(buf, raw);
+		break;
+	case 2:
+		net_buf_simple_add_le16(buf, raw);
+		break;
+	case 3:
+		net_buf_simple_add_le24(buf, raw);
+		break;
+	case 4:
+		net_buf_simple_add_le32(buf, raw);
+		break;
+	default:
+		return -EIO;
+	}
+
+	return 0;
+}
+
+static int scalar_decode(const struct bt_mesh_sensor_format *format,
+			 struct net_buf_simple *buf, struct sensor_value *val)
+{
+	const struct scalar_repr *repr = format->user_data;
+
+	if (buf->len < format->size) {
+		return -ENOMEM;
+	}
+
+	s32_t raw;
+
+	switch (format->size) {
+	case 1:
+		if (repr->flags & SIGNED) {
+			raw = (s8_t) net_buf_simple_pull_u8(buf);
+		} else {
+			raw = net_buf_simple_pull_u8(buf);
+		}
+		break;
+	case 2:
+		if (repr->flags & SIGNED) {
+			raw = (s16_t) net_buf_simple_pull_le16(buf);
+		} else {
+			raw = net_buf_simple_pull_le16(buf);
+		}
+		break;
+	case 3:
+		raw = net_buf_simple_pull_le24(buf);
+
+		if ((repr->flags & SIGNED) && (raw & BIT(24))) {
+			raw |= (BIT_MASK(8) << 24);
+		}
+		break;
+	case 4:
+		raw = net_buf_simple_pull_le32(buf);
+		break;
+	default:
+		return -ERANGE;
+	}
+
+	u32_t max_value = scalar_max(format);
+	s32_t min_value = scalar_min(format);
+
+	if (raw < min_value || raw > max_value) {
+		return -ERANGE;
+	}
+
+	s64_t million = mul_scalar(raw * 1000000LL, repr);
+
+	val->val1 = million / 1000000LL;
+	val->val2 = million % 1000000LL;
+
+	return 0;
+}
+
+static int boolean_encode(const struct bt_mesh_sensor_format *format,
+			  const struct sensor_value *val,
+			  struct net_buf_simple *buf)
+{
+	if (net_buf_simple_tailroom(buf) < 1) {
+		return -ENOMEM;
+	}
+
+	net_buf_simple_add_u8(buf, !!val->val1);
+	return 0;
+}
+
+static int boolean_decode(const struct bt_mesh_sensor_format *format,
+			  struct net_buf_simple *buf, struct sensor_value *val)
+{
+	if (buf->len < 1) {
+		return -ENOMEM;
+	}
+
+	u8_t b = net_buf_simple_pull_u8(buf);
+
+	if (b > 1) {
+		return -EINVAL;
+	}
+
+	val->val1 = b;
+	val->val2 = 0;
+	return 0;
+}
+
+static int exp_1_1_encode(const struct bt_mesh_sensor_format *format,
+			  const struct sensor_value *val,
+			  struct net_buf_simple *buf)
+{
+	if (net_buf_simple_tailroom(buf) < 1) {
+		return -ENOMEM;
+	}
+
+	net_buf_simple_add_u8(buf, sensor_powtime_encode((val->val1 * 1000) +
+							 (val->val2 / 1000)));
+	return 0;
+}
+
+static int exp_1_1_decode(const struct bt_mesh_sensor_format *format,
+			  struct net_buf_simple *buf, struct sensor_value *val)
+{
+	if (buf->len < 1) {
+		return -ENOMEM;
+	}
+
+	u64_t time_ns = sensor_powtime_decode_ns(net_buf_simple_pull_u8(buf));
+
+	val->val1 = time_ns / 1000000L;
+	val->val2 = time_ns % 1000000L;
+	return 0;
+}
+
+static int float32_encode(const struct bt_mesh_sensor_format *format,
+			  const struct sensor_value *val,
+			  struct net_buf_simple *buf)
+{
+	if (net_buf_simple_tailroom(buf) < 1) {
+		return -ENOMEM;
+	}
+
+	/* IEEE-754 32-bit floating point */
+	float fvalue = (float)val->val1 + (float)val->val2 / 1000000L;
+
+	net_buf_simple_add_mem(buf, &fvalue, sizeof(float));
+
+	return 0;
+}
+
+static int float32_decode(const struct bt_mesh_sensor_format *format,
+			  struct net_buf_simple *buf, struct sensor_value *val)
+{
+	if (buf->len < 1) {
+		return -ENOMEM;
+	}
+
+	float fvalue;
+
+	memcpy(&fvalue, net_buf_simple_pull_mem(buf, sizeof(float)),
+	       sizeof(float));
+
+	val->val1 = (u32_t)fvalue;
+	val->val2 = ((u32_t)(fvalue * 1000000.0f)) / 1000000L;
+	return 0;
+}
+
+/*******************************************************************************
+ * Sensor Formats
+ *
+ * Formats define how single channels are encoded and decoded, and are generally
+ * represented as a scalar format with multipliers.
+ *
+ * See Mesh Model Specification Section 2.3 for details.
+ ******************************************************************************/
+
+
+/*******************************************************************************
+ * Percentage formats
+ ******************************************************************************/
+FORMAT(percentage_8)  = SCALAR_FORMAT_MAX(1,
+					  (UNSIGNED | HAS_UNDEFINED),
+					  percent,
+					  SCALAR(1, -1),
+					  200);
+FORMAT(percentage_16) = SCALAR_FORMAT_MAX(2,
+					  (UNSIGNED | HAS_UNDEFINED),
+					  percent,
+					  SCALAR(1e-2, 0),
+					  200);
+
+/*******************************************************************************
+ * Environmental formats
+ ******************************************************************************/
+FORMAT(temp_8)		  = SCALAR_FORMAT(1,
+					  SIGNED,
+					  celsius,
+					  SCALAR(1, -1));
+FORMAT(temp)		  = SCALAR_FORMAT(2,
+					  SIGNED,
+					  celsius,
+					  SCALAR(1e-2, 0));
+FORMAT(co2_concentration) = SCALAR_FORMAT(2,
+					  (HAS_HIGHER_THAN | HAS_UNDEFINED),
+					  ppm,
+					  SCALAR(1, 0));
+FORMAT(noise)		  = SCALAR_FORMAT(1,
+					  (UNSIGNED |
+					   HAS_HIGHER_THAN |
+					   HAS_UNDEFINED),
+					  db,
+					  SCALAR(1, 0));
+FORMAT(voc_concentration) = SCALAR_FORMAT_MAX(2,
+					      (UNSIGNED |
+					       HAS_HIGHER_THAN |
+					       HAS_UNDEFINED),
+					      ppb,
+					      SCALAR(1, 0),
+					      65533);
+FORMAT(humidity)          = SCALAR_FORMAT_MAX(2,
+					      UNSIGNED,
+					      percent,
+					      SCALAR(1e-2, 0),
+					      10000);
+
+/*******************************************************************************
+ * Time formats
+ ******************************************************************************/
+FORMAT(time_decihour_8)	    = SCALAR_FORMAT_MAX(1,
+						(UNSIGNED | HAS_UNDEFINED),
+						hours,
+						SCALAR(1e-1, 0),
+						240);
+FORMAT(time_hour_24)	    = SCALAR_FORMAT(3,
+					    (UNSIGNED | HAS_UNDEFINED),
+					    hours,
+					    SCALAR(1e-1, 0));
+FORMAT(time_second_16)	    = SCALAR_FORMAT(2,
+					    (UNSIGNED | HAS_UNDEFINED),
+					    seconds,
+					    SCALAR(1, 0));
+FORMAT(time_exp_8)	    = {
+	 .size = 1,
+#ifdef CONFIG_BT_MESH_SENSOR_LABELS
+	.unit = &bt_mesh_sensor_unit_seconds,
+#endif
+	.encode = exp_1_1_encode,
+	.decode = exp_1_1_decode,
+};
+
+/*******************************************************************************
+ * Electrical formats
+ ******************************************************************************/
+FORMAT(electric_current) = SCALAR_FORMAT(2,
+					 (UNSIGNED | HAS_UNDEFINED),
+					 ampere,
+					 SCALAR(1e-2, 0));
+FORMAT(voltage)		 = SCALAR_FORMAT(2,
+					 (UNSIGNED | HAS_UNDEFINED),
+					 volt,
+					 SCALAR(1, -6));
+FORMAT(energy32)	 = SCALAR_FORMAT(4,
+					 UNSIGNED | HAS_INVALID | HAS_UNDEFINED,
+					 kwh,
+					 SCALAR(1e-3, 0));
+FORMAT(power)		 = SCALAR_FORMAT(3,
+					 (UNSIGNED | HAS_UNDEFINED),
+					 watt,
+					 SCALAR(1e-1, 0));
+FORMAT(energy)           = SCALAR_FORMAT(3,
+					 (UNSIGNED | HAS_UNDEFINED),
+					 kwh,
+					 SCALAR(1, 0));
+
+/*******************************************************************************
+ * Lighting formats
+ ******************************************************************************/
+FORMAT(chromatic_distance)      = SCALAR_FORMAT_MAX(2,
+						(SIGNED |
+						 HAS_INVALID |
+						 HAS_UNDEFINED),
+						unitless, SCALAR(1e-5, 0),
+						5000);
+FORMAT(chromaticity_coordinate) = SCALAR_FORMAT(2,
+						UNSIGNED,
+						unitless,
+						SCALAR(1, -16));
+FORMAT(correlated_color_temp)	= SCALAR_FORMAT(2,
+						(UNSIGNED | HAS_UNDEFINED),
+						kelvin,
+						SCALAR(1, 0));
+FORMAT(illuminance)		= SCALAR_FORMAT(3,
+						(UNSIGNED | HAS_UNDEFINED),
+						lux,
+						SCALAR(1e-2, 0));
+FORMAT(luminous_efficacy)	= SCALAR_FORMAT(2,
+						(UNSIGNED | HAS_UNDEFINED),
+						lumen_per_watt,
+						SCALAR(1e-1, 0));
+FORMAT(luminous_energy)		= SCALAR_FORMAT(3,
+						(UNSIGNED | HAS_UNDEFINED),
+						lumen_hour,
+						SCALAR(1e3, 0));
+FORMAT(luminous_exposure)	= SCALAR_FORMAT(3,
+						(UNSIGNED | HAS_UNDEFINED),
+						lux_hour,
+						SCALAR(1e3, 0));
+FORMAT(luminous_flux)		= SCALAR_FORMAT(2,
+						(UNSIGNED | HAS_UNDEFINED),
+						lumen,
+						SCALAR(1, 0));
+
+/*******************************************************************************
+ * Miscellaneous formats
+ ******************************************************************************/
+FORMAT(count_16)	 = SCALAR_FORMAT(2,
+					 (UNSIGNED | HAS_UNDEFINED),
+					 unitless,
+					 SCALAR(1, 0));
+FORMAT(gen_lvl)		 = SCALAR_FORMAT(2,
+					 UNSIGNED,
+					 unitless,
+					 SCALAR(1, 0));
+FORMAT(cos_of_the_angle) = SCALAR_FORMAT_MAX(1,
+					     SIGNED,
+					     unitless,
+					     SCALAR(1, 0),
+					     100);
+FORMAT(boolean) = {
+	.encode = boolean_encode,
+	.decode = boolean_decode,
+	.size	= 1,
+#ifdef CONFIG_BT_MESH_SENSOR_LABELS
+	.unit = &bt_mesh_sensor_unit_unitless,
+#endif
+};
+FORMAT(coefficient) = {
+	.encode = float32_encode,
+	.decode = float32_decode,
+	.size	= 4,
+#ifdef CONFIG_BT_MESH_SENSOR_LABELS
+	.unit = &bt_mesh_sensor_unit_unitless,
+#endif
+};
+
+/*******************************************************************************
+ * Sensor types
+ *
+ * Sensor types are stored in a common flash section
+ * ".bt_mesh_sensor_type.static.*". This forces them to be sequential, and lets
+ * us do lookup of IDs without forcing all sensor types into existence. Only
+ * sensor types that are referenced by the application will appear in the
+ * section, the rest will be pruned by the linker.
+ ******************************************************************************/
+static const struct bt_mesh_sensor_channel electric_current_stats[] = {
+	CHANNEL("Avg", electric_current),
+	CHANNEL("Standard deviation", electric_current),
+	CHANNEL("Min", electric_current),
+	CHANNEL("Max", electric_current),
+	CHANNEL("Sensing duration", time_exp_8),
+};
+
+static const struct bt_mesh_sensor_channel voltage_stats[] = {
+	CHANNEL("Avg", voltage),
+	CHANNEL("Standard deviation", voltage),
+	CHANNEL("Min", voltage),
+	CHANNEL("Max", voltage),
+	CHANNEL("Sensing duration", time_exp_8),
+};
+
+/*******************************************************************************
+ * Occupancy
+ ******************************************************************************/
+SENSOR_TYPE(motion_sensed) = {
+	.id = BT_MESH_PROP_ID_MOTION_SENSED,
+	CHANNELS(CHANNEL("Motion sensed", percentage_8)),
+};
+SENSOR_TYPE(motion_threshold) = {
+	.id = BT_MESH_PROP_ID_MOTION_THRESHOLD,
+	CHANNELS(CHANNEL("Motion threshold", percentage_8)),
+};
+SENSOR_TYPE(people_count) = {
+	.id = BT_MESH_PROP_ID_PEOPLE_COUNT,
+	CHANNELS(CHANNEL("People count", count_16)),
+};
+SENSOR_TYPE(presence_detected) = {
+	.id = BT_MESH_PROP_ID_PRESENCE_DETECTED,
+	CHANNELS(CHANNEL("Presence detected", boolean)),
+};
+SENSOR_TYPE(time_since_motion_sensed) = {
+	.id = BT_MESH_PROP_ID_TIME_SINCE_MOTION_SENSED,
+	CHANNELS(CHANNEL("Time since motion detected", time_second_16)),
+};
+SENSOR_TYPE(time_since_presence_detected) = {
+	.id = BT_MESH_PROP_ID_TIME_SINCE_PRESENCE_DETECTED,
+	CHANNELS(CHANNEL("Time since presence detected", time_second_16)),
+};
+
+/*******************************************************************************
+ * Ambient temperature
+ ******************************************************************************/
+SENSOR_TYPE(avg_amb_temp_in_day) = {
+	.id = BT_MESH_PROP_ID_AVG_AMB_TEMP_IN_A_PERIOD_OF_DAY,
+	.flags = BT_MESH_SENSOR_TYPE_FLAG_SERIES,
+	CHANNELS(CHANNEL("Temperature", temp_8),
+		 CHANNEL("Start time", time_decihour_8),
+		 CHANNEL("End time", time_decihour_8)),
+};
+SENSOR_TYPE(indoor_amb_temp_stat_values) = {
+	.id = BT_MESH_PROP_ID_INDOOR_AMB_TEMP_STAT_VALUES,
+	CHANNELS(CHANNEL("Avg", temp_8),
+		 CHANNEL("Standard deviation", temp_8),
+		 CHANNEL("Min", temp_8),
+		 CHANNEL("Max", temp_8),
+		 CHANNEL("Sensing duration", time_exp_8)),
+};
+SENSOR_TYPE(outdoor_stat_values) = {
+	.id = BT_MESH_PROP_ID_OUTDOOR_STAT_VALUES,
+	CHANNELS(CHANNEL("Avg", temp_8),
+		 CHANNEL("Standard deviation", temp_8),
+		 CHANNEL("Min", temp_8),
+		 CHANNEL("Max", temp_8),
+		 CHANNEL("Sensing duration", time_exp_8)),
+};
+SENSOR_TYPE(present_amb_temp) = {
+	.id = BT_MESH_PROP_ID_PRESENT_AMB_TEMP,
+	CHANNELS(CHANNEL("Present ambient temperature", temp_8)),
+};
+SENSOR_TYPE(present_indoor_amb_temp) = {
+	.id = BT_MESH_PROP_ID_PRESENT_INDOOR_AMB_TEMP,
+	CHANNELS(CHANNEL("Present indoor ambient temperature", temp_8)),
+};
+SENSOR_TYPE(present_outdoor_amb_temp) = {
+	.id = BT_MESH_PROP_ID_PRESENT_OUTDOOR_AMB_TEMP,
+	CHANNELS(CHANNEL("Present outdoor ambient temperature", temp_8)),
+};
+SENSOR_TYPE(desired_amb_temp) = {
+	.id = BT_MESH_PROP_ID_DESIRED_AMB_TEMP,
+	CHANNELS(CHANNEL("Desired ambient temperature", temp_8)),
+};
+SENSOR_TYPE(precise_present_amb_temp) = {
+	.id = BT_MESH_PROP_ID_PRECISE_PRESENT_AMB_TEMP,
+	CHANNELS(CHANNEL("Precise present ambient temperature", temp)),
+};
+
+/*******************************************************************************
+ * Environmental
+ ******************************************************************************/
+SENSOR_TYPE(present_amb_rel_humidity) = {
+	.id = BT_MESH_PROP_ID_PRESENT_AMB_REL_HUMIDITY,
+	CHANNELS(CHANNEL("Present ambient relative humidity", humidity)),
+};
+SENSOR_TYPE(present_amb_co2_concentration) = {
+	.id = BT_MESH_PROP_ID_PRESENT_AMB_CO2_CONCENTRATION,
+	CHANNELS(CHANNEL("Present ambient CO2 concentration",
+			 co2_concentration)),
+};
+SENSOR_TYPE(present_amb_voc_concentration) = {
+	.id = BT_MESH_PROP_ID_PRESENT_AMB_VOC_CONCENTRATION,
+	CHANNELS(CHANNEL("Present ambient VOC concentration",
+			 voc_concentration)),
+};
+SENSOR_TYPE(present_amb_noise) = {
+	.id = BT_MESH_PROP_ID_PRESENT_AMB_NOISE,
+	CHANNELS(CHANNEL("Present ambient noise", noise)),
+};
+
+/*******************************************************************************
+ * Device operating temperature
+ ******************************************************************************/
+SENSOR_TYPE(dev_op_temp_range_spec) = {
+	.id = BT_MESH_PROP_ID_DEV_OP_TEMP_RANGE_SPEC,
+	CHANNELS(CHANNEL("Min", temp),
+		 CHANNEL("Max", temp)),
+};
+SENSOR_TYPE(dev_op_temp_stat_values) = {
+	.id = BT_MESH_PROP_ID_DEV_OP_TEMP_STAT_VALUES,
+	CHANNELS(CHANNEL("Avg", temp),
+		 CHANNEL("Standard deviation", temp),
+		 CHANNEL("Min", temp),
+		 CHANNEL("Max", temp),
+		 CHANNEL("Sensing duration", time_exp_8)),
+};
+SENSOR_TYPE(present_dev_op_temp) = {
+	.id = BT_MESH_PROP_ID_PRESENT_DEV_OP_TEMP,
+	CHANNELS(CHANNEL("Temperature", temp)),
+};
+
+SENSOR_TYPE(rel_runtime_in_a_dev_op_temp_range) = {
+	.id = BT_MESH_PROP_ID_REL_RUNTIME_IN_A_DEV_OP_TEMP_RANGE,
+	.flags = BT_MESH_SENSOR_TYPE_FLAG_SERIES,
+	CHANNELS(CHANNEL("Relative value", percentage_8),
+		 CHANNEL("Min", temp),
+		 CHANNEL("Max", temp))
+};
+
+/*******************************************************************************
+ * Electrical input
+ ******************************************************************************/
+SENSOR_TYPE(avg_input_current) = {
+	.id = BT_MESH_PROP_ID_AVG_INPUT_CURRENT,
+	CHANNELS(CHANNEL("Electric current value", electric_current),
+		 CHANNEL("Sensing duration", time_exp_8)),
+};
+SENSOR_TYPE(avg_input_voltage) = {
+	.id = BT_MESH_PROP_ID_AVG_INPUT_VOLTAGE,
+	CHANNELS(CHANNEL("Voltage value", voltage),
+		 CHANNEL("Sensing duration", time_exp_8)),
+};
+SENSOR_TYPE(input_current_range_spec) = {
+	.id = BT_MESH_PROP_ID_INPUT_CURRENT_RANGE_SPEC,
+	CHANNELS(CHANNEL("Min", electric_current),
+		 CHANNEL("Max", electric_current),
+		 CHANNEL("Typical electric current value", electric_current)),
+};
+SENSOR_TYPE(input_current_stat) = {
+	.id = BT_MESH_PROP_ID_INPUT_CURRENT_STAT,
+	.channel_count = ARRAY_SIZE(electric_current_stats),
+	.channels = electric_current_stats,
+};
+SENSOR_TYPE(input_voltage_range_spec) = {
+	.id = BT_MESH_PROP_ID_INPUT_VOLTAGE_RANGE_SPEC,
+	CHANNELS(CHANNEL("Min", voltage),
+		 CHANNEL("Max", voltage),
+		 CHANNEL("Typical voltage value", voltage)),
+};
+SENSOR_TYPE(input_voltage_stat) = {
+	.id = BT_MESH_PROP_ID_INPUT_VOLTAGE_STAT,
+	.channel_count = ARRAY_SIZE(voltage_stats),
+	.channels = voltage_stats,
+};
+SENSOR_TYPE(present_input_current) = {
+	.id = BT_MESH_PROP_ID_PRESENT_INPUT_CURRENT,
+	CHANNELS(CHANNEL("Present input current", electric_current)),
+};
+SENSOR_TYPE(present_input_ripple_voltage) = {
+	.id = BT_MESH_PROP_ID_PRESENT_INPUT_RIPPLE_VOLTAGE,
+	CHANNELS(CHANNEL("Present input ripple voltage", percentage_8)),
+};
+SENSOR_TYPE(present_input_voltage) = {
+	.id = BT_MESH_PROP_ID_PRESENT_INPUT_VOLTAGE,
+	CHANNELS(CHANNEL("Present input voltage", voltage)),
+};
+SENSOR_TYPE(rel_runtime_in_an_input_current_range) = {
+	.id = BT_MESH_PROP_ID_REL_RUNTIME_IN_AN_INPUT_CURRENT_RANGE,
+	.flags = BT_MESH_SENSOR_TYPE_FLAG_SERIES,
+	CHANNELS(CHANNEL("Relative runtime value", percentage_8),
+		 CHANNEL("Min", electric_current),
+		 CHANNEL("Max", electric_current)),
+};
+
+SENSOR_TYPE(rel_runtime_in_an_input_voltage_range) = {
+	.id = BT_MESH_PROP_ID_REL_RUNTIME_IN_AN_INPUT_VOLTAGE_RANGE,
+	.flags = BT_MESH_SENSOR_TYPE_FLAG_SERIES,
+	CHANNELS(CHANNEL("Relative runtime value", percentage_8),
+		 CHANNEL("Min", voltage),
+		 CHANNEL("Max", voltage)),
+};
+
+/*******************************************************************************
+ * Energy management
+ ******************************************************************************/
+SENSOR_TYPE(present_dev_input_power) = {
+	.id = BT_MESH_PROP_ID_PRESENT_DEV_INPUT_POWER,
+	CHANNELS(CHANNEL("Present device input power", power)),
+};
+SENSOR_TYPE(present_dev_op_efficiency) = {
+	.id = BT_MESH_PROP_ID_PRESENT_DEV_OP_EFFICIENCY,
+	CHANNELS(CHANNEL("Present device operating efficiency", percentage_8)),
+};
+SENSOR_TYPE(tot_dev_energy_use) = {
+	.id = BT_MESH_PROP_ID_TOT_DEV_ENERGY_USE,
+	CHANNELS(CHANNEL("Total device energy use", energy)),
+};
+SENSOR_TYPE(precise_tot_dev_energy_use) = {
+	.id = BT_MESH_PROP_ID_PRECISE_TOT_DEV_ENERGY_USE,
+	CHANNELS(CHANNEL("Total device energy use", energy32)),
+};
+SENSOR_TYPE(dev_energy_use_since_turn_on) = {
+	.id = BT_MESH_PROP_ID_DEV_ENERGY_USE_SINCE_TURN_ON,
+	CHANNELS(CHANNEL("Device energy use since turn on", energy)),
+};
+SENSOR_TYPE(power_factor) = {
+	.id = BT_MESH_PROP_ID_POWER_FACTOR,
+	CHANNELS(CHANNEL("Cosine of the angle", cos_of_the_angle)),
+};
+SENSOR_TYPE(rel_dev_energy_use_in_a_period_of_day) = {
+	.id = BT_MESH_PROP_ID_REL_DEV_ENERGY_USE_IN_A_PERIOD_OF_DAY,
+	.flags = BT_MESH_SENSOR_TYPE_FLAG_SERIES,
+	CHANNELS(CHANNEL("Energy", energy),
+		 CHANNEL("Start time", time_decihour_8),
+		 CHANNEL("End time", time_decihour_8)),
+};
+SENSOR_TYPE(rel_dev_runtime_in_a_generic_level_range) = {
+	.id = BT_MESH_PROP_ID_REL_DEV_RUNTIME_IN_A_GENERIC_LEVEL_RANGE,
+	.flags = BT_MESH_SENSOR_TYPE_FLAG_SERIES,
+	CHANNELS(CHANNEL("Relative value", percentage_8),
+		 CHANNEL("Min", gen_lvl),
+		 CHANNEL("Max", gen_lvl)),
+};
+
+/*******************************************************************************
+ * Photometry
+ ******************************************************************************/
+SENSOR_TYPE(present_amb_light_level) = {
+	.id = BT_MESH_PROP_ID_PRESENT_AMB_LIGHT_LEVEL,
+	CHANNELS(CHANNEL("Present ambient light level", illuminance)),
+};
+SENSOR_TYPE(present_cie_1931_chromaticity_coords) = {
+	.id = BT_MESH_PROP_ID_PRESENT_CIE_1931_CHROMATICITY_COORDS,
+	CHANNELS(CHANNEL("Chromaticity x-coordinate", chromaticity_coordinate),
+		 CHANNEL("Chromaticity y-coordinate", chromaticity_coordinate)),
+};
+SENSOR_TYPE(present_correlated_col_temp) = {
+	.id = BT_MESH_PROP_ID_PRESENT_CORRELATED_COL_TEMP,
+	CHANNELS(CHANNEL("Present correlated color temperature",
+			 correlated_color_temp)),
+};
+SENSOR_TYPE(present_illuminance) = {
+	.id = BT_MESH_PROP_ID_PRESENT_ILLUMINANCE,
+	CHANNELS(CHANNEL("Present illuminance", illuminance)),
+};
+SENSOR_TYPE(present_luminous_flux) = {
+	.id = BT_MESH_PROP_ID_PRESENT_LUMINOUS_FLUX,
+	CHANNELS(CHANNEL("Present luminous flux", luminous_flux)),
+};
+SENSOR_TYPE(present_planckian_distance) = {
+	.id = BT_MESH_PROP_ID_PRESENT_PLANCKIAN_DISTANCE,
+	CHANNELS(CHANNEL("Present planckian distance", chromatic_distance)),
+};
+SENSOR_TYPE(rel_exposure_time_in_an_illuminance_range) = {
+	.id = BT_MESH_PROP_ID_REL_EXPOSURE_TIME_IN_AN_ILLUMINANCE_RANGE,
+	.flags = BT_MESH_SENSOR_TYPE_FLAG_SERIES,
+	CHANNELS(CHANNEL("Relative value", percentage_8),
+		 CHANNEL("Min", illuminance),
+		 CHANNEL("Max", illuminance))
+};
+SENSOR_TYPE(tot_light_exposure_time) = {
+	.id = BT_MESH_PROP_ID_TOT_LIGHT_EXPOSURE_TIME,
+	CHANNELS(CHANNEL("Total light exposure time", time_hour_24)),
+};
+SENSOR_TYPE(lumen_maintenance_factor) = {
+	.id = BT_MESH_PROP_ID_LUMEN_MAINTENANCE_FACTOR,
+	CHANNELS(CHANNEL("Lumen maintenance factor", percentage_8)),
+};
+SENSOR_TYPE(luminous_efficacy) = {
+	.id = BT_MESH_PROP_ID_LUMINOUS_EFFICACY,
+	CHANNELS(CHANNEL("Luminous efficacy", luminous_efficacy)),
+};
+SENSOR_TYPE(luminous_energy_since_turn_on) = {
+	.id = BT_MESH_PROP_ID_LUMINOUS_ENERGY_SINCE_TURN_ON,
+	CHANNELS(CHANNEL("Luminous energy since turn on", luminous_energy)),
+};
+SENSOR_TYPE(luminous_exposure) = {
+	.id = BT_MESH_PROP_ID_LUMINOUS_EXPOSURE,
+	CHANNELS(CHANNEL("Luminous exposure", luminous_exposure)),
+};
+SENSOR_TYPE(luminous_flux_range) = {
+	.id = BT_MESH_PROP_ID_LUMINOUS_FLUX_RANGE,
+	CHANNELS(CHANNEL("Min", luminous_flux),
+		 CHANNEL("Max", luminous_flux)),
+};
+
+/*******************************************************************************
+ * Power supply output
+ ******************************************************************************/
+SENSOR_TYPE(avg_output_current) = {
+	.id = BT_MESH_PROP_ID_AVG_OUTPUT_CURRENT,
+	CHANNELS(CHANNEL("Electric current value", electric_current),
+		 CHANNEL("Sensing duration", time_exp_8)),
+};
+SENSOR_TYPE(avg_output_voltage) = {
+	.id = BT_MESH_PROP_ID_AVG_OUTPUT_VOLTAGE,
+	CHANNELS(CHANNEL("Voltage value", voltage),
+		 CHANNEL("Sensing duration", time_exp_8)),
+};
+SENSOR_TYPE(output_current_range) = {
+	.id = BT_MESH_PROP_ID_OUTPUT_CURRENT_RANGE,
+	CHANNELS(CHANNEL("Min", electric_current),
+		 CHANNEL("Max", electric_current)),
+};
+SENSOR_TYPE(output_current_stat) = {
+	.id = BT_MESH_PROP_ID_OUTPUT_CURRENT_STAT,
+	.channel_count = ARRAY_SIZE(electric_current_stats),
+	.channels = electric_current_stats,
+};
+SENSOR_TYPE(output_ripple_voltage_spec) = {
+	.id = BT_MESH_PROP_ID_OUTPUT_RIPPLE_VOLTAGE_SPEC,
+	CHANNELS(CHANNEL("Output ripple voltage", percentage_8)),
+};
+SENSOR_TYPE(output_voltage_range) = {
+	.id = BT_MESH_PROP_ID_OUTPUT_VOLTAGE_RANGE,
+	CHANNELS(CHANNEL("Min", voltage),
+		 CHANNEL("Max", voltage)),
+};
+SENSOR_TYPE(output_voltage_stat) = {
+	.id = BT_MESH_PROP_ID_OUTPUT_VOLTAGE_STAT,
+	.channel_count = ARRAY_SIZE(voltage_stats),
+	.channels = voltage_stats,
+};
+SENSOR_TYPE(present_output_current) = {
+	.id = BT_MESH_PROP_ID_PRESENT_OUTPUT_CURRENT,
+	CHANNELS(CHANNEL("Present output current", electric_current)),
+};
+SENSOR_TYPE(present_output_voltage) = {
+	.id = BT_MESH_PROP_ID_PRESENT_OUTPUT_VOLTAGE,
+	CHANNELS(CHANNEL("Present output voltage", voltage)),
+};
+SENSOR_TYPE(present_rel_output_ripple_voltage) = {
+	.id = BT_MESH_PROP_ID_PRESENT_REL_OUTPUT_RIPPLE_VOLTAGE,
+	CHANNELS(CHANNEL("Output ripple voltage", percentage_8)),
+};
+
+SENSOR_TYPE(gain) = {
+	.id = BT_MESH_PROP_ID_SENSOR_GAIN,
+	CHANNELS(CHANNEL("Sensor gain", coefficient)),
+};
+/******************************************************************************/
+
+const struct bt_mesh_sensor_type *bt_mesh_sensor_type_get(u16_t id)
+{
+	Z_STRUCT_SECTION_FOREACH(bt_mesh_sensor_type, type) {
+		if (type->id == id) {
+			return type;
+		}
+	}
+
+	return NULL;
+}

--- a/subsys/bluetooth/mesh/sensor_types.ld
+++ b/subsys/bluetooth/mesh/sensor_types.ld
@@ -1,0 +1,10 @@
+SECTION_DATA_PROLOGUE(bt_mesh_sensor_types_sections,,SUBALIGN(4))
+{
+	_bt_mesh_sensor_type_list_start = .;
+#ifdef CONFIG_BT_MESH_SENSOR_ALL_TYPES
+	KEEP(*(SORT_BY_NAME("._bt_mesh_sensor_type.static.*")));
+#else
+	*(SORT_BY_NAME("._bt_mesh_sensor_type.static.*"));
+#endif
+	_bt_mesh_sensor_type_list_end = .;
+} GROUP_LINK_IN(ROMABLE_REGION)


### PR DESCRIPTION
Adds the sensor models, and all the required scaffolding around it to
connect the sensors to the Zephyr sensor API.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>