### PR TITLE
applications: asset_tracker: Ignore invalid RSRP values

### DIFF
--- a/applications/asset_tracker/src/main.c
+++ b/applications/asset_tracker/src/main.c
@@ -646,14 +646,15 @@ static void cloud_cmd_handler(struct cloud_command *cmd)
 /**@brief Callback handler for LTE RSRP data. */
 static void modem_rsrp_handler(char rsrp_value)
 {
-	rsrp.value = rsrp_value;
-
-	/* If the RSRP value is 255, it's documented as 'not known or not
-	 * detectable'. Therefore, we should not send those values.
+	/* RSRP raw values that represent actual signal strength are
+	 * 0 through 97 (per "nRF91 AT Commands" v1.1). If the received value
+	 * falls outside this range, we should not send the value.
 	 */
-	if (rsrp.value == 255) {
+	if (rsrp_value > 97) {
 		return;
 	}
+
+	rsrp.value = rsrp_value;
 
 	/* Only send the RSRP if transmission is not already scheduled.
 	 * Checking CONFIG_HOLD_TIME_RSRP gives the compiler a shortcut.


### PR DESCRIPTION
Moves the check for invalid RSRP values to before the static copy is
updated, ensuring no invalid values are scheduled to be sent.
Changes the validity check to a "whitelist" type check for valid values.