### PR TITLE
net: lib: aws_fota: Fix debug print on not properly null terminated buff

### DIFF
--- a/subsys/net/lib/aws_fota/src/aws_fota.c
+++ b/subsys/net/lib/aws_fota/src/aws_fota.c
@@ -318,7 +318,13 @@ static int on_publish_evt(struct mqtt_client *const client,
 	bool doc_update_rejected =
 		aws_jobs_cmp(update_topic, topic, topic_len, "rejected");
 
-	LOG_DBG("Received topic: %s", log_strdup(topic));
+#if defined(CONFIG_AWS_FOTA_LOG_LEVEL_DBG)
+	char debug_log[topic_len + 1];
+
+	memcpy(debug_log, topic, topic_len);
+	debug_log[topic_len] = '\0';
+	LOG_DBG("Received topic: %s", log_strdup(debug_log));
+#endif
 
 	if (is_notify_next_topic || is_get_next_topic || is_get_accepted) {
 		LOG_INF("Checking for an available job");
@@ -329,8 +335,10 @@ static int on_publish_evt(struct mqtt_client *const client,
 		LOG_ERR("Job document update was rejected");
 		return job_update_rejected(client, payload_len);
 	}
-	LOG_INF("received an unhandled MQTT publish event on topic: %s",
-		log_strdup(topic));
+#if defined(CONFIG_AWS_FOTA_LOG_LEVEL_DBG)
+	LOG_DBG("received an unhandled MQTT publish event on topic: %s",
+		log_strdup(debug_log));
+#endif
 
 	return 1;
 }


### PR DESCRIPTION
The topic buffer from MQTT Publish events are not null terminated
meaning there could reside other data withing the buffer. So just
printing out the buffer in log would give some weird print outs. This
fixes the issue by adding a `'\0'` at the end of the buffer using topic
length.

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>