### PR TITLE
net: fota_download: Bugfix progress event

### DIFF
--- a/include/net/fota_download.h
+++ b/include/net/fota_download.h
@@ -47,9 +47,7 @@ enum fota_download_evt_id {
  */
 struct fota_download_evt {
 	enum fota_download_evt_id id;
-#ifdef CONFIG_FOTA_DOWNLOAD_PROGRESS_EVT
 	int offset;
-#endif
 };
 
 /**

--- a/subsys/net/lib/aws_fota/src/aws_fota.c
+++ b/subsys/net/lib/aws_fota/src/aws_fota.c
@@ -504,13 +504,11 @@ static void http_fota_handler(const struct fota_download_evt *evt)
 		callback(AWS_FOTA_EVT_ERROR);
 		break;
 
-#ifdef CONFIG_FOTA_DOWNLOAD_PROGRESS_EVT
 	case FOTA_DOWNLOAD_EVT_PROGRESS:
 		stored_progress = evt->offset;
 		err = update_job_execution(c, job_id, AWS_JOBS_IN_PROGRESS,
 					   fota_state, stored_progress, "");
 		break;
-#endif
 	}
 
 }

--- a/subsys/net/lib/fota_download/Kconfig
+++ b/subsys/net/lib/fota_download/Kconfig
@@ -17,7 +17,6 @@ config FOTA_SOCKET_RETRIES
 
 config FOTA_DOWNLOAD_PROGRESS_EVT
 	bool "Emit progress event upon receiving a download fragment"
-	default y
 
 module=FOTA_DOWNLOAD
 module-dep=LOG


### PR DESCRIPTION
Sets FOTA download progress event to default `n` and fix a bug which
makes it impossible to compile it with the event turned off.

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>