### PR TITLE
bluetooth: controller: Always use same stack size

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -12,7 +12,7 @@ config BT_HCI_TX_STACK_SIZE
 	# NOTE: This value is derived from other symbols and should only be
 	# changed if required by architecture
 	int
-	default 1536 if (BT_LL_NRFXLIB && BT_PERIPHERAL)
+	default 1536 if BT_LL_NRFXLIB
 	help
 	  Stack size needed for executing bt_send with specified driver.
 	  NOTE: This is an advanced setting and should not be changed unless
@@ -41,7 +41,7 @@ config BT_RX_STACK_SIZE
 # when Nordic BLE controller is used.
 config SYSTEM_WORKQUEUE_STACK_SIZE
 	int
-	default 2048 if (BT_LL_NRFXLIB && BT_CENTRAL)
+	default 2048 if BT_LL_NRFXLIB
 
 config BLECTRL_SLAVE_COUNT
 	int "Number of concurrent slave roles"


### PR DESCRIPTION
It is expected that the used feature will not influence the stack usage
too much. This may be optimized later.

Signed-off-by: Rubin Gerritsen <rubin.gerritsen@nordicsemi.no>