### PR TITLE
fprotect: Add workaround for nRF53 erratum 19

### DIFF
--- a/lib/fprotect/Kconfig
+++ b/lib/fprotect/Kconfig
@@ -11,12 +11,19 @@ config FPROTECT
 	  Use hardware peripherals (BPROT, ACL, or SPU) to write-protect
 	  regions of flash until next reset.
 
-if FPROTECT
-config FPROTECT_BLOCK_SIZE
-	int "Block size of fprotect"
-	default 32768 if SOC_NRF9160
-	default 16384 if SOC_NRF5340_CPUAPP
-	default $(dt_int_val,DT_SOC_NV_FLASH_1000000_ERASE_BLOCK_SIZE) if SOC_NRF5340_CPUNET
-	default $(dt_int_val,DT_SOC_NV_FLASH_0_ERASE_BLOCK_SIZE)
+
+if !ARM
+config NRF_SPU_FLASH_REGION_SIZE
+	hex
+	default 0x1000
+	help
+	  Redefinition for the benefit of qemu_x86
 endif
 
+if FPROTECT
+config FPROTECT_BLOCK_SIZE
+	hex "Block size of fprotect"
+	default NRF_SPU_FLASH_REGION_SIZE if SOC_NRF9160 || SOC_NRF5340_CPUAPP
+	default $(dt_hex_val,DT_SOC_NV_FLASH_1000000_ERASE_BLOCK_SIZE) if SOC_NRF5340_CPUNET
+	default $(dt_hex_val,DT_SOC_NV_FLASH_0_ERASE_BLOCK_SIZE)
+endif

--- a/lib/fprotect/fprotect_spu.c
+++ b/lib/fprotect/fprotect_spu.c
@@ -8,17 +8,26 @@
 #include <string.h>
 #include <hal/nrf_spu.h>
 #include <errno.h>
+#include <soc.h>
+
+
+#if defined(CONFIG_SOC_NRF5340_CPUAPP) \
+	&& defined(CONFIG_NRF5340_CPUAPP_ERRATUM19)
+#define SPU_BLOCK_SIZE (nrf53_has_erratum19() ? 32*1024 : 16*1024)
+#else
+#define SPU_BLOCK_SIZE CONFIG_FPROTECT_BLOCK_SIZE
+#endif
 
 int fprotect_area(u32_t start, size_t length)
 {
-	if (start % CONFIG_FPROTECT_BLOCK_SIZE != 0 ||
-		length % CONFIG_FPROTECT_BLOCK_SIZE != 0) {
+	if (start % SPU_BLOCK_SIZE != 0 ||
+		length % SPU_BLOCK_SIZE != 0) {
 		return -EINVAL;
 	}
 
-	for (u32_t i = 0; i < length / CONFIG_FPROTECT_BLOCK_SIZE; i++) {
+	for (u32_t i = 0; i < length / SPU_BLOCK_SIZE; i++) {
 		nrf_spu_flashregion_set(NRF_SPU_S,
-				(start / CONFIG_FPROTECT_BLOCK_SIZE) + i,
+				(start / SPU_BLOCK_SIZE) + i,
 				true,
 				NRF_SPU_MEM_PERM_EXECUTE |
 				NRF_SPU_MEM_PERM_READ,

--- a/subsys/bootloader/Kconfig
+++ b/subsys/bootloader/Kconfig
@@ -130,8 +130,8 @@ menuconfig IS_SECURE_BOOTLOADER
 if IS_SECURE_BOOTLOADER
 
 config PM_PARTITION_SIZE_PROVISION
-	int
-	default 128 if SOC_NRF9160 || SOC_NRF5340_CPUAPP # Stored in OTP region
+	hex
+	default 0x80 if SOC_NRF9160 || SOC_NRF5340_CPUAPP # Stored in OTP region
 	default FPROTECT_BLOCK_SIZE
 	prompt "Flash space reserved for PROVISION" if !(SOC_NRF9160 || SOC_NRF5340_CPUAPP)
 	help
@@ -139,8 +139,8 @@ config PM_PARTITION_SIZE_PROVISION
 
 config PM_PARTITION_SIZE_B0_IMAGE
 	hex "Flash space reserved for B0_IMAGE"
-	default 0x8000 if SOC_NRF9160 || SOC_NRF5340_CPUAPP
-	default 0x7800 if SOC_NRF5340_CPUNET
+	default FPROTECT_BLOCK_SIZE if SOC_NRF9160 || SOC_NRF5340_CPUAPP
+	default 0x3800 if SOC_NRF5340_CPUNET
 	default 0x7000
 	help
 	  Flash space set aside for the B0_IMAGE partition.


### PR DESCRIPTION
More info: https://github.com/NordicPlayground/fw-nrfconnect-zephyr/pull/277

Depends on: ~https://github.com/NordicPlayground/fw-nrfconnect-zephyr/pull/277~ (merged)