### PR TITLE
dfu: dfu_target: Fix issue with not being able to only have modem DFU

### DIFF
--- a/tests/subsys/dfu/dfu_target/mcuboot/src/main.c
+++ b/tests/subsys/dfu/dfu_target/mcuboot/src/main.c
@@ -25,7 +25,7 @@ bool dfu_target_mcuboot_identify(const void *const buf)
 	return identify_retval;
 }
 
-int dfu_target_mcuboot_init(size_t file_size)
+int dfu_target_mcuboot_init(size_t file_size, dfu_target_callback_t cb)
 {
 	return init_retval;
 }
@@ -60,7 +60,7 @@ static void init(void)
 
 	zassert_true(ret > 0, "Valid type not recognized");
 
-	err = dfu_target_init(ret, FILE_SIZE);
+	err = dfu_target_init(ret, FILE_SIZE, NULL);
 	zassert_equal(err, 0, NULL);
 }
 
@@ -82,10 +82,10 @@ static void test_init(void)
 	ret = dfu_target_img_type(0, 0);
 	zassert_true(ret > 0, "Valid type not recognized");
 
-	err = dfu_target_init(ret, FILE_SIZE);
+	err = dfu_target_init(ret, FILE_SIZE, NULL);
 	zassert_equal(err, 0, NULL);
 
-	err = dfu_target_init(ret, FILE_SIZE);
+	err = dfu_target_init(ret, FILE_SIZE, NULL);
 	zassert_equal(err, 0, "Re-initialization should pass");
 
 	err = dfu_target_done(true);
@@ -94,17 +94,17 @@ static void test_init(void)
 	/* Now clean up and try invalid types */
 	done();
 
-	err = dfu_target_init(0, FILE_SIZE);
+	err = dfu_target_init(0, FILE_SIZE, NULL);
 	zassert_true(err < 0, "Did not fail when invalid type is used");
 
 	done();
 
-	err = dfu_target_init(2, FILE_SIZE);
+	err = dfu_target_init(2, FILE_SIZE, NULL);
 	zassert_true(err < 0, "Did not fail when invalid type is used");
 
 	init_retval = -42;
 
-	err = dfu_target_init(ret, FILE_SIZE);
+	err = dfu_target_init(ret, FILE_SIZE, NULL);
 	zassert_equal(err, -42, "Did not return error code from target");
 
 	done();

--- a/tests/subsys/dfu/dfu_target/mcuboot/testcase.yaml
+++ b/tests/subsys/dfu/dfu_target/mcuboot/testcase.yaml
@@ -1,4 +1,4 @@
 tests:
   dfu_target.mcuboot:
-    platform_whitelist: nrf52840_pca10056 nrf52_pca10040 nrf51_pca10028 nrf9160_pca10090
+    platform_whitelist: nrf52840_pca10056 nrf52_pca10040 nrf51_pca10028 nrf9160_pca10090 native_posix qemu_cortex_m3
     tags: dfu mcuboot

--- a/tests/subsys/dfu/dfu_target_mcuboot/CMakeLists.txt
+++ b/tests/subsys/dfu/dfu_target_mcuboot/CMakeLists.txt
@@ -22,6 +22,7 @@ target_include_directories(app
   PRIVATE
   ${ZEPHYR_BASE}/../nrf/subsys/dfu/include
   . # To get 'pm_config.h'
+  ${ZEPHYR_BASE}/../nrf/include/dfu
   )
 
 target_compile_options(app

--- a/tests/subsys/dfu/dfu_target_mcuboot/src/main.c
+++ b/tests/subsys/dfu/dfu_target_mcuboot/src/main.c
@@ -7,6 +7,7 @@
 #include <zephyr/types.h>
 #include <stdbool.h>
 #include <ztest.h>
+#include <dfu_target.h>
 #include <dfu_target_mcuboot.h>
 
 /* Create buffer which we will fill with strings to test with.
@@ -22,7 +23,7 @@ char buf[1024];
 static void test_dfu_ctx_mcuboot_set_b1_file(void)
 {
 	int err;
-	char *update;
+	const char *update;
 	bool s0_active = true;
 
 	memcpy(buf, S0_S1, sizeof(S0_S1));
@@ -41,7 +42,7 @@ static void test_dfu_ctx_mcuboot_set_b1_file(void)
 static void test_dfu_ctx_mcuboot_set_b1_file__no_separator(void)
 {
 	int err;
-	char *update;
+	const char *update;
 	bool s0_active = true;
 
 	memcpy(buf, NO_SPACE, sizeof(NO_SPACE));
@@ -54,7 +55,7 @@ static void test_dfu_ctx_mcuboot_set_b1_file__no_separator(void)
 static void test_dfu_ctx_mcuboot_set_b1_file__null(void)
 {
 	int err;
-	char *update;
+	const char *update;
 	bool s0_active = true;
 
 	err = dfu_ctx_mcuboot_set_b1_file(NULL, s0_active, &update);
@@ -67,7 +68,7 @@ static void test_dfu_ctx_mcuboot_set_b1_file__null(void)
 static void test_dfu_ctx_mcuboot_set_b1_file__not_terminated(void)
 {
 	int err;
-	char *update;
+	const char *update;
 	bool s0_active = true;
 
 	/* Remove any null terminator */
@@ -81,7 +82,7 @@ static void test_dfu_ctx_mcuboot_set_b1_file__not_terminated(void)
 static void test_dfu_ctx_mcuboot_set_b1_file__empty(void)
 {
 	int err;
-	char *update;
+	const char *update;
 	bool s0_active = true;
 
 	err = dfu_ctx_mcuboot_set_b1_file("", s0_active, &update);

--- a/tests/unity/example_test/sample.yaml
+++ b/tests/unity/example_test/sample.yaml
@@ -1,7 +1,3 @@
 sample:
   description: Example Unity/Cmock test
   name: example_unity_test
-tests:
-  unity.example:
-    platform_whitelist: native_posix
-    tags: example

--- a/tests/unity/example_test/testcase.yaml
+++ b/tests/unity/example_test/testcase.yaml
@@ -1,0 +1,3 @@
+tests:
+  unity.example:
+    tags: example


### PR DESCRIPTION
In the DFU target library you were not able to only define modem DFU or
MCUBoot DFU anymore due to changes in how IS_ENABLED is processed. This
change fixes the issue and is originally created by @hakonfam and also suggested by @junqingzou.

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>