### PR TITLE
lib: bsdlib: use SOCK_DGRAM when creating LTE sockets

### DIFF
--- a/boards/arm/nrf9160_pca20035/board_nonsecure.c
+++ b/boards/arm/nrf9160_pca20035/board_nonsecure.c
@@ -28,7 +28,7 @@ static int pca20035_magpio_configure(void)
 	int buffer;
 	u8_t read_buffer[AT_CMD_MAX_READ_LENGTH];
 
-	at_socket_fd = socket(AF_LTE, 0, NPROTO_AT);
+	at_socket_fd = socket(AF_LTE, SOCK_DGRAM, NPROTO_AT);
 	if (at_socket_fd == -1) {
 		LOG_ERR("AT socket could not be opened");
 		return -EFAULT;

--- a/lib/at_cmd/at_cmd.c
+++ b/lib/at_cmd/at_cmd.c
@@ -53,7 +53,7 @@ K_MEM_SLAB_DEFINE(rsp_work_items, sizeof(struct callback_work_item),
 
 static int open_socket(void)
 {
-	common_socket_fd = socket(AF_LTE, 0, NPROTO_AT);
+	common_socket_fd = socket(AF_LTE, SOCK_DGRAM, NPROTO_AT);
 
 	if (common_socket_fd == -1) {
 		return -errno;

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
@@ -272,7 +272,7 @@ static int nct_client_id_get(char *id)
 	char imei_buf[NRF_IMEI_LEN + 1];
 	int ret;
 
-	at_socket_fd = nrf_socket(NRF_AF_LTE, 0, NRF_PROTO_AT);
+	at_socket_fd = nrf_socket(NRF_AF_LTE, NRF_SOCK_DGRAM, NRF_PROTO_AT);
 	__ASSERT_NO_MSG(at_socket_fd >= 0);
 
 	bytes_written = nrf_write(at_socket_fd, "AT+CGSN", 7);


### PR DESCRIPTION
Using type 0 in NRF_AF_LTE socket creation leads to NRF_EPROTOTYPE
in nrfxlib versions after 0.6.0
This commit replaces the 0 with (NRF_)SOCK_DGRAM

Signed-off-by: Kimmo Puusaari <kimmo.puusaari@nordicsemi.no>