### PR TITLE
manifest: Fix for devices which are not using fprotect in MCUBoot

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -49,7 +49,7 @@ manifest:
       remote: zephyrproject
     - name: mcuboot
       repo-path: fw-nrfconnect-mcuboot
-      revision: f3430e727fe1f2ca459c527b351daa988c3d0ce5
+      revision: 60b340765a64cd28b6768b3f5cad724a22c25874
       path: bootloader/mcuboot
     - name: mcumgr
       repo-path: fw-nrfconnect-mcumgr


### PR DESCRIPTION
Fixes MCUBoot for devices which are not using fprotect in MCUBoot
leaving a symbol unresolved in MCUBoot's `pm.yml` file.

Will update SHA when https://github.com/NordicPlayground/fw-nrfconnect-mcuboot/pull/90 is merged

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>