### PR TITLE
application: asset_tracker: move JSON handling from main to cloud_codec

### DIFF
--- a/applications/asset_tracker/src/cloud_codec/cloud_codec.h
+++ b/applications/asset_tracker/src/cloud_codec/cloud_codec.h
@@ -222,17 +222,27 @@ int cloud_decode_command(char const *input);
 int cloud_decode_init(cloud_cmd_cb_t cb);
 
 /**
- * @brief Encode data to be transmitted to the digital twin,
- *	  from sensor data structure to a cloud data structure
- *	  containing a JSON string.
+ * @brief Encode device status data to be transmitted to the
+ *        digital twin.
  *
- * @param sensor Pointer to sensor data.
+ * @param modem_param Pointer to optional modem parameter data.
+ * @param ui Pointer to array of cloud data channel name
+ *           strings.
+ * @param ui_count Size of the ui array.
+ * @param fota Pointer to array of FOTA services.
+ * @param fota_count Size of the fota array.
+ * @param fota_version Version of the FOTA service.
  * @param output Pointer to encoded data structure.
  *
- * @return 0 if the operation was successful, otherwise a (negative) error code.
+ * @return 0 if the operation was successful, otherwise a
+ *         (negative) error code.
  */
-int cloud_encode_digital_twin_data(const struct cloud_channel_data *channel,
-				   struct cloud_msg *output);
+int cloud_encode_device_status_data(
+	void *modem_param,
+	const char *const ui[], const u32_t ui_count,
+	const char *const fota[], const u32_t fota_count,
+	const u16_t fota_version,
+	struct cloud_msg *output);
 
 /**
  * @brief Releases memory used by cloud data structure.


### PR DESCRIPTION
Refactor device_status_send() to rely on cloud_codec.c to do the encoding (so we can eventually switch encoders between json and cbor or others).  Clean up sensor_data_send() (not overloaded now with device status).

Remove now-unnecessary channel parameter from cloud_encode_device_status_data().  Combine with cloud_encode_digital_twin_data() and simplify further.

Also, in related cleanup, reorder some encoding functions in cloud_codec.c so they are adjacent to other encoding functions in the file.  This makes it more readable.

Jira: TG91-231