### PR TITLE
lib: bsdlib: Add interpretation for EALREADY

### DIFF
--- a/lib/bsdlib/bsd_os.c
+++ b/lib/bsdlib/bsd_os.c
@@ -301,6 +301,9 @@ void bsd_os_errno_set(int err_code)
 	case NRF_EINPROGRESS:
 		errno = EINPROGRESS;
 		break;
+	case NRF_EALREADY:
+		errno = EALREADY;
+		break;
 	case NRF_ECANCELED:
 		errno = ECANCELED;
 		break;


### PR DESCRIPTION
Missing interpretation for NRF_EALREADY added

Signed-off-by: Kimmo Puusaari <kimmo.puusaari@nordicsemi.no>