### PR TITLE
linker: generalize s1 linking, include ISR generation

### DIFF
--- a/cmake/s1.cmake
+++ b/cmake/s1.cmake
@@ -11,64 +11,124 @@ if (CONFIG_MCUBOOT AND CONFIG_MCUBOOT_BUILD_S1_VARIANT)
 # most of the variables required for compiling/linking is only available
 # in the scope of this file.
 
-  # Create linker script which has an offset from S0 to S1.
+  set(link_variant_name s1)
+  set(link_variant ${link_variant_name}_)
+
   configure_linker_script(
-    linker_mcuboot_s1.cmd
-    "-DLINK_MCUBOOT_INTO_S1;-DLINKER_PASS2"
+    ${link_variant}linker_prebuilt.cmd
+    "-DLINK_INTO_${link_variant_name}"
     ${PRIV_STACK_DEP}
     ${CODE_RELOCATION_DEP}
-    ${ZEPHYR_PREBUILT_EXECUTABLE}
     ${OFFSETS_H_TARGET}
     )
 
   add_custom_target(
-    linker_mcuboot_s1_target
+    ${link_variant}linker_prebuilt_target
     DEPENDS
-    linker_mcuboot_s1.cmd
+    ${link_variant}linker_prebuilt.cmd
     )
 
-  # Link against linker script with updated offset.
-  set(MCUBOOT_S1_EXECUTABLE s1_image)
-  add_executable(${MCUBOOT_S1_EXECUTABLE} ${ZEPHYR_BASE}/misc/empty_file.c)
+  # Create prebuilt executable, which is used as input for ISR generation.
+  set(${link_variant}prebuilt ${link_variant}image_prebuilt)
+  add_executable(${${link_variant}prebuilt} ${ZEPHYR_BASE}/misc/empty_file.c)
   toolchain_ld_link_elf(
-    TARGET_ELF            ${MCUBOOT_S1_EXECUTABLE}
-    OUTPUT_MAP            ${PROJECT_BINARY_DIR}/${MCUBOOT_S1_EXECUTABLE}.map
+    TARGET_ELF            ${${link_variant}prebuilt}
+    OUTPUT_MAP            ${PROJECT_BINARY_DIR}/${${link_variant}prebuilt}.map
     LIBRARIES_PRE_SCRIPT  ""
-    LINKER_SCRIPT         ${PROJECT_BINARY_DIR}/linker_mcuboot_s1.cmd
+    LINKER_SCRIPT         ${PROJECT_BINARY_DIR}/${link_variant}linker_prebuilt.cmd
     LIBRARIES_POST_SCRIPT ""
     DEPENDENCIES          ""
     )
-  add_dependencies(${MCUBOOT_S1_EXECUTABLE} linker_mcuboot_s1_target)
+  set_property(TARGET ${${link_variant}prebuilt} PROPERTY LINK_DEPENDS ${PROJECT_BINARY_DIR}/${link_variant}linker_prebuilt.cmd)
+  add_dependencies(   ${${link_variant}prebuilt} ${link_variant}linker_prebuilt_target ${PRIV_STACK_DEP} ${LINKER_SCRIPT_TARGET} ${OFFSETS_LIB})
 
-  set(s1_hex_cmd "")
-  set(s1_hex_byprod "")
-  set(output ${PROJECT_BINARY_DIR}/../../zephyr/${MCUBOOT_S1_EXECUTABLE}.hex)
+  if(CONFIG_GEN_ISR_TABLES)
+    # ${link_variant}isr_tables.c is generated from ${ZEPHYR_PREBUILT_EXECUTABLE} by
+    # gen_isr_tables.py
+    set(obj_copy_cmd "")
+    bintools_objcopy(
+      RESULT_CMD_LIST obj_copy_cmd
+      TARGET_INPUT    ${OUTPUT_FORMAT}
+      TARGET_OUTPUT   "binary"
+      SECTION_ONLY    ".intList"
+      FILE_INPUT      $<TARGET_FILE:${${link_variant}prebuilt}>
+      FILE_OUTPUT     "${link_variant}isrList.bin"
+      )
+
+    add_custom_command(
+      OUTPUT ${link_variant}isr_tables.c
+      ${obj_copy_cmd}
+      COMMAND ${PYTHON_EXECUTABLE}
+      ${ZEPHYR_BASE}/arch/common/gen_isr_tables.py
+      --output-source ${link_variant}isr_tables.c
+      --kernel $<TARGET_FILE:${${link_variant}prebuilt}>
+      --intlist ${link_variant}isrList.bin
+      $<$<BOOL:${CONFIG_BIG_ENDIAN}>:--big-endian>
+      $<$<BOOL:${CMAKE_VERBOSE_MAKEFILE}>:--debug>
+      ${GEN_ISR_TABLE_EXTRA_ARG}
+      DEPENDS ${${link_variant}prebuilt}
+      )
+
+    set(${link_variant}generated_kernel_files ${link_variant}isr_tables.c)
+  endif()
+
+  configure_linker_script(
+    ${link_variant}linker.cmd
+    "-DLINK_INTO_${link_variant_name};-DLINKER_PASS2"
+    ${PRIV_STACK_DEP}
+    ${CODE_RELOCATION_DEP}
+    ${${link_variant}prebuilt}
+    ${OFFSETS_H_TARGET}
+    )
+
+  add_custom_target(
+    ${link_variant}linker_target
+    DEPENDS
+    ${link_variant}linker.cmd
+    )
+
+  # Link against linker script with updated offset.
+  set(exe ${link_variant}image)
+  add_executable(${exe} ${ZEPHYR_BASE}/misc/empty_file.c ${${link_variant}generated_kernel_files})
+  toolchain_ld_link_elf(
+    TARGET_ELF            ${exe}
+    OUTPUT_MAP            ${PROJECT_BINARY_DIR}/${exe}.map
+    LIBRARIES_PRE_SCRIPT  ""
+    LINKER_SCRIPT         ${PROJECT_BINARY_DIR}/${link_variant}linker.cmd
+    LIBRARIES_POST_SCRIPT ""
+    DEPENDENCIES          ""
+    )
+  add_dependencies(${exe} ${link_variant}linker_target)
+
+  set(${link_variant}hex_cmd "")
+  set(${link_variant}hex_byprod "")
+  set(output ${PROJECT_BINARY_DIR}/../../zephyr/${exe}.hex)
 
   # Rule to generate hex file of .elf
   bintools_objcopy(
-    RESULT_CMD_LIST    s1_hex_cmd
-    RESULT_BYPROD_LIST s1_hex_byprod
+    RESULT_CMD_LIST    ${link_variant}hex_cmd
+    RESULT_BYPROD_LIST ${link_variant}hex_byprod
     STRIP_ALL
     GAP_FILL           "0xff"
     TARGET_OUTPUT      "ihex"
     SECTION_REMOVE     ${out_hex_sections_remove}
-    FILE_INPUT         ${MCUBOOT_S1_EXECUTABLE}.elf
+    FILE_INPUT         ${exe}.elf
     FILE_OUTPUT        ${output}
     )
 
-  add_custom_command(${s1_hex_cmd}
-    DEPENDS ${MCUBOOT_S1_EXECUTABLE}
+  add_custom_command(${${link_variant}hex_cmd}
+    DEPENDS ${exe}
     OUTPUT ${output})
 
   add_custom_target(
-    s1_image_hex
+    ${link_variant}image_hex
     ALL
     DEPENDS
     ${output}
     )
 
   # Register in the parent image that this child image will have
-  # s1_image.hex as a byproduct, this allows the parent image to know
+  # ${link_variant}image.hex as a byproduct, this allows the parent image to know
   # where the hex file comes from and create custom commands that
   # depend on it.
   set_property(

--- a/west.yml
+++ b/west.yml
@@ -38,7 +38,7 @@ manifest:
     - name: zephyr
       repo-path: fw-nrfconnect-zephyr
       west-commands: scripts/west-commands.yml
-      revision: 30f47eace36c9593c8f6efacebc75c0f66aa7b17
+      revision: 7ddab664b04b3f5a635285ecedd469ec738aa608
     - name: segger
       revision: 6fcf61606d6012d2c44129edc033f59331e268bc
       path: modules/debug/segger


### PR DESCRIPTION
In the future we might want to store other images than mcuboot
in s0/s1, remove the mcuboot specific naming.

In addition, add the ISR table generation linker stage
so that images that use interrupts can also be linked
against s1.

depends on https://github.com/NordicPlayground/fw-nrfconnect-zephyr/pull/276

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>