### PR TITLE
applications: nrf_desktop: Disable constlat on pca20037

### DIFF
--- a/applications/nrf_desktop/configuration/nrf52_pca20037/app_ZDebug.conf
+++ b/applications/nrf_desktop/configuration/nrf52_pca20037/app_ZDebug.conf
@@ -61,8 +61,6 @@ CONFIG_DESKTOP_FN_KEYS_LOCK=0x4181
 CONFIG_DESKTOP_SETTINGS_LOAD_BY_THREAD_ENABLE=y
 CONFIG_DESKTOP_SETTINGS_LOAD_THREAD_STACK_SIZE=1024
 
-CONFIG_DESKTOP_CONSTLAT_ENABLE=y
-
 ################################################################################
 # Zephyr Configuration
 

--- a/applications/nrf_desktop/configuration/nrf52_pca20037/app_ZDebugMCUBoot.conf
+++ b/applications/nrf_desktop/configuration/nrf52_pca20037/app_ZDebugMCUBoot.conf
@@ -62,8 +62,6 @@ CONFIG_DESKTOP_FN_KEYS_LOCK=0x4181
 CONFIG_DESKTOP_SETTINGS_LOAD_BY_THREAD_ENABLE=y
 CONFIG_DESKTOP_SETTINGS_LOAD_THREAD_STACK_SIZE=1024
 
-CONFIG_DESKTOP_CONSTLAT_ENABLE=y
-
 ################################################################################
 # Zephyr Configuration
 

--- a/applications/nrf_desktop/configuration/nrf52_pca20037/app_ZDebugWithShell.conf
+++ b/applications/nrf_desktop/configuration/nrf52_pca20037/app_ZDebugWithShell.conf
@@ -65,8 +65,6 @@ CONFIG_DESKTOP_KERNEL_SHELL=y
 CONFIG_DESKTOP_SETTINGS_LOAD_BY_THREAD_ENABLE=y
 CONFIG_DESKTOP_SETTINGS_LOAD_THREAD_STACK_SIZE=1024
 
-CONFIG_DESKTOP_CONSTLAT_ENABLE=y
-
 ################################################################################
 # Zephyr Configuration
 

--- a/applications/nrf_desktop/configuration/nrf52_pca20037/app_ZRelease.conf
+++ b/applications/nrf_desktop/configuration/nrf52_pca20037/app_ZRelease.conf
@@ -57,8 +57,6 @@ CONFIG_DESKTOP_FN_KEYS_LOCK=0x4181
 CONFIG_DESKTOP_SETTINGS_LOAD_BY_THREAD_ENABLE=y
 CONFIG_DESKTOP_SETTINGS_LOAD_THREAD_STACK_SIZE=1024
 
-CONFIG_DESKTOP_CONSTLAT_ENABLE=y
-
 ################################################################################
 # Zephyr Configuration
 

--- a/applications/nrf_desktop/configuration/nrf52_pca20037/app_ZReleaseMCUBoot.conf
+++ b/applications/nrf_desktop/configuration/nrf52_pca20037/app_ZReleaseMCUBoot.conf
@@ -58,8 +58,6 @@ CONFIG_DESKTOP_FN_KEYS_LOCK=0x4181
 CONFIG_DESKTOP_SETTINGS_LOAD_BY_THREAD_ENABLE=y
 CONFIG_DESKTOP_SETTINGS_LOAD_THREAD_STACK_SIZE=1024
 
-CONFIG_DESKTOP_CONSTLAT_ENABLE=y
-
 ################################################################################
 # Zephyr Configuration
 


### PR DESCRIPTION
Change disables constant latency interrupts on pca20037. This configuration is no longer needed. The disconnections are no longer observed.