### PR TITLE
dfu: dfu_target: Add option to always restart download from offset 0

### DIFF
--- a/samples/nrf9160/http_application_update/src/main.c
+++ b/samples/nrf9160/http_application_update/src/main.c
@@ -103,6 +103,7 @@ static int dfu_button_init(void)
 
 void fota_dl_handler(const struct fota_download_evt *evt)
 {
+	int err;
 	switch (evt->id) {
 	case FOTA_DOWNLOAD_EVT_ERROR:
 		printk("Received error from fota_download\n");
@@ -110,6 +111,22 @@ void fota_dl_handler(const struct fota_download_evt *evt)
 	case FOTA_DOWNLOAD_EVT_FINISHED:
 		/* Re-enable button callback */
 		gpio_pin_enable_callback(gpiob, DT_ALIAS_SW0_GPIOS_PIN);
+		break;
+	case FOTA_DOWNLOAD_EVT_ERASE_PENDING:
+		printk("FOTA_DOWNLOAD_EVT_ERASE_PENDING modem firmware erase is"
+		       " pending, reboot or disconnect the LTE link\n");
+		err = lte_lc_offline();
+		if (err != 0) {
+			printk("Failed to disconnect\n");
+		}
+		break;
+	case FOTA_DOWNLOAD_EVT_ERASE_DONE:
+		printk("FOTA_DOWNLOAD_EVT_ERASE_DONE, reconnecting the LTE"
+		       " link\n");
+		err = lte_lc_connect();
+		if (err != 0) {
+			printk("Failed to reconnect\n");
+		}
 		break;
 
 	default:

--- a/subsys/dfu/Kconfig
+++ b/subsys/dfu/Kconfig
@@ -11,6 +11,13 @@ menuconfig DFU_TARGET
 
 if (DFU_TARGET)
 
+config DFU_TARGET_ALWAYS_RESTART
+	bool "Always start writing from the start"
+	help
+	  Ensures that the download always start from offset 0 and does not try
+	  to resume from where it last stopped writing. This means it will erase
+	  anything previously written by dfu target.
+
 config DFU_TARGET_MCUBOOT
 	bool "MCUBoot update support"
 	default y

--- a/subsys/dfu/src/dfu_target_mcuboot.c
+++ b/subsys/dfu/src/dfu_target_mcuboot.c
@@ -161,7 +161,11 @@ int dfu_target_mcuboot_init(size_t file_size, dfu_target_callback_t cb)
 
 int dfu_target_mcuboot_offset_get(size_t *out)
 {
+#ifndef CONFIG_DFU_TARGET_ALWAYS_RESTART
 	*out = flash_img_bytes_written(&flash_img);
+#else
+	*out = 0;
+#endif
 	return 0;
 }
 

--- a/subsys/dfu/src/dfu_target_modem.c
+++ b/subsys/dfu/src/dfu_target_modem.c
@@ -7,7 +7,6 @@
 #include <dfu/dfu_target.h>
 
 LOG_MODULE_REGISTER(dfu_target_modem, CONFIG_DFU_TARGET_LOG_LEVEL);
-
 #define DIRTY_IMAGE 0x280000
 #define MODEM_MAGIC 0x7544656d
 
@@ -171,6 +170,9 @@ int dfu_target_modem_init(size_t file_size, dfu_target_callback_t cb)
 	if (offset == DIRTY_IMAGE) {
 		delete_banked_modem_fw();
 	} else if (offset != 0) {
+#ifdef CONFIG_DFU_TARGET_ALWAYS_RESTART
+		offset = 0;
+#endif
 		LOG_INF("Setting offset to 0x%x", offset);
 		len = sizeof(offset);
 		err = setsockopt(fd, SOL_DFU, SO_DFU_OFFSET, &offset, len);


### PR DESCRIPTION
Add Kconfig which enables `dfu_target` to ignore the current offset and
always start writing data from offset 0.

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>