### PR TITLE
Bluetooth: gatt_dm: Fix discovery for services with no characteristics

### DIFF
--- a/subsys/bluetooth/gatt_dm.c
+++ b/subsys/bluetooth/gatt_dm.c
@@ -301,6 +301,11 @@ static u8_t discovery_process_service(struct bt_gatt_dm *dm,
 		return BT_GATT_ITER_STOP;
 	}
 
+	if (cur_attr->handle == cur_service_val->end_handle) {
+		/* No characteristics to discover, go to next service. */
+		return BT_GATT_ITER_CONTINUE;
+	}
+
 	dm->discover_params.uuid         = NULL;
 	dm->discover_params.type         = BT_GATT_DISCOVER_ATTRIBUTE;
 	dm->discover_params.start_handle = cur_attr->handle + 1;


### PR DESCRIPTION
Fix discovery for services when the service has no characteristics.
Example of such a service is the GATT service which is mandatory, but
all characteristics are optional.

Issue reported on devzone here:
https://devzone.nordicsemi.com/f/nordic-q-a/58757/service-discovery-issues-using-the-discovery-manager

Can be reproduced with enabling asserts in peripheral_gatt_dm and connecting with a zephyr central application which has disabled all GATT service characteristics.

Example:
west build -b nrf52840_pca10056 samples/bluetooth/peripheral_gatt_dm -- -DCONFIG_ASSERT=y
west build tests/bluetooth/shell -- -DCONFIG_BT_GATT_SERVICE_CHANGED=n
Shell commands:
```
bt init
bt connect <peripheral_gatt_dm addr>
```