### PR TITLE
doc: update Working with XXX user guides

### DIFF
--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -24,3 +24,11 @@
 .. |nRF52DK| replace:: nRF52 DK board (PCA10040)
 .. |nRF52840Dongle| replace:: nRF52840 Dongle (PCA10059)
 .. |Thingy91| replace:: Thingy:91 (PCA20035) - see :ref:`ug_thingy91`
+
+.. |fota_upgrades_def| replace:: You can upgrade the firmware of the device over the air, thus without a wired connection.
+   Such an upgrade is called a FOTA (firmware over-the-air) upgrade.
+
+.. |fota_upgrades_req_mcuboot| replace:: To upgrade the application, you must use :doc:`mcuboot:index` as the upgradable bootloader (:option:`CONFIG_BOOTLOADER_MCUBOOT` must be enabled).
+
+.. |fota_upgrades_building| replace:: To create a binary file for an application upgrade, make sure that :option:`CONFIG_BOOTLOADER_MCUBOOT` is enabled and build the application as usual.
+   The build will create several binary files (see :ref:`mcuboot:mcuboot_ncs`).

--- a/doc/nrf/ug_nrf52.rst
+++ b/doc/nrf/ug_nrf52.rst
@@ -45,6 +45,14 @@ Refer to the PCA number for building projects for these boards and find a link t
      - PCA10040
      - :ref:`nrf52810_pca10040<zephyr:nrf52810_pca10040>`
 
+nRF Desktop
+===========
+
+The nRF Desktop application is a complete project that integrates Bluetooth Low Energy, see the :ref:`nrf_desktop` application.
+It can be built for the nRF Desktop reference hardware or an nRF52840 DK.
+
+The nRF Desktop is a reference design of a HID device that is connected to a host through Bluetooth Low Energy or USB, or both.
+This application supports configurations for simple mouse, gaming mouse, keyboard, and USB dongle.
 
 Secure bootloader chain
 =======================
@@ -131,6 +139,50 @@ The nRF52 Series devices support running another protocol in parallel with the n
 The :ref:`Multi-Protocol Service Layer (MPSL) <nrfxlib:mpsl>` library provides services for multi-protocol applications.
 
 
+.. |note| replace:: There is currently no support for upgrading the bootloader (:doc:`mcuboot:index`) on nRF52 Series devices.
+
+.. fota_upgrades_start
+
+FOTA upgrades
+*************
+
+|fota_upgrades_def|
+FOTA upgrades can be used to replace the application.
+
+.. note::
+   |note|
+
+To perform a FOTA upgrade, complete the following steps:
+
+1. Make sure that your application supports FOTA upgrades.
+      To download and apply FOTA upgrades, the following requirements apply:
+
+      * You must enable the mcumgr module, which handles the transport protocol over Bluetooth Low Energy.
+        To enable this module in your application, complete the following steps:
+
+        a. Enable :option:`CONFIG_MCUMGR_CMD_OS_MGMT`, :option:`CONFIG_MCUMGR_CMD_IMG_MGMT`, and :option:`CONFIG_MCUMGR_SMP_BT`.
+        #. Call ``os_mgmt_register_group()`` and ``img_mgmt_register_group()`` in your application.
+        #. Call ``smp_bt_register()`` in your application to initialize the mcumgr Bluetooth Low Energy transport.
+
+        See the code of the :ref:`zephyr:smp_svr_sample` for an implementation example.
+        After completing these steps, your application should advertise the SMP Service with UUID 8D53DC1D-1DB7-4CD3-868B-8A527460AA84.
+
+      * |fota_upgrades_req_mcuboot|
+
+#. Create a binary file that contains the new image.
+      |fota_upgrades_building|
+      The :file:`app_update.bin` file is the file that must be downloaded to the device.
+
+#. Download the new image to a device.
+      Use `nRF Connect for Mobile`_ or `nRF Toolbox`_ to upgrade your device with the new firmware.
+
+      To do so, make sure that you can access the :file:`app_update.bin` file from your phone or tablet.
+      Then connect to the device with the mobile app and initiate the DFU process to transfer :file:`app_update.bin` to the device.
+
+      .. note::
+         There is currently no support for the FOTA process in nRF Connect for Desktop.
+
+.. fota_upgrades_end
 
 Building and programming a sample
 *********************************

--- a/doc/nrf/ug_nrf5340.rst
+++ b/doc/nrf/ug_nrf5340.rst
@@ -69,6 +69,14 @@ Zephyr includes the `OpenAMP`_ library, which provides a complete solution for e
 The IPC peripheral is presented to Zephyr as an Interprocessor Mailbox (IPM) device.
 The OpenAMP library uses the IPM SHIM layer, which in turn uses the IPC driver in `nrfx`_.
 
+.. |note| replace:: It is currently only possible to upgrade the firmware on the application core.
+   Also, there is currently no support for upgrading the bootloader (:doc:`mcuboot:index`) on the nRF5430.
+
+
+.. include:: ug_nrf52.rst
+   :start-after: fota_upgrades_start
+   :end-before: fota_upgrades_end
+
 
 Available samples
 *****************

--- a/doc/nrf/ug_nrf9160.rst
+++ b/doc/nrf/ug_nrf9160.rst
@@ -167,15 +167,14 @@ For more detailed information, see the `system mode section in the AT Commands r
 FOTA upgrades
 *************
 
-You can upgrade the firmware of the nRF9160 over the air, thus without a wired connection.
-Such an upgrade is called a FOTA (firmware over-the-air) upgrade.
+|fota_upgrades_def|
 FOTA upgrades can be used to apply delta patches to the `LTE modem`_ firmware and to replace the upgradable bootloader or the application.
 
 .. note::
    Even though the Secure Partition Manager and the application are two individually compiled components, they are treated as a single binary blob in the context of firmware upgrades.
    When we refer to the application in this section, we therefore mean the application including the Secure Partition Manager.
 
-A FOTA upgrade requires the following steps:
+To perform a FOTA upgrade, complete the following steps:
 
 1. Make sure that your application supports FOTA upgrades.
       To download and apply FOTA upgrades, your application must use the :ref:`lib_fota_download` library.
@@ -184,7 +183,7 @@ A FOTA upgrade requires the following steps:
 
       In addition, the following requirements apply:
 
-      * If you want to upgrade the application, :doc:`mcuboot:index` must be used as upgradable bootloader (:option:`CONFIG_BOOTLOADER_MCUBOOT`).
+      * |fota_upgrades_req_mcuboot|
       * If you want to upgrade the upgradable bootloader, the :ref:`bootloader` must be used (:option:`CONFIG_SECURE_BOOT`).
       * If you want to upgrade the modem firmware, neither MCUboot nor the immutable bootloader are required, because the modem firmware upgrade is handled by the modem itself.
 
@@ -192,8 +191,7 @@ A FOTA upgrade requires the following steps:
       This step does not apply for upgrades of the modem firmware.
       You can download delta patches for the modem firmware from the `nRF9160 product website (compatible downloads)`_.
 
-      To create a binary file for an application upgrade, make sure that :option:`CONFIG_BOOTLOADER_MCUBOOT` is enabled and build the application as usual.
-      The build will create several binary files (see :ref:`mcuboot:mcuboot_ncs`).
+      |fota_upgrades_building|
       The :file:`app_update.bin` file is the file that should be uploaded to the server.
 
       To create binary files for a bootloader upgrade, make sure that :option:`CONFIG_SECURE_BOOT` and :option:`CONFIG_BUILD_S1_VARIANT` are enabled and build MCUboot as usual.


### PR DESCRIPTION
Add information about nRF Desktop to the nRF52 user guide.
Also, add a FOTA upgrades section to the nRF52 and nRF53
user guide, reusing content from the nRF9160 user guide.

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>

PDF output (updated 03/20):
[Working with nRF9160 — nRF Connect SDK 1.2.pdf](https://github.com/NordicPlayground/fw-nrfconnect-nrf/files/4358931/Working.with.nRF9160.nRF.Connect.SDK.1.2.pdf)
[Working with nRF5340 — nRF Connect SDK 1.2.pdf](https://github.com/NordicPlayground/fw-nrfconnect-nrf/files/4358932/Working.with.nRF5340.nRF.Connect.SDK.1.2.pdf)
[Working with nRF52 — nRF Connect SDK 1.2.pdf](https://github.com/NordicPlayground/fw-nrfconnect-nrf/files/4358934/Working.with.nRF52.nRF.Connect.SDK.1.2.pdf)

