### PR TITLE
Use manifest imports

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -2,3 +2,4 @@ recommonmark==0.4.0
 sphinxcontrib-mscgen>=0.5
 ecdsa
 intelhex
+west>=0.7.2

--- a/scripts/west_commands/ncs_commands.py
+++ b/scripts/west_commands/ncs_commands.py
@@ -4,37 +4,27 @@
 
 '''The "ncs-xyz" extension commands.'''
 
+import argparse
 from pathlib import PurePath
 import subprocess
 from textwrap import dedent
 
-import packaging.version
 from west import log
 from west.commands import WestCommand
-from west.manifest import Manifest, MalformedManifest
-from west.version import __version__ as west_ver
+from west.manifest import Manifest, MalformedManifest, ImportFlag, \
+    MANIFEST_PROJECT_INDEX
 import yaml
 
 import ncs_west_helpers as nwh
 
 def add_zephyr_rev_arg(parser):
-    parser.add_argument('-z', '--zephyr-rev',
-                        help='''upstream git ref to use for zephyr project;
-                        default is upstream/master''')
+    parser.add_argument('-z', '--zephyr-rev', metavar='REF',
+                        help='''zephyr git ref (commit, branch, etc.);
+                        default: upstream/master''')
 
 def add_projects_arg(parser):
     parser.add_argument('projects', metavar='PROJECT', nargs='*',
-                        help='''projects (by name or path) to operate on;
-                        defaults to all projects in the manifest which
-                        are shared with the upstream manifest''')
-
-def check_west_version():
-    min_ver = '0.6.99'
-    if (packaging.version.parse(west_ver) <
-            packaging.version.parse(min_ver)):
-        log.die('this command currently requires a pre-release west '
-                f'(your west version is {west_ver}, '
-                f'but must be at least {min_ver}')
+                        help='projects (by name or path) to operate on')
 
 def likely_merged(np, zp, nsha, zsha):
     analyzer = nwh.RepoAnalyzer(np, zp, nsha, zsha)
@@ -45,12 +35,17 @@ def likely_merged(np, zp, nsha, zsha):
         log.msg('downstream patches which are likely merged upstream',
                 '(revert these if appropriate):', color=log.WRN_COLOR)
         for dc, ucs in likely_merged.items():
-            log.inf(f'- {dc.oid} ({nwh.commit_shortlog(dc)})\n'
-                    '  Similar upstream commits:')
-            for uc in ucs:
-                log.inf(f'  {uc.oid} ({nwh.commit_shortlog(uc)})')
+            if len(ucs) == 1:
+                log.inf(f'- {dc.oid} {nwh.commit_shortlog(dc)}')
+                log.inf(f'  Similar upstream shortlog:\n'
+                        f'  {ucs[0].oid} {nwh.commit_shortlog(ucs[0])}')
+            else:
+                log.inf(f'- {dc.oid} {nwh.commit_shortlog(dc)}\n'
+                        '  Similar upstream shortlogs:')
+                for i, uc in enumerate(ucs, start=1):
+                    log.inf(f'    {i}. {uc.oid} {nwh.commit_shortlog(uc)}')
     else:
-        log.inf('no downstream patches seem to have been merged upstream')
+        log.dbg('no downstream patches seem to have been merged upstream')
 
 def to_ncs_name(zp):
     # convert zp, a west.manifest.Project in the zephyr manifest,
@@ -77,7 +72,7 @@ class NcsWestCommand(WestCommand):
             sha = project.sha(revision)
             project.git('cat-file -e ' + sha)
             return sha
-        except subprocess.CalledProcessError:
+        except (subprocess.CalledProcessError, FileNotFoundError):
             return None
 
     def setup_upstream_downstream(self, args):
@@ -131,13 +126,6 @@ class NcsWestCommand(WestCommand):
                            capture_stdout=True, check=True)
         z_west_yml = cp.stdout.decode('utf-8')
         try:
-            # The topdir kwarg was added in a pre-release west, which
-            # is required to use this file. The latest stable (0.6.3)
-            # doesn't have it, so pylint is failing with a false error
-            # report here. Turn it off for now; this can be removed
-            # when west 0.7 is out.
-            #
-            # pylint: disable=unexpected-keyword-arg
             return Manifest.from_data(source_data=yaml.safe_load(z_west_yml),
                                       topdir=self.topdir)
         except MalformedManifest:
@@ -176,21 +164,22 @@ class NcsLoot(NcsWestCommand):
             Downstream revisions are loaded from nrf/west.yml.'''))
 
     def do_add_parser(self, parser_adder):
-        parser = parser_adder.add_parser(self.name, help=self.help,
-                                         description=self.description)
+        parser = parser_adder.add_parser(
+            self.name, help=self.help,
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            description=self.description)
         add_zephyr_rev_arg(parser)
         parser.add_argument('-s', '--sha', dest='sha_only',
                             action='store_true',
                             help='only print SHAs of OOT commits')
-        parser.add_argument('-f', '--file', dest='files', action='append',
-                            help='''restrict output to patches touching
-                            this file; may be given multiple times. If used,
-                            a single project must be given''')
+        parser.add_argument('-f', '--file', dest='files', metavar='FILE',
+                            action='append',
+                            help='''list patches changing this file;
+                            may be given multiple times''')
         add_projects_arg(parser)
         return parser
 
     def do_run(self, args, unknown_args):
-        check_west_version()
         if args.files and len(args.projects) != 1:
             self.parser.error('--file used, so expected 1 project argument, '
                               f'but got: {len(args.projects)}')
@@ -214,7 +203,7 @@ class NcsLoot(NcsWestCommand):
         # name: project name
         # project: the west.manifest.Project instance in the NCS manifest
         # z_project: the Project instance in the upstream manifest
-        log.banner(f'{_name_and_path(project)}')
+        name_path = _name_and_path(project)
 
         # Get the upstream revision of the project. The zephyr project
         # has to be treated as a special case.
@@ -227,40 +216,47 @@ class NcsLoot(NcsWestCommand):
             nsha = project.sha(project.revision)
             project.git('cat-file -e ' + nsha)
         except subprocess.CalledProcessError:
-            log.wrn(f"can't get loot; please run "
-                    f'"west update {project.name}" '
-                    f'(need revision {project.revision})')
+            log.wrn(f"{name_path}: can't get loot; please run "
+                    f'"west update" (need revision {project.revision})')
             return
         try:
             zsha = z_project.sha(z_rev)
             z_project.git('cat-file -e ' + zsha)
         except subprocess.CalledProcessError:
-            log.wrn("can't get loot; please fetch upstream URL "
-                    f'{z_project.url} '
-                    f'(need revision {z_project.revision})')
+            log.wrn(f"{name_path}: can't get loot; please fetch upstream URL "
+                    f'{z_project.url} (need revision {z_project.revision})')
             return
 
-        log.inf(f'NCS commit: {nsha}\nupstream commit: {zsha}')
         try:
             analyzer = nwh.RepoAnalyzer(project, z_project,
                                         project.revision, z_rev)
         except nwh.InvalidRepositoryError as ire:
-            log.die(str(ire))
+            log.die(f"{name_path}: {str(ire)}")
+
         try:
             loot = analyzer.downstream_outstanding
-            log.inf('OOT patches: ' +
-                    (f'{len(loot)} total ' if loot else 'none'))
-            for c in loot:
-                if args.files and not nwh.commit_affects_files(c, args.files):
-                    log.dbg(f"skipping {c.oid}; it doesn't affect file filter",
-                            level=log.VERBOSE_VERY)
-                    continue
-                if args.sha_only:
-                    log.inf(str(c.oid))
-                else:
-                    log.inf(f'- {c.oid} {nwh.commit_shortlog(c)}')
         except nwh.UnknownCommitsError as uce:
-            log.die('unknown commits:', str(uce))
+            log.die(f'{name_path}: unknown commits: {str(uce)}')
+
+        if not loot and log.VERBOSE <= log.VERBOSE_NONE:
+            # Don't print output if there's no loot unless verbose
+            # mode is on.
+            return
+
+        log.banner(name_path)
+        log.inf(f'NCS commit: {nsha}, upstream commit: {zsha}')
+        log.inf('OOT patches: ' +
+                (f'{len(loot)} total' if loot else 'none') +
+                (', output limited by --file' if args.files else ''))
+        for c in loot:
+            if args.files and not nwh.commit_affects_files(c, args.files):
+                log.dbg(f"skipping {c.oid}; it doesn't affect file filter",
+                        level=log.VERBOSE_VERY)
+                continue
+            if args.sha_only:
+                log.inf(str(c.oid))
+            else:
+                log.inf(f'- {c.oid} {nwh.commit_shortlog(c)}')
 
 class NcsCompare(NcsWestCommand):
     def __init__(self):
@@ -268,7 +264,7 @@ class NcsCompare(NcsWestCommand):
             'ncs-compare',
             'compare upstream manifest with NCS',
             dedent('''
-            Compares project status between zephyr/west.ml and your
+            Compares project status between zephyr/west.yml and your
             current NCS west manifest-rev branches (i.e. the results of your
             most recent 'west update').
 
@@ -276,14 +272,27 @@ class NcsCompare(NcsWestCommand):
             upstream projects.'''))
 
     def do_add_parser(self, parser_adder):
-        parser = parser_adder.add_parser(self.name, help=self.help,
-                                         description=self.description)
+        parser = parser_adder.add_parser(
+            self.name, help=self.help,
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            description=self.description)
         add_zephyr_rev_arg(parser)
         return parser
 
     def do_run(self, args, unknown_args):
-        check_west_version()
         self.setup_upstream_downstream(args)
+
+        # Get a dict containing projects that are in the NCS which are
+        # *not* imported from Zephyr in nrf/west.yml. We will treat
+        # these specially to make the output easier to understand.
+        ignored_imports = Manifest.from_file(
+            import_flags=ImportFlag.IGNORE_PROJECTS)
+        in_nrf = set(p.name for p in
+                     ignored_imports.projects[MANIFEST_PROJECT_INDEX + 1:])
+        # This is a dict mapping names of projects which *are* imported
+        # from zephyr to the Project instances.
+        self.imported_pmap = {name: project for name, project in
+                              self.ncs_pmap.items() if name not in in_nrf}
 
         log.inf('Comparing your manifest-rev branches with zephyr/west.yml '
                 f'at {self.zephyr_rev}' +
@@ -319,17 +328,25 @@ class NcsCompare(NcsWestCommand):
                        'not in nrf (these are all OK):')
             print_lst(missing_blacklisted)
 
-        log.banner('blacklisted zephyr projects in nrf:')
+        log.banner('blacklisted zephyr projects in NCS:')
         if present_blacklisted:
-            log.wrn('these should all be removed from nrf')
+            log.wrn(f'these should all be removed from {self.manifest.path}!')
             print_lst(present_blacklisted)
         else:
             log.inf('none (OK)')
 
-        log.banner('non-blacklisted zephyr projects',
-                   'missing from nrf:')
+        log.banner('non-blacklisted zephyr projects missing from NCS:')
         if missing_allowed:
-            log.wrn('these should be blacklisted or added to nrf')
+            west_yml = self.manifest.path
+            log.wrn(
+                f'missing projects should be added to NCS or blacklisted\n'
+                f"  To add to NCS:\n"
+                f"    1. do the zephyr mergeup\n"
+                f"    2. update zephyr revision in {west_yml}\n"
+                f"    3. add projects to zephyr's name_whitelist in "
+                f"{west_yml}\n"
+                f"    4. run west {self.name} again to check your work\n"
+                f"  To blacklist: edit _PROJECT_BLACKLIST in {__file__}")
             for p in missing_allowed:
                 log.small_banner(f'{_name_and_path(p)}:')
                 log.inf(f'upstream revision: {p.revision}')
@@ -338,7 +355,7 @@ class NcsCompare(NcsWestCommand):
             log.inf('none (OK)')
 
         if present_allowed:
-            log.banner('projects in both zephyr and nrf:')
+            log.banner('projects in both zephyr and NCS:')
             for zp in present_allowed:
                 # Do some extra checking on unmerged commits.
                 self.allowed_project(zp)
@@ -350,7 +367,12 @@ class NcsCompare(NcsWestCommand):
     def allowed_project(self, zp):
         nn = to_ncs_name(zp)
         np = self.ncs_pmap[nn]
-        banner = f'{nn} ({zp.path}):'
+        # is_imported is true if we imported this project from the
+        # zephyr manifest rather than defining it directly ourselves
+        # in nrf/west.yml.
+        is_imported = nn in self.imported_pmap
+        imported = ', imported from zephyr' if is_imported else ''
+        banner = f'{nn} ({zp.path}){imported}:'
 
         nrev = 'refs/heads/manifest-rev'
         if np.name == 'zephyr':
@@ -380,9 +402,9 @@ class NcsCompare(NcsWestCommand):
         if zsha == nsha:
             status = 'up to date'
         elif ahead and not behind:
-            status = f'ahead by {ahead} commits'
+            status = f'ahead by {ahead} commit' + ("s" if ahead > 1 else "")
         elif np.is_ancestor_of(nsha, zsha):
-            status = f'behind by {behind} commits; can be fast-forwarded'
+            status = f'behind by {behind} commit' + ("s" if behind > 1 else "")
         else:
             status = f'diverged: {ahead} ahead, {behind} behind'
 
@@ -396,6 +418,9 @@ class NcsCompare(NcsWestCommand):
                 likely_merged(np, zp, nsha, zsha)
         else:
             # Behind or diverged: always print.
+            if is_imported and 'behind by' in status:
+                status += ' and imported: update by doing zephyr mergeup'
+
             log.small_banner(banner)
             log.inf(commits)
             log.msg(status, color=log.WRN_COLOR)

--- a/west.yml
+++ b/west.yml
@@ -1,52 +1,89 @@
-# The west manifest file for the nRF Connect SDK (NCS).
+# The west manifest file (west.yml) for the nRF Connect SDK (NCS).
 #
-# The per-installation west configuration file specifies the location of this
-# manifest file. The "path" option in the [manifest] section of .west/config
-# defines the folder that contains west.yml. The path is relative to the folder
-# that contains .west.
+# The per-workspace west configuration file, ncs/.west/config,
+# specifies the location of this manifest file like this:
 #
-# You can create your own manifest files and put them in any
-# repository you want, to create your own custom NCS installation.
-# For example, you could create a manifest file in your own
-# out-of-tree application directory, which would pull the nrf repository
-# in as an ordinary project.
+#     [manifest]
+#     path = nrf
 #
-# You can pass your manifest repositories to west init when creating a
-# new NCS installation. See the west documentation for more
-# information.
+# See the west documentation for more information:
+#
+# https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/west/index.html
 
 manifest:
-  defaults:
-    remote: ncs
+  # This west.yml requires west 0.7 or later, because the "import"
+  # feature used below was introduced then.
+  version: 0.7
 
+  # "remotes" is a list of locations where git repositories are cloned
+  # and fetched from.
   remotes:
-      # nRF Connect SDK base URL.
+    # nRF Connect SDK GitHub organization.
+    # NCS repositories are hosted here.
     - name: ncs
       url-base: https://github.com/NordicPlayground
+    # Third-party repository sources:
     - name: zephyrproject
       url-base: https://github.com/zephyrproject-rtos
     - name: throwtheswitch
       url-base: https://github.com/ThrowTheSwitch
     - name: armmbed
       url-base: https://github.com/ARMmbed
-    - name: civetweb
-      url-base: https://github.com/civetweb
 
-  # The list of external projects for the nRF Connect SDK.
-  #
+  # If not otherwise specified, the projects below should be obtained
+  # from the ncs remote.
+  defaults:
+    remote: ncs
+
+  # "projects" is a list of git repositories which make up the NCS
+  # source code.
   projects:
+
+    # The Zephyr RTOS fork in the NCS, along with the subset of its
+    # modules which NCS imports directly.
+    #
+    # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/introduction/index.html
+    # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: fw-nrfconnect-zephyr
-      west-commands: scripts/west-commands.yml
-      revision: 367eec2dd60d4e15ab6b9aff22d33686312997ed
-    - name: segger
-      revision: 6fcf61606d6012d2c44129edc033f59331e268bc
-      path: modules/debug/segger
-      remote: zephyrproject
-    - name: mbedtls
-      path: modules/crypto/mbedtls
-      revision: 3776c158fe138a72c97c187e4d31c81c37884be9
-      remote: zephyrproject
+      revision: 9e7299a38e1256fee8a12155a43a6455f19bf0ae
+      import:
+        # In addition to the zephyr repository itself, NCS also
+        # imports the contents of zephyr/west.yml at the above
+        # revision. Only the projects explicitly named in the
+        # following whitelist are imported.
+        #
+        # Note that the zephyr west extensions (like 'build', 'flash',
+        # 'debug', etc.) are automatically provided by this import, so
+        # there's no need to add a redundant west-commands: key for
+        # the zephyr project.
+        #
+        # Please keep this list sorted alphabetically.
+        name-whitelist:
+          - canopennode
+          - ci-tools
+          - civetweb
+          - edtt
+          - fatfs
+          - hal_nordic
+          - hal_st
+          - libmetal
+          - littlefs
+          - loramac-node
+          - lvgl
+          - mbedtls
+          - mipi-sys-t
+          - net-tools
+          - nrf_hw_models
+          - open-amp
+          - openthread
+          - segger
+          - tinycbor
+
+    # NCS repositories.
+    #
+    # Some of these are also Zephyr modules which have NCS-specific
+    # changes.
     - name: mcuboot
       repo-path: fw-nrfconnect-mcuboot
       revision: 60b340765a64cd28b6768b3f5cad724a22c25874
@@ -55,21 +92,10 @@ manifest:
       repo-path: fw-nrfconnect-mcumgr
       revision: v0.0.1-ncs1
       path: modules/lib/mcumgr
-    - name: tinycbor
-      path: modules/lib/tinycbor
-      revision: 0fc68fceacd1efc1ce809c5880c380f3d98b7b6e
-      remote: zephyrproject
-    - name: ci-tools
-      path: tools/ci-tools
-      remote: zephyrproject
-      revision: e869d2524d1344d80063bf2898095faf9228f7b5
-    - name: net-tools
-      path: tools/net-tools
-      remote: zephyrproject
-      revision: 30b7efa827b04d2e47840716b0372737fe7d6c92
     - name: nrfxlib
       path: nrfxlib
       revision: 7f72d296488975ee45a420a00f9e48b85ec5e20b
+    # Other third-party repositories.
     - name: cmock
       path: test/cmock
       revision: c243b9a7a7b3c471023193992b46cf1bd1910450
@@ -83,63 +109,11 @@ manifest:
       repo-path: mbedtls
       revision: mbedtls-2.16.4
       remote: armmbed
-    - name: civetweb
-      path: modules/lib/civetweb
-      remote: civetweb
-      revision: 99129c5efc907ea613c4b73ccff07581feb58a7a
-    - name: edtt
-      path: tools/edtt
-      remote: zephyrproject
-      revision: dd4dd502ef2fbeced6ef7faaba562a7ddca45632
-    - name: fatfs
-      path: modules/fs/fatfs
-      remote: zephyrproject
-      revision: 9ee6b9b9511151d0d64a74d532d39c6f2bbd4f16
-    - name: hal_nordic
-      path: modules/hal/nordic
-      remote: zephyrproject
-      revision: 12d7647870888e4cb0e421f2b26884c2e76915ac
-    - name: hal_st
-      path: modules/hal/st
-      remote: zephyrproject
-      revision: fa481784b3c49780f18d50bafe00390ccb62b2ec
-    - name: libmetal
-      path: modules/hal/libmetal
-      remote: zephyrproject
-      revision: 45e630d6152824f807d3f919958605c4626cbdff
-    - name: loramac-node
-      path: modules/lib/loramac-node
-      remote: zephyrproject
-      revision: 29e516ec585b1a909af2b5f1c60d83e7d4d563e3
-    - name: lvgl
-      path: modules/lib/gui/lvgl
-      remote: zephyrproject
-      revision: 74fc2e753a997bd71cefa34dd9c56dcb954b42e2
-    - name: nrf_hw_models
-      path: modules/bsim_hw_models/nrf_hw_models
-      remote: zephyrproject
-      revision: fec69703cb1ca06fcdab6d5fde01274f0fc5c759
-    - name: open-amp
-      path: modules/lib/open-amp
-      remote: zephyrproject
-      revision: 9b591b289e1f37339bd038b5a1f0e6c8ad39c63a
-    - name: openthread
-      path: modules/lib/openthread
-      remote: zephyrproject
-      revision: 3c6191eb4e8ca44b5f4eeaa696837bce14e83c69
-    - name: littlefs
-      path: modules/fs/littlefs
-      remote: zephyrproject
-      revision: fe9572dd5a9fcf93a249daa4233012692bd2881d
-    - name: mipi-sys-t
-      path: modules/debug/mipi-sys-t
-      remote: zephyrproject
-      revision: baf51863f19f009b92e762115ba5572a5b996b92
-    - name: canopennode
-      path: modules/lib/canopennode
-      remote: zephyrproject
-      revision: 5c6b0566d56264efd4bf23ed58bc7cb8b32fe063
 
+  # West-related configuration for the nrf repository.
   self:
+    # This repository should be cloned to ncs/nrf.
     path: nrf
+    # This line configures west extensions which are currently only
+    # for internal use by NCS maintainers.
     west-commands: scripts/west-commands.yml


### PR DESCRIPTION
Use the west 0.7 manifest imports feature in the NCS. This means we now require west 0.7. I will push a west 0.7.2 and make that our minimum version.

I have tested this on Arch Linux with a fresh init + update + build + flash + debug + debugserver + attach + list. No issues observed.

Users who are running west 0.6 will see this error:

```
FATAL ERROR: Malformed manifest file .../nrf/west.yml (schema: .../west/manifest-schema.yml):
Schema validation failed:
 - Key 'version' was not defined. Path: ''.
 - Key 'import' was not defined. Path: '/projects/0'.
```

So heads-up that if you see this error, you need west 0.7.

I also tested our NCS extensions and made some changes to keep their output usable now that the way we will be doing mergeups depends on if the project in question is imported or not.

CI fails because it's using west 0.6. We should update the CI container once west 0.7.2 is available early next week for more testing.