### PR TITLE
GPS: Fix issues related to stopping GPS search

### DIFF
--- a/applications/asset_tracker/src/gps_controller/gps_controller.c
+++ b/applications/asset_tracker/src/gps_controller/gps_controller.c
@@ -79,7 +79,7 @@ static void stop(struct k_work *work)
 		return;
 	}
 
-#ifdef CONFIG_GPS_CONTROL_PSM_ENABLE_ON_START
+#ifdef CONFIG_GPS_CONTROL_PSM_DISABLE_ON_STOP
 	LOG_INF("Disabling PSM");
 
 	err = lte_lc_psm_req(false);
@@ -87,7 +87,7 @@ static void stop(struct k_work *work)
 		LOG_ERR("PSM mode could not be disabled, error: %d",
 			err);
 	}
-#endif /* CONFIG_GPS_CONTROL_PSM_ENABLE_ON_START */
+#endif /* CONFIG_GPS_CONTROL_PSM_DISABLE_ON_STOP */
 
 	err = gps_stop(gps_dev);
 	if (err) {


### PR DESCRIPTION
drivers: nrf9160_gps: Fix notification of stopped search

Fixes an issue where `GPS_EVT_SEARCH_STOPPED` was never sent
from the driver, even though the GPS was successfully stopped.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>

---

applications: asset_tracker: Fix typo in PSM handling

Fixes typo in code for disabling PSM when GPS search is stopped.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>