### PR TITLE
samples: nrf9160: serial_lte_modem support hexadecimal arbitrary data

### DIFF
--- a/samples/nrf9160/serial_lte_modem/CMakeLists.txt
+++ b/samples/nrf9160/serial_lte_modem/CMakeLists.txt
@@ -21,6 +21,7 @@ include($ENV{ZEPHYR_BASE}/cmake/app/boilerplate.cmake NO_POLICY_SCOPE)
 project(serial_lte_modem)
 
 target_sources(app PRIVATE src/main.c)
+target_sources(app PRIVATE src/slm_util.c)
 target_sources(app PRIVATE src/slm_at_host.c)
 target_sources(app PRIVATE src/slm_at_tcpip.c)
 target_sources(app PRIVATE src/slm_at_icmp.c)

--- a/samples/nrf9160/serial_lte_modem/README.rst
+++ b/samples/nrf9160/serial_lte_modem/README.rst
@@ -114,6 +114,7 @@ The following proprietary BSD socket AT commands are used in this sample:
 * AT#XSENDTO=<url>,<port>,<data>
 * AT#XRECVFROM=<url>,<port>[,<length>]
 * AT#XGETADDRINFO=<url>
+* AT#XDATATYPE=<type>
 
 ICMP AT commands
 ****************
@@ -127,8 +128,7 @@ GPS AT Commands
 
 The following proprietary GPS AT commands are used in this sample:
 
-* AT#XGPSRUN=<op>[,<mask>]
-* AT#XGPSRUN?
+* AT#XGPS=<op>[,<mask>]
 
 Building and Running
 ********************

--- a/samples/nrf9160/serial_lte_modem/src/slm_at_gps.h
+++ b/samples/nrf9160/serial_lte_modem/src/slm_at_gps.h
@@ -35,12 +35,10 @@ void slm_at_gps_clac(void);
 /**
  * @brief Initialize GPS AT command parser.
  *
- * @param callback Callback function to send AT response
- *
  * @retval 0 If the operation was successful.
  *           Otherwise, a (negative) error code is returned.
  */
-int slm_at_gps_init(at_cmd_handler_t callback);
+int slm_at_gps_init(void);
 
 /**
  * @brief Uninitialize GPS AT command parser.

--- a/samples/nrf9160/serial_lte_modem/src/slm_at_host.h
+++ b/samples/nrf9160/serial_lte_modem/src/slm_at_host.h
@@ -28,6 +28,15 @@ typedef struct slm_at_cmd_list {
 	slm_at_handler_t handler;
 } slm_at_cmd_list_t;
 
+/**@brief Arbitrary data type over AT channel. */
+enum slm_data_type_t {
+	DATATYPE_HEXADECIMAL,
+	DATATYPE_PLAINTEXT,
+	DATATYPE_JSON,
+	DATATYPE_HTML,
+	DATATYPE_OMATLV
+};
+
 /**
  * @brief Initialize AT host for serial LTE modem
  *
@@ -36,42 +45,6 @@ typedef struct slm_at_cmd_list {
  */
 int slm_at_host_init(void);
 
-/**
- * @brief Compare name of AT command ignoring case
- *
- * @param cmd Command string received from UART
- * @param slm_cmd Propreiatry command supported by SLM
- * @param slm_cmd_length Length of string to compare
- *
- * @retval true If two commands match, false if not.
- */
-static inline bool slm_at_cmd_cmp(const char *cmd,
-				const char *slm_cmd,
-				u8_t slm_cmd_length)
-{
-	int i;
-
-	if (strlen(cmd) < slm_cmd_length) {
-		return false;
-	}
-
-	for (i = 0; i < slm_cmd_length; i++) {
-		if (toupper(*(cmd + i)) != *(slm_cmd + i)) {
-			return false;
-		}
-	}
-#if defined(CONFIG_SLM_CR_LF_TERMINATION)
-	if (strlen(cmd) > (slm_cmd_length + 2)) {
-#else
-	if (strlen(cmd) > (slm_cmd_length + 1)) {
-#endif
-		char ch = *(cmd + i);
-		/* With parameter, SET TEST, "="; READ, "?" */
-		return ((ch == '=') || (ch == '?'));
-	}
-
-	return true;
-}
 /** @} */
 
 #endif /* SLM_AT_HOST_ */

--- a/samples/nrf9160/serial_lte_modem/src/slm_at_icmp.h
+++ b/samples/nrf9160/serial_lte_modem/src/slm_at_icmp.h
@@ -35,12 +35,10 @@ void slm_at_icmp_clac(void);
 /**
  * @brief Initialize ICMP AT command parser.
  *
- * @param callback Callback function to send AT response
- *
  * @retval 0 If the operation was successful.
  *           Otherwise, a (negative) error code is returned.
  */
-int slm_at_icmp_init(at_cmd_handler_t callback);
+int slm_at_icmp_init(void);
 
 /**
  * @brief Uninitialize ICMP AT command parser.

--- a/samples/nrf9160/serial_lte_modem/src/slm_at_tcpip.h
+++ b/samples/nrf9160/serial_lte_modem/src/slm_at_tcpip.h
@@ -35,12 +35,10 @@ void slm_at_tcpip_clac(void);
 /**
  * @brief Initialize TCP/IP AT command parser.
  *
- * @param callback Callback function to send AT response
- *
  * @retval 0 If the operation was successful.
  *           Otherwise, a (negative) error code is returned.
  */
-int slm_at_tcpip_init(at_cmd_handler_t callback);
+int slm_at_tcpip_init(void);
 
 /**
  * @brief Uninitialize TCP/IP AT command parser.

--- a/samples/nrf9160/serial_lte_modem/src/slm_util.c
+++ b/samples/nrf9160/serial_lte_modem/src/slm_util.c
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <stdio.h>
+#include "slm_util.h"
+
+#define PRINTABLE_ASCII(ch) (ch > 0x1f && ch < 0x7f)
+
+/**
+ * @brief Compare string ignoring case
+ */
+bool slm_util_casecmp(const char *str1, const char *str2)
+{
+	int str2_len = strlen(str2);
+
+	if (strlen(str1) != str2_len) {
+		return false;
+	}
+
+	for (int i = 0; i < str2_len; i++) {
+		if (toupper(*(str1 + i)) != toupper(*(str2 + i))) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+
+/**
+ * @brief Compare name of AT command ignoring case
+ */
+bool slm_util_cmd_casecmp(const char *cmd, const char *slm_cmd)
+{
+	int i;
+	int slm_cmd_len = strlen(slm_cmd);
+
+	if (strlen(cmd) < slm_cmd_len) {
+		return false;
+	}
+
+	for (i = 0; i < slm_cmd_len; i++) {
+		if (toupper(*(cmd + i)) != toupper(*(slm_cmd + i))) {
+			return false;
+		}
+	}
+#if defined(CONFIG_SLM_CR_LF_TERMINATION)
+	if (strlen(cmd) > (slm_cmd_len + 2)) {
+#else
+	if (strlen(cmd) > (slm_cmd_len + 1)) {
+#endif
+		char ch = *(cmd + i);
+		/* With parameter, SET TEST, "="; READ, "?" */
+		return ((ch == '=') || (ch == '?'));
+	}
+
+	return true;
+}
+
+/**
+ * @brief Detect hexdecimal data type
+ */
+bool slm_util_hex_check(const u8_t *data, u16_t data_len)
+{
+	for (int i = 0; i < data_len; i++) {
+		char ch = *(data + i);
+
+		if (!PRINTABLE_ASCII(ch) && ch != '\r' && ch != '\n') {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
+ * @brief Encode hex array to hexdecimal string (ASCII text)
+ */
+int slm_util_htoa(const u8_t *hex, u16_t hex_len,
+		char *ascii, u16_t ascii_len)
+{
+	if (hex == NULL || ascii == NULL) {
+		return -EINVAL;
+	}
+	if (ascii_len < (hex_len * 2)) {
+		return -EINVAL;
+	}
+
+	for (int i = 0; i < hex_len; i++) {
+		sprintf(ascii + (i * 2), "%02X", *(hex + i));
+	}
+
+	return (hex_len * 2);
+}
+
+/**
+ * @brief Decode hexdecimal string (ASCII text) to hex array
+ */
+int slm_util_atoh(const char *ascii, u16_t ascii_len,
+		u8_t *hex, u16_t hex_len)
+{
+	char hex_str[3];
+
+	if (hex == NULL || ascii == NULL) {
+		return -EINVAL;
+	}
+	if ((ascii_len % 2) > 0) {
+		return -EINVAL;
+	}
+	if (ascii_len > (hex_len * 2)) {
+		return -EINVAL;
+	}
+
+	hex_str[2] = '\0';
+	for (int i = 0; i < ascii_len; i++) {
+		strncpy(&hex_str[0], ascii + (i * 2), 2);
+		*(hex + i) = (u8_t)strtoul(hex_str, NULL, 16);
+	}
+
+	return (ascii_len / 2);
+}

--- a/samples/nrf9160/serial_lte_modem/src/slm_util.h
+++ b/samples/nrf9160/serial_lte_modem/src/slm_util.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#ifndef SLM_UTIL_
+#define SLM_UTIL_
+
+/**@file slm_util.h
+ *
+ * @brief Utility functions for serial LTE modem
+ * @{
+ */
+
+#include <zephyr/types.h>
+#include <ctype.h>
+#include <stdbool.h>
+
+/**
+ * @brief Compare string ignoring case
+ *
+ * @param str1 First string
+ * @param str2 Second string
+ *
+ * @return true If two commands match, false if not.
+ */
+bool slm_util_casecmp(const char *str1, const char *str2);
+
+/**
+ * @brief Compare name of AT command ignoring case
+ *
+ * @param cmd Command string received from UART
+ * @param slm_cmd Propreiatry command supported by SLM
+ *
+ * @return true If two commands match, false if not.
+ */
+bool slm_util_cmd_casecmp(const char *cmd, const char *slm_cmd);
+
+/**
+ * @brief Detect hexdecimal data type
+ *
+ * @param hex[in] Hex arrary to be encoded
+ * @param hex_len[in] Length of hex array
+ *
+ * @return true if the input is hexdecimal array, otherwise false
+ */
+bool slm_util_hex_check(const u8_t *hex, u16_t hex_len);
+
+/**
+ * @brief Encode hex array to hexdecimal string (ASCII text)
+ *
+ * @param hex[in] Hex arrary to be encoded
+ * @param hex_len[in] Length of hex array
+ * @param ascii[out] encoded hexdecimal string
+ * @param ascii_len[in] reserved buffer size
+ *
+ * @return actual size of ascii string if the operation was successful.
+ *           Otherwise, a (negative) error code is returned.
+ */
+int slm_util_htoa(const u8_t *hex, u16_t hex_len,
+		char *ascii, u16_t ascii_len);
+
+/**
+ * @brief Decode hexdecimal string (ASCII text) to hex array
+ *
+ * @param ascii[in] encoded hexdecimal string
+ * @param ascii_len[in] size of hexdecimal string
+ * @param hex[out] decoded hex arrary
+ * @param hex_len[in] reserved size of hex array
+ *
+ * @return actual size of hex array if the operation was successful.
+ *           Otherwise, a (negative) error code is returned.
+ */
+int slm_util_atoh(const char *ascii, u16_t ascii_len,
+		u8_t *hex, u16_t hex_len);
+
+/** @} */
+
+#endif /* SLM_UTIL_ */


### PR DESCRIPTION
Add to support hexadecimal data over AT channel in TCP/IP module
.external to SLM, add AT#XDATATYPE to indicate type of sending data
.SLM to external, detect data type and indicate to external
.Actual data over AT channel is hexadecimal string format
Misc update
.Added "slm_util" for shared utility functions
.Renamed "AT#XGPSRUN" to "AT#XGPS"

Similar mechanism will be used in MQTT/LwM2M/FTP modules

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>