### PR TITLE
partition_manager: Add more descriptive error message on non compliance

### DIFF
--- a/scripts/partition_manager.py
+++ b/scripts/partition_manager.py
@@ -440,17 +440,21 @@ def get_required_offset(align, start, size, move_up):
     end = start + size
     align_start = 'start' in align
 
-    if (align_start and start % align['start'] == 0) or (not align_start and end % align['end'] == 0):
-        return 0
+    try:
+        if (align_start and start % align['start'] == 0) or (not align_start and end % align['end'] == 0):
+            return 0
 
-    if move_up:
-        return align['start'] - (start % align['start']) if align_start else align['end'] - (end % align['end'])
-    else:
-        if align_start:
-            return start % align['start']
+        if move_up:
+            return align['start'] - (start % align['start']) if align_start else align['end'] - (end % align['end'])
         else:
-            # Special handling is needed if start is 0 since this partition can not be moved down
-            return end % align['end'] if start != 0 else align['end'] - (end % align['end'])
+            if align_start:
+                return start % align['start']
+            else:
+                # Special handling is needed if start is 0 since this partition can not be moved down
+                return end % align['end'] if start != 0 else align['end'] - (end % align['end'])
+    except TypeError as err:
+        keyword = 'start' if align_start else 'end'
+        raise TypeError(f"elements in align: {{{keyword}:{align[keyword]}}} is not type of \'int\'") from err
 
 
 def set_size_addr(entry, size, address):
@@ -796,6 +800,17 @@ def test():
     offset = get_required_offset(align={'end': 800}, start=0, size=1000, move_up=False)
     assert offset == 600
 
+    for l in [
+            lambda : get_required_offset(align={'end': ["CONFIG_VAR"]}, start=0, size=1000, move_up=False),
+            lambda : get_required_offset(align={'start': ["CONFIG_VAR"]}, start=0, size=1000, move_up=False),
+            lambda : get_required_offset(align={'start': [[2]]},start=0, size=1000, move_up=False)
+            ]:
+        failed = False
+        try:
+            l()
+        except TypeError:
+            failed = True
+        assert failed, "Should have received a TypeError."
     # Verify that the first partition can be aligned, and that the inserted empty partition is placed behind it.
     td = {'first': {'placement': {'before': 'app', 'align': {'end': 800}}, 'size': 100}, 'app': {}}
     s, sub_partitions = resolve(td)


### PR DESCRIPTION
If the C-preprocessor is not able to find a match for a symbol it will
leave the symbol name. This caused partition_manager to fail which it
should. However the error it raised was not very descriptive so I added
a function which checks the alignment symbols and if they are not
integers a `TypeError` exception will be raised with an additional
print out on what failed.

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>