### PR TITLE
cmake: pattern match '_ns' and 'ns' to non-secure boards

### DIFF
--- a/cmake/multi_image.cmake
+++ b/cmake/multi_image.cmake
@@ -38,23 +38,16 @@ function(image_board_selection board_in board_out)
   # images defined.
   # TODO: Allow multiple non-secure images by using Kconfig to set the
   # secure/non-secure property rather than using a separate board definition.
-  set(nonsecure_boards_with_ns_suffix
-    nrf9160_pca10090ns
-    nrf9160_pca20035ns
-    nrf5340_dk_nrf5340_cpuappns
-    )
-  if(${board_in} IN_LIST nonsecure_boards_with_ns_suffix)
-    string(LENGTH ${board_in} len)
-    math(EXPR len_without_suffix "${len} - 2")
-    string(SUBSTRING ${board_in} 0 ${len_without_suffix} board_in_without_suffix)
-
+  string(REGEX REPLACE "(_?ns)$" "" board_in_without_suffix ${board_in})
+  if(NOT ${board_in} STREQUAL ${board_in_without_suffix})
+    if (NOT CONFIG_ARM_NONSECURE_FIRMWARE)
+      message(FATAL_ERROR "${board_in} is not a valid name for a board without "
+      "'CONFIG_ARM_NONSECURE_FIRMWARE' set. This because the 'ns'/'_ns' ending "
+      "indicates that the board is the non-secure variant in a TrustZone "
+      "enabled system.")
+    endif()
     set(${board_out} ${board_in_without_suffix} PARENT_SCOPE)
     message("Changed board to secure ${board_in_without_suffix} (NOT NS)")
-
-  elseif(${board_in} STREQUAL actinius_icarus_ns)
-    set(${board_out} actinius_icarus PARENT_SCOPE)
-    message("Changed board to secure actinius_icarus (NOT NS)")
-
   else()
     set(${board_out} ${board_in} PARENT_SCOPE)
   endif()


### PR DESCRIPTION
Prior to this a hard coded list was used to identify non-secure boards.

With this patch it is possible to define OOT boards that are non-secure
by having the _ns or ns suffix.

Note that it is not supported to have a board name ending with
'_ns' or 'ns' if it is not a trustzone enabled board.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>