### PR TITLE
cmake: remove support for b0 without s1

### DIFF
--- a/samples/bootloader/pm.yml
+++ b/samples/bootloader/pm.yml
@@ -15,9 +15,12 @@ s0_pad:
     after: b0
     align: {start: CONFIG_FPROTECT_BLOCK_SIZE}
 
+spm_app:
+  span: [spm, app]
+
 s0_image:
   # S0 spans over the image booted by B0
-  span: {one_of: [mcuboot, spm, app]}
+  span: {one_of: [mcuboot, spm_app]}
 
 s0:
   # Phony container to allow hex overriding
@@ -31,10 +34,9 @@ s1_pad:
     align: {start: DT_FLASH_ERASE_BLOCK_SIZE}
 
 s1_image:
-  # This partition will only exist if mcuboot exists.
-  share_size: mcuboot
+  share_size: {one_of: [mcuboot, s0_image]}
   placement:
-    after: s1_pad
+    after: [s1_pad, s0]
     align: {end: CONFIG_FPROTECT_BLOCK_SIZE}
 
 s1:

--- a/scripts/bootloader/hash.py
+++ b/scripts/bootloader/hash.py
@@ -18,7 +18,8 @@ def parse_args():
 
     parser.add_argument("--infile", "-i", "--in", "-in", required=True,
                         help="Hash the contents of the specified file. If a *.hex file is given, the contents will "
-                             "first be converted to binary. For all other file types, no conversion is done.")
+                             "first be converted to binary, with all non-specified area being set to 0xff. "
+                             "For all other file types, no conversion is done.")
     return parser.parse_args()
 
 
@@ -27,8 +28,7 @@ if __name__ == "__main__":
 
     if args.infile.endswith('.hex'):
         ih = IntelHex(args.infile)
-        if len(ih) - 1 != (ih.maxaddr() - ih.minaddr()):
-            raise RuntimeError("Non-contiguous hex file not supported.")
+        ih.padding = 0xff  # Allows hashing with empty regions
         to_hash = ih.tobinstr()
     else:
         to_hash = open(args.infile, 'rb').read()

--- a/scripts/bootloader/provision.py
+++ b/scripts/bootloader/provision.py
@@ -29,9 +29,8 @@ def parse_args():
     parser = argparse.ArgumentParser(
         description="Generate provision hex file.",
         formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument("--s0-addr", type=lambda x: int(x, 0), required=True, help="Set address of s0")
-    parser.add_argument("--s1-addr", type=lambda x: int(x, 0), required=False,
-                        help="Set address of s1. Will default to value of --s0-addr if not set.")
+    parser.add_argument("--s0-addr", type=lambda x: int(x, 0), required=True, help="Address of image slot s0")
+    parser.add_argument("--s1-addr", type=lambda x: int(x, 0), required=True, help="Address of image slot s1")
     parser.add_argument("--provision-addr", type=lambda x: int(x, 0),
                         required=True, help="Set address of provision data")
     parser.add_argument("--public-key-files", required=True,

--- a/subsys/bootloader/Kconfig
+++ b/subsys/bootloader/Kconfig
@@ -8,8 +8,7 @@ menu "Bootloader"
 
 config MCUBOOT_BUILD_S1_VARIANT
 	bool
-	prompt "Build S1 variant of mcuboot" if !SECURE_BOOT
-	default y if SECURE_BOOT
+	prompt "Build S1 variant of mcuboot"
 
 config SECURE_BOOT
 	bool "Use Secure Bootloader"

--- a/subsys/bootloader/image/CMakeLists.txt
+++ b/subsys/bootloader/image/CMakeLists.txt
@@ -27,9 +27,6 @@ if (CONFIG_BOOTLOADER_MCUBOOT)
     ${CMAKE_CURRENT_SOURCE_DIR}/multi_image_mcuboot.conf
     )
 
-  # Partition S1 is only enabled when MCUBoot is enabled.
-  set(s1_addr $<TARGET_PROPERTY:partition_manager,PM_S1_ADDRESS>)
-
 else()
 
   if (CONFIG_SPM)
@@ -46,12 +43,6 @@ if (image_to_boot)
     )
 else()
   assert(CONFIG_FW_INFO "CONFIG_FW_INFO must be set")
-endif()
-
-# Partition S0 will always contain the image to be booted by B0.
-set(s0_addr $<TARGET_PROPERTY:partition_manager,PM_S0_ADDRESS>)
-if (s1_addr)
-  set(s1_arg --s1-addr ${s1_addr})
 endif()
 
 if (DEFINED CONFIG_SOC_NRF9160)
@@ -95,8 +86,8 @@ add_custom_command(
   COMMAND
   ${PYTHON_EXECUTABLE}
   ${NRF_BOOTLOADER_SCRIPTS}/provision.py
-  --s0-addr ${s0_addr}
-  ${s1_arg}
+  --s0-addr $<TARGET_PROPERTY:partition_manager,PM_S0_ADDRESS>
+  --s1-addr $<TARGET_PROPERTY:partition_manager,PM_S1_ADDRESS>
   --provision-addr ${provision_addr}
   --public-key-files ${ALL_PUBLIC_KEY_FILES}
   --output ${PROVISION_HEX}


### PR DESCRIPTION
This configuration does not make sense, it is not documented,
so remove specical handling for supporting this configuration.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>