### PR TITLE
SPM: Properly support nRF53 in FLASH and RAM configurations

### DIFF
--- a/subsys/spm/secure_services.ld
+++ b/subsys/spm/secure_services.ld
@@ -1,9 +1,9 @@
 #if USE_PARTITION_MANAGER
 	#include <pm_config.h>
-	#define SPU_REGION_SIZE 32768
 	#define NON_SECURE_APP_ADDRESS PM_APP_ADDRESS
-	ASSERT(((_image_rom_start + _flash_used - 1) / SPU_REGION_SIZE)
-		< (NON_SECURE_APP_ADDRESS / SPU_REGION_SIZE),
+	ASSERT(((_image_rom_start + _flash_used - 1)
+			/ CONFIG_NRF_SPU_FLASH_REGION_SIZE)
+		< (NON_SECURE_APP_ADDRESS / CONFIG_NRF_SPU_FLASH_REGION_SIZE),
 		"SPM and app are sharing an SPU region. \
 Cannot partition flash correctly into secure and non-secure. \
 Adjust partitions sizes so they are placed in separate regions." )

--- a/subsys/spm/spm.c
+++ b/subsys/spm/spm.c
@@ -155,19 +155,17 @@ static void config_regions(bool ram, size_t start, size_t end, u32_t perm)
 		} else {
 			NRF_SPU->FLASHREGION[i].PERM = perm;
 		}
-		PRINT("%02u 0x%05x 0x%05x \t", i,
-					region_size * i, region_size * (i + 1));
-		PRINT("%s", perm & (ram ? SRAM_SECURE : FLASH_SECURE)
-							? "Secure\t\t" :
-							  "Non-Secure\t");
-		PRINT("%c", perm & (ram ? SRAM_READ : FLASH_READ)  ? 'r' : '-');
-		PRINT("%c", perm & (ram ? SRAM_WRITE : FLASH_WRITE)
-								? 'w' : '-');
-		PRINT("%c", perm & (ram ? SRAM_EXEC : FLASH_EXEC)  ? 'x' : '-');
-		PRINT("%c", perm & (ram ? SRAM_LOCK : FLASH_LOCK)  ? 'l' : '-');
-		PRINT("\n");
 	}
 
+	PRINT("%02u %02u 0x%05x 0x%05x \t", start, end - 1,
+				region_size * start, region_size * end);
+	PRINT("%s", perm & (ram ? SRAM_SECURE : FLASH_SECURE) ? "Secure\t\t" :
+								"Non-Secure\t");
+	PRINT("%c", perm & (ram ? SRAM_READ : FLASH_READ)  ? 'r' : '-');
+	PRINT("%c", perm & (ram ? SRAM_WRITE : FLASH_WRITE) ? 'w' : '-');
+	PRINT("%c", perm & (ram ? SRAM_EXEC : FLASH_EXEC)  ? 'x' : '-');
+	PRINT("%c", perm & (ram ? SRAM_LOCK : FLASH_LOCK)  ? 'l' : '-');
+	PRINT("\n");
 }
 
 

--- a/subsys/spm/spm.c
+++ b/subsys/spm/spm.c
@@ -10,6 +10,7 @@
 #include <linker/linker-defs.h>
 #include <device.h>
 #include <drivers/gpio.h>
+#include <hal/nrf_spu.h>
 #include "spm_internal.h"
 
 #if !defined(CONFIG_ARM_SECURE_FIRMWARE)
@@ -135,8 +136,8 @@ static void spm_config_nsc_flash(void)
 		"The Non-Secure Callable region is overflowed by %d byte(s).\n",
 		(u32_t)__sg_size - nsc_size);
 
-	NRF_SPU->FLASHNSC[0].REGION = FLASH_NSC_REGION_FROM_ADDR(__sg_start);
-	NRF_SPU->FLASHNSC[0].SIZE = FLASH_NSC_SIZE_REG(nsc_size);
+	nrf_spu_flashnsc_set(NRF_SPU, 0, FLASH_NSC_SIZE_REG(nsc_size),
+			FLASH_NSC_REGION_FROM_ADDR(__sg_start), false);
 
 	PRINT("Non-secure callable region 0 placed in flash region %d with size %d.\n",
 		NRF_SPU->FLASHNSC[0].REGION, NRF_SPU->FLASHNSC[0].SIZE << 5);

--- a/subsys/spm/spm_internal.h
+++ b/subsys/spm/spm_internal.h
@@ -10,14 +10,59 @@
 #include <zephyr.h>
 #include <nrfx.h>
 #include <sys/util.h>
+#include <sys/__assert.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 
-/* Size of secure attribution configurable flash region. */
-#define FLASH_SECURE_ATTRIBUTION_REGION_SIZE (32*1024)
+/* Total RAM Size */
+#ifdef CONFIG_SOC_NRF9160
+#define TOTAL_RAM_SIZE (256*1024)
+#elif defined(CONFIG_SOC_NRF5340_CPUAPP)
+#define TOTAL_RAM_SIZE (512*1024)
+#endif
+
+/* SPU RAM regions */
+#define RAM_SECURE_ATTRIBUTION_REGION_SIZE CONFIG_NRF_SPU_RAM_REGION_SIZE
+#define NUM_RAM_SECURE_ATTRIBUTION_REGIONS (TOTAL_RAM_SIZE \
+				/ RAM_SECURE_ATTRIBUTION_REGION_SIZE)
+
+/* SPU FLASH regions */
+#if (defined(CONFIG_SOC_NRF5340_CPUAPP) \
+	&& defined(CONFIG_NRF5340_CPUAPP_ERRATUM19))
+static inline u32_t spu_flash_region_size(void)
+{
+	if (NRF_FICR->INFO.PART == 0x5340) {
+		if (NRF_FICR->INFO.VARIANT == 0x41414142) {
+			return 32*1024;
+		}
+		return 16*1024;
+	}
+	__ASSERT(false, "Function should only be called on an nRF53 device.");
+	return 0;
+}
+
+static inline u32_t num_spu_flash_regions(void)
+{
+	if (NRF_FICR->INFO.PART == 0x5340) {
+		if (NRF_FICR->INFO.VARIANT == 0x41414142) {
+			return 32;
+		}
+		return 64;
+	}
+	__ASSERT(false, "Function should only be called on an nRF53 device.");
+	return 0;
+}
+#define FLASH_SECURE_ATTRIBUTION_REGION_SIZE spu_flash_region_size()
+#define NUM_FLASH_SECURE_ATTRIBUTION_REGIONS num_spu_flash_regions()
+#else
+
+#define FLASH_SECURE_ATTRIBUTION_REGION_SIZE CONFIG_NRF_SPU_FLASH_REGION_SIZE
+#define NUM_FLASH_SECURE_ATTRIBUTION_REGIONS (DT_SOC_NV_FLASH_0_SIZE \
+				/ FLASH_SECURE_ATTRIBUTION_REGION_SIZE)
+#endif
 
 /* Minimum size of Non-Secure Callable regions. */
 #define FLASH_NSC_MIN_SIZE 32

--- a/west.yml
+++ b/west.yml
@@ -38,7 +38,7 @@ manifest:
     - name: zephyr
       repo-path: fw-nrfconnect-zephyr
       west-commands: scripts/west-commands.yml
-      revision: c025ef3dd5667e185c46f0255f6003f778d22b62
+      revision: 367eec2dd60d4e15ab6b9aff22d33686312997ed
     - name: segger
       revision: 6fcf61606d6012d2c44129edc033f59331e268bc
       path: modules/debug/segger


### PR DESCRIPTION
The logic has been refactored.

The second commit also changes the printing. Instead of listing all regions, printing now looks like this:

    Flash regions           Domain          Permissions
    00 04 0x00000 0x28000   Secure          rwxl
    05 31 0x28000 0x100000  Non-Secure      rwxl

    Non-secure callable region 0 placed in flash region 4 with size 32.

    SRAM region             Domain          Permissions
    00 07 0x00000 0x10000   Secure          rwxl
    08 63 0x10000 0x80000   Non-Secure      rwxl

~DNM until https://github.com/NordicPlayground/fw-nrfconnect-zephyr/pull/277 is merged.~ (merged)

Reopened from #1931 
