### PR TITLE
SPM: Properly support nRF53 in FLASH and RAM configurations

### DIFF
--- a/subsys/spm/secure_services.ld
+++ b/subsys/spm/secure_services.ld
@@ -1,9 +1,9 @@
 #if USE_PARTITION_MANAGER
 	#include <pm_config.h>
-	#define SPU_REGION_SIZE 32768
 	#define NON_SECURE_APP_ADDRESS PM_APP_ADDRESS
-	ASSERT(((_image_rom_start + _flash_used - 1) / SPU_REGION_SIZE)
-		< (NON_SECURE_APP_ADDRESS / SPU_REGION_SIZE),
+	ASSERT(((_image_rom_start + _flash_used - 1)
+			/ CONFIG_NRF_SPU_FLASH_REGION_SIZE)
+		< (NON_SECURE_APP_ADDRESS / CONFIG_NRF_SPU_FLASH_REGION_SIZE),
 		"SPM and app are sharing an SPU region. \
 Cannot partition flash correctly into secure and non-secure. \
 Adjust partitions sizes so they are placed in separate regions." )

--- a/subsys/spm/spm.c
+++ b/subsys/spm/spm.c
@@ -154,19 +154,17 @@ static void config_regions(bool ram, size_t start, size_t end, u32_t perm)
 		} else {
 			NRF_SPU->FLASHREGION[i].PERM = perm;
 		}
-		PRINT("%02u 0x%05x 0x%05x \t", i,
-					region_size * i, region_size * (i + 1));
-		PRINT("%s", perm & (ram ? SRAM_SECURE : FLASH_SECURE)
-							? "Secure\t\t" :
-							  "Non-Secure\t");
-		PRINT("%c", perm & (ram ? SRAM_READ : FLASH_READ)  ? 'r' : '-');
-		PRINT("%c", perm & (ram ? SRAM_WRITE : FLASH_WRITE)
-								? 'w' : '-');
-		PRINT("%c", perm & (ram ? SRAM_EXEC : FLASH_EXEC)  ? 'x' : '-');
-		PRINT("%c", perm & (ram ? SRAM_LOCK : FLASH_LOCK)  ? 'l' : '-');
-		PRINT("\n");
 	}
 
+	PRINT("%02u %02u 0x%05x 0x%05x \t", start, end - 1,
+				region_size * start, region_size * end);
+	PRINT("%s", perm & (ram ? SRAM_SECURE : FLASH_SECURE) ? "Secure\t\t" :
+								"Non-Secure\t");
+	PRINT("%c", perm & (ram ? SRAM_READ : FLASH_READ)  ? 'r' : '-');
+	PRINT("%c", perm & (ram ? SRAM_WRITE : FLASH_WRITE) ? 'w' : '-');
+	PRINT("%c", perm & (ram ? SRAM_EXEC : FLASH_EXEC)  ? 'x' : '-');
+	PRINT("%c", perm & (ram ? SRAM_LOCK : FLASH_LOCK)  ? 'l' : '-');
+	PRINT("\n");
 }
 
 

--- a/subsys/spm/spm.c
+++ b/subsys/spm/spm.c
@@ -10,6 +10,7 @@
 #include <linker/linker-defs.h>
 #include <device.h>
 #include <drivers/gpio.h>
+#include <hal/nrf_spu.h>
 #include "spm_internal.h"
 
 #if !defined(CONFIG_ARM_SECURE_FIRMWARE)
@@ -134,8 +135,8 @@ static void spm_config_nsc_flash(void)
 		"The Non-Secure Callable region is overflowed by %d byte(s).\n",
 		(u32_t)__sg_size - nsc_size);
 
-	NRF_SPU->FLASHNSC[0].REGION = FLASH_NSC_REGION_FROM_ADDR(__sg_start);
-	NRF_SPU->FLASHNSC[0].SIZE = FLASH_NSC_SIZE_REG(nsc_size);
+	nrf_spu_flashnsc_set(NRF_SPU, 0, FLASH_NSC_SIZE_REG(nsc_size),
+			FLASH_NSC_REGION_FROM_ADDR(__sg_start), false);
 
 	PRINT("Non-secure callable region 0 placed in flash region %d with size %d.\n",
 		NRF_SPU->FLASHNSC[0].REGION, NRF_SPU->FLASHNSC[0].SIZE << 5);

--- a/subsys/spm/spm.c
+++ b/subsys/spm/spm.c
@@ -29,11 +29,12 @@
 #define NON_SECURE_APP_ADDRESS DT_FLASH_AREA_IMAGE_0_NONSECURE_OFFSET_0
 #endif /* USE_PARTITION_MANAGER */
 
-#define FIRST_NONSECURE_ADDRESS (NON_SECURE_APP_ADDRESS)
-#define LAST_SECURE_REGION_INDEX \
-	((FIRST_NONSECURE_ADDRESS / FLASH_SECURE_ATTRIBUTION_REGION_SIZE) - 1)
+#define NON_SECURE_RAM_OFFSET 0x10000
 
-BUILD_ASSERT_MSG(LAST_SECURE_REGION_INDEX != -1, "SPM is too small.");
+#define NON_SECURE_FLASH_REGION_INDEX \
+	((NON_SECURE_APP_ADDRESS) / (FLASH_SECURE_ATTRIBUTION_REGION_SIZE))
+#define NON_SECURE_RAM_REGION_INDEX \
+	((NON_SECURE_RAM_OFFSET) / (RAM_SECURE_ATTRIBUTION_REGION_SIZE))
 
 /*
  *  * The security configuration for depends on where the non secure app
@@ -138,9 +139,35 @@ static void spm_config_nsc_flash(void)
 
 	PRINT("Non-secure callable region 0 placed in flash region %d with size %d.\n",
 		NRF_SPU->FLASHNSC[0].REGION, NRF_SPU->FLASHNSC[0].SIZE << 5);
-	PRINT("\n");
 }
 #endif /* CONFIG_ARM_FIRMWARE_HAS_SECURE_ENTRY_FUNCS */
+
+
+static void config_regions(bool ram, size_t start, size_t end, u32_t perm)
+{
+	const size_t region_size = ram ? RAM_SECURE_ATTRIBUTION_REGION_SIZE
+					: FLASH_SECURE_ATTRIBUTION_REGION_SIZE;
+
+	for (size_t i = start; i < end; i++) {
+		if (ram) {
+			NRF_SPU->RAMREGION[i].PERM = perm;
+		} else {
+			NRF_SPU->FLASHREGION[i].PERM = perm;
+		}
+		PRINT("%02u 0x%05x 0x%05x \t", i,
+					region_size * i, region_size * (i + 1));
+		PRINT("%s", perm & (ram ? SRAM_SECURE : FLASH_SECURE)
+							? "Secure\t\t" :
+							  "Non-Secure\t");
+		PRINT("%c", perm & (ram ? SRAM_READ : FLASH_READ)  ? 'r' : '-');
+		PRINT("%c", perm & (ram ? SRAM_WRITE : FLASH_WRITE)
+								? 'w' : '-');
+		PRINT("%c", perm & (ram ? SRAM_EXEC : FLASH_EXEC)  ? 'x' : '-');
+		PRINT("%c", perm & (ram ? SRAM_LOCK : FLASH_LOCK)  ? 'l' : '-');
+		PRINT("\n");
+	}
+
+}
 
 
 static void spm_config_flash(void)
@@ -148,37 +175,23 @@ static void spm_config_flash(void)
 	/* Regions of flash up to and including SPM are configured as Secure.
 	 * The rest of flash is configured as Non-Secure.
 	 */
-	static const u32_t flash_perm[] = {
-		/* Configuration for Secure Regions */
-		[0 ... LAST_SECURE_REGION_INDEX] =
-			FLASH_READ | FLASH_WRITE | FLASH_EXEC |
-			FLASH_LOCK | FLASH_SECURE,
-		/* Configuration for Non Secure Regions */
-		[(LAST_SECURE_REGION_INDEX + 1) ... 31] =
-			FLASH_READ | FLASH_WRITE | FLASH_EXEC |
-			FLASH_LOCK | FLASH_NONSEC,
-	};
+	const u32_t secure_flash_perm = FLASH_READ | FLASH_WRITE | FLASH_EXEC
+			| FLASH_LOCK | FLASH_SECURE;
+	const u32_t nonsecure_flash_perm = FLASH_READ | FLASH_WRITE | FLASH_EXEC
+			| FLASH_LOCK | FLASH_NONSEC;
 
-	PRINT("Flash region\t\tDomain\t\tPermissions\n");
+	PRINT("Flash regions\t\tDomain\t\tPermissions\n");
 
-	/* Assign permissions */
-	for (size_t i = 0; i < ARRAY_SIZE(flash_perm); i++) {
-
-		NRF_SPU->FLASHREGION[i].PERM = flash_perm[i];
-
-		PRINT("%02u 0x%05x 0x%05x \t", i, 32 * KB(i), 32 * KB(i + 1));
-		PRINT("%s", flash_perm[i] & FLASH_SECURE ? "Secure\t\t" :
-							   "Non-Secure\t");
-
-		PRINT("%c", flash_perm[i] & FLASH_READ  ? 'r' : '-');
-		PRINT("%c", flash_perm[i] & FLASH_WRITE ? 'w' : '-');
-		PRINT("%c", flash_perm[i] & FLASH_EXEC  ? 'x' : '-');
-		PRINT("%c", flash_perm[i] & FLASH_LOCK  ? 'l' : '-');
-		PRINT("\n");
-	}
+	config_regions(false, 0, NON_SECURE_FLASH_REGION_INDEX,
+			secure_flash_perm);
+	config_regions(false, NON_SECURE_FLASH_REGION_INDEX,
+			NUM_FLASH_SECURE_ATTRIBUTION_REGIONS,
+			nonsecure_flash_perm);
+	PRINT("\n");
 
 #if defined(CONFIG_ARM_FIRMWARE_HAS_SECURE_ENTRY_FUNCS)
 	spm_config_nsc_flash();
+	PRINT("\n");
 
 #if defined(CONFIG_SPM_SECURE_SERVICES)
 	int err = spm_secure_services_init();
@@ -188,8 +201,6 @@ static void spm_config_flash(void)
 	}
 #endif
 #endif /* CONFIG_ARM_FIRMWARE_HAS_SECURE_ENTRY_FUNCS */
-
-	PRINT("\n");
 }
 
 static void spm_config_sram(void)
@@ -197,32 +208,21 @@ static void spm_config_sram(void)
 	/* Lower 64 kB of SRAM is allocated to the Secure firmware image.
 	 * The rest of SRAM is allocated to Non-Secure firmware image.
 	 */
-	static const u32_t sram_perm[] = {
-		/* Configuration for Regions 0 - 7 (0 - 64 kB) */
-		[0 ... 7] = SRAM_READ | SRAM_WRITE | SRAM_EXEC |
-			    SRAM_LOCK | SRAM_SECURE,
-		/* Configuration for Regions 8 - 31 (64 - 256 kB) */
-		[8 ... 31] = SRAM_READ | SRAM_WRITE | SRAM_EXEC |
-			     SRAM_LOCK | SRAM_NONSEC,
-	};
+
+	const u32_t secure_ram_perm = SRAM_READ | SRAM_WRITE | SRAM_EXEC
+		| SRAM_LOCK | SRAM_SECURE;
+	const u32_t nonsecure_ram_perm = SRAM_READ | SRAM_WRITE | SRAM_EXEC
+		| SRAM_LOCK | SRAM_NONSEC;
 
 	PRINT("SRAM region\t\tDomain\t\tPermissions\n");
 
-	/* Assign permissions */
-	for (size_t i = 0; i < ARRAY_SIZE(sram_perm); i++) {
-
-		NRF_SPU->RAMREGION[i].PERM = sram_perm[i];
-
-		PRINT("%02u 0x%05x 0x%05x\t", i, 8 * KB(i), 8 * KB(i + 1));
-		PRINT("%s", sram_perm[i] & SRAM_SECURE ? "Secure\t\t" :
-							 "Non-Secure\t");
-
-		PRINT("%c", sram_perm[i] & SRAM_READ  ? 'r' : '-');
-		PRINT("%c", sram_perm[i] & SRAM_WRITE ? 'w' : '-');
-		PRINT("%c", sram_perm[i] & SRAM_EXEC  ? 'x' : '-');
-		PRINT("%c", sram_perm[i] & SRAM_LOCK  ? 'l' : '-');
-		PRINT("\n");
-	}
+	/* Configuration for Secure RAM Regions (0 - 64 kB) */
+	config_regions(true, 0, NON_SECURE_RAM_REGION_INDEX,
+			secure_ram_perm);
+	/* Configuration for Non-Secure RAM Regions (64 kb - end) */
+	config_regions(true, NON_SECURE_RAM_REGION_INDEX,
+			NUM_RAM_SECURE_ATTRIBUTION_REGIONS,
+			nonsecure_ram_perm);
 	PRINT("\n");
 }
 

--- a/subsys/spm/spm_internal.h
+++ b/subsys/spm/spm_internal.h
@@ -10,14 +10,59 @@
 #include <zephyr.h>
 #include <nrfx.h>
 #include <sys/util.h>
+#include <sys/__assert.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 
-/* Size of secure attribution configurable flash region. */
-#define FLASH_SECURE_ATTRIBUTION_REGION_SIZE (32*1024)
+/* Total RAM Size */
+#ifdef CONFIG_SOC_NRF9160
+#define TOTAL_RAM_SIZE (256*1024)
+#elif defined(CONFIG_SOC_NRF5340_CPUAPP)
+#define TOTAL_RAM_SIZE (512*1024)
+#endif
+
+/* SPU RAM regions */
+#define RAM_SECURE_ATTRIBUTION_REGION_SIZE CONFIG_NRF_SPU_RAM_REGION_SIZE
+#define NUM_RAM_SECURE_ATTRIBUTION_REGIONS (TOTAL_RAM_SIZE \
+				/ RAM_SECURE_ATTRIBUTION_REGION_SIZE)
+
+/* SPU FLASH regions */
+#if (defined(CONFIG_SOC_NRF5340_CPUAPP) \
+	&& defined(CONFIG_NRF5340_CPUAPP_ERRATUM19))
+static inline u32_t spu_flash_region_size(void)
+{
+	if (NRF_FICR->INFO.PART == 0x5340) {
+		if (NRF_FICR->INFO.VARIANT == 0x41414142) {
+			return 32*1024;
+		}
+		return 16*1024;
+	}
+	__ASSERT(false, "Function should only be called on an nRF53 device.");
+	return 0;
+}
+
+static inline u32_t num_spu_flash_regions(void)
+{
+	if (NRF_FICR->INFO.PART == 0x5340) {
+		if (NRF_FICR->INFO.VARIANT == 0x41414142) {
+			return 32;
+		}
+		return 64;
+	}
+	__ASSERT(false, "Function should only be called on an nRF53 device.");
+	return 0;
+}
+#define FLASH_SECURE_ATTRIBUTION_REGION_SIZE spu_flash_region_size()
+#define NUM_FLASH_SECURE_ATTRIBUTION_REGIONS num_spu_flash_regions()
+#else
+
+#define FLASH_SECURE_ATTRIBUTION_REGION_SIZE CONFIG_NRF_SPU_FLASH_REGION_SIZE
+#define NUM_FLASH_SECURE_ATTRIBUTION_REGIONS (DT_SOC_NV_FLASH_0_SIZE \
+				/ FLASH_SECURE_ATTRIBUTION_REGION_SIZE)
+#endif
 
 /* Minimum size of Non-Secure Callable regions. */
 #define FLASH_NSC_MIN_SIZE 32

--- a/west.yml
+++ b/west.yml
@@ -38,7 +38,7 @@ manifest:
     - name: zephyr
       repo-path: fw-nrfconnect-zephyr
       west-commands: scripts/west-commands.yml
-      revision: 30f47eace36c9593c8f6efacebc75c0f66aa7b17
+      revision: pull/277/head
     - name: segger
       revision: 6fcf61606d6012d2c44129edc033f59331e268bc
       path: modules/debug/segger


### PR DESCRIPTION
The logic has been refactored.

The second commit also changes the printing. Instead of listing all regions, printing now looks like this:

    Flash regions           Domain          Permissions
    00 04 0x00000 0x28000   Secure          rwxl
    05 31 0x28000 0x100000  Non-Secure      rwxl

    Non-secure callable region 0 placed in flash region 4 with size 32.

    SRAM region             Domain          Permissions
    00 07 0x00000 0x10000   Secure          rwxl
    08 63 0x10000 0x80000   Non-Secure      rwxl
