### PR TITLE
manifest: update zephyr to include west topdir fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -38,7 +38,7 @@ manifest:
     - name: zephyr
       repo-path: fw-nrfconnect-zephyr
       west-commands: scripts/west-commands.yml
-      revision: 7ddab664b04b3f5a635285ecedd469ec738aa608
+      revision: c025ef3dd5667e185c46f0255f6003f778d22b62
     - name: segger
       revision: 6fcf61606d6012d2c44129edc033f59331e268bc
       path: modules/debug/segger


### PR DESCRIPTION
This PR is in order to run CI for https://github.com/NordicPlayground/fw-nrfconnect-zephyr/pull/285

If https://github.com/NordicPlayground/fw-nrfconnect-zephyr/pull/285 is merged before:
https://github.com/NordicPlayground/fw-nrfconnect-nrf/pull/1942 then it can make this PR obsolete.

Ensure PR #1942 is updated to also include the SHA for https://github.com/NordicPlayground/fw-nrfconnect-zephyr/pull/285

----

This PR updates the manifest to include a fix for west topdir checking
when west version == 0.7.0

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>