### PR TITLE
samples: NFC: Wake up by NFC ported to nRF340

### DIFF
--- a/samples/nfc/system_off/CMakeLists.txt
+++ b/samples/nfc/system_off/CMakeLists.txt
@@ -9,6 +9,7 @@ cmake_minimum_required(VERSION 3.8.2)
 set(NRF_SUPPORTED_BOARDS
   nrf52_pca10040
   nrf52840_pca10056
+  nrf5340_dk_nrf5340_cpuapp
   )
 
 include($ENV{ZEPHYR_BASE}/../nrf/cmake/boilerplate.cmake)

--- a/samples/nfc/system_off/README.rst
+++ b/samples/nfc/system_off/README.rst
@@ -46,6 +46,7 @@ Requirements
 
 * One of the following development boards:
 
+  * |nRF5340DK|
   * |nRF52840DK|
   * |nRF52DK|
 

--- a/samples/nfc/system_off/sample.yaml
+++ b/samples/nfc/system_off/sample.yaml
@@ -5,5 +5,5 @@ tests:
   test_build:
     build_only: true
     build_on_all: true
-    platform_whitelist: nrf52840_pca10056
+    platform_whitelist: nrf52840_pca10056 nrf52_pca10040 nrf5340_dk_nrf5340_cpuapp
     tags: ci_build


### PR DESCRIPTION
Wake up from system off by NFC is also available on nRF340, so the sample should also support it. Only one significant difference compared to nRF52 is a different location of the reset reason register `RESETREAS`. It is moved from `POWER` to `RESET` peripheral.