### PR TITLE
manifest: Update mcuboot revision to not use fprotect on thingy:91

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -49,7 +49,7 @@ manifest:
       remote: zephyrproject
     - name: mcuboot
       repo-path: fw-nrfconnect-mcuboot
-      revision:  e09ecbe78dc9f24be0dd652e591a9eedf1fbf914
+      revision: f3430e727fe1f2ca459c527b351daa988c3d0ce5
       path: bootloader/mcuboot
     - name: mcumgr
       repo-path: fw-nrfconnect-mcumgr


### PR DESCRIPTION
PR https://github.com/NordicPlayground/fw-nrfconnect-mcuboot/pull/89
Disables fprotect for thingy:91 since it has an unaligned size which
causes it to lock up when you try to fprotect the area.

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>