### PR TITLE
applications: asset_tracker: Add static pm.yml for backward compatibility with older releases

### DIFF
--- a/applications/asset_tracker/CMakeLists.txt
+++ b/applications/asset_tracker/CMakeLists.txt
@@ -9,6 +9,11 @@ cmake_minimum_required(VERSION 3.8.2)
 set(spm_CONF_FILE ${CMAKE_CURRENT_SOURCE_DIR}/spm.conf)
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)
+
+set(PM_STATIC_YML_FILE
+  ${CMAKE_CURRENT_SOURCE_DIR}/configuration/${BOARD}/pm_static.yml
+  )
+
 include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(asset_tracker)
 zephyr_compile_definitions(PROJECT_NAME=${PROJECT_NAME})

--- a/applications/asset_tracker/configuration/nrf9160_pca20035ns/pm_static.yml
+++ b/applications/asset_tracker/configuration/nrf9160_pca20035ns/pm_static.yml
@@ -1,0 +1,50 @@
+app: {address: 0x18200, size: 0x5ae00}
+mcuboot:
+  address: 0x0
+  placement:
+    before: [mcuboot_primary]
+  size: 0xc000
+mcuboot_pad:
+  address: 0xc000
+  placement:
+    align: {start: 0x1000}
+    before: [mcuboot_primary_app]
+  size: 0x200
+mcuboot_primary:
+  address: 0xc000
+  orig_span: &id001 [spm, mcuboot_pad, app]
+  sharers: 0x1
+  size: 0x69000
+  span: *id001
+mcuboot_primary_app:
+  address: 0xc200
+  orig_span: &id002 [app, spm]
+  size: 0x68e00
+  span: *id002
+mcuboot_scratch:
+  address: 0xde000
+  placement:
+    after: [app]
+    align: {start: 0x1000}
+  size: 0x1e000
+mcuboot_secondary:
+  address: 0x75000
+  placement:
+    after: [mcuboot_primary]
+    align: {start: 0x1000}
+  share_size: [mcuboot_primary]
+  size: 0x69000
+EMPTY_0:
+  address: 0xfc000
+  size: 0x2000
+settings_storage:
+  address: 0xfe000
+  placement:
+    after: [mcuboot_scratch]
+  size: 0x2000
+spm:
+  address: 0xc200
+  inside: [mcuboot_primary_app]
+  placement:
+    before: [app]
+  size: 0xc000


### PR DESCRIPTION
Adds a static pm.yml and turns of FOTA Download event to reduce the data
consumed when doing an update.

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>