### PR TITLE
bsdlib send() limit workaround

### DIFF
--- a/ext/cjson/cJSON.c
+++ b/ext/cjson/cJSON.c
@@ -427,7 +427,7 @@ static unsigned char* ensure(printbuffer * const p, size_t needed)
     }
     else
     {
-        newsize = needed * 2;
+        newsize = needed + 1;
     }
 
     if (p->hooks.reallocate != NULL)

--- a/lib/bsdlib/Kconfig
+++ b/lib/bsdlib/Kconfig
@@ -32,6 +32,24 @@ config BSD_LIBRARY_TRACE_ENABLED
 	# This enable UARTE1 peripheral and includes nrfx UARTE driver.
 	select NRFX_UARTE1
 
+config NRF91_SOCKET_SEND_SPLIT_LARGE_BLOCKS
+	bool "Split large blocks passed to send() or sendto()"
+	default n
+	help
+	  Workaround a limitation in the nRF91 modem firmware's bsdlib
+	  implementation regarding return value for send() or sendto()
+	  calls larger than the module can handle. It should send the data
+	  up to the maximum, and return that as the return value. Instead,
+	  it returns error 22.
+
+config NRF91_SOCKET_BLOCK_LIMIT
+	int "Maximum size the modem can send"
+	default 2048
+	help
+	  Blocks larger than this value will be split into two or more
+	  send() or sendto() calls. This may not work for certain kinds
+	  of sockets or certain flag parameter values.
+
 endif # BSD_LIBRARY
 
 endmenu

--- a/lib/bsdlib/nrf91_sockets.c
+++ b/lib/bsdlib/nrf91_sockets.c
@@ -737,6 +737,9 @@ static ssize_t nrf91_socket_offload_recvfrom(int sd, void *buf, short int len,
 static ssize_t nrf91_socket_offload_send(int sd, const void *buf, size_t len,
 					 int flags)
 {
+	if (IS_ENABLED(CONFIG_NRF91_SOCKET_SEND_SPLIT_LARGE_BLOCKS)) {
+		len = MIN(len, CONFIG_NRF91_SOCKET_BLOCK_LIMIT);
+	}
 	return nrf_send(sd, buf, len, z_to_nrf_flags(flags));
 }
 
@@ -745,6 +748,9 @@ static ssize_t nrf91_socket_offload_sendto(int sd, const void *buf, size_t len,
 					   socklen_t tolen)
 {
 	ssize_t retval;
+	if (IS_ENABLED(CONFIG_NRF91_SOCKET_SEND_SPLIT_LARGE_BLOCKS)) {
+		len = MIN(len, CONFIG_NRF91_SOCKET_BLOCK_LIMIT);
+	}
 
 	if (to == NULL) {
 		retval = nrf_sendto(sd, buf, len, z_to_nrf_flags(flags), NULL,


### PR DESCRIPTION
lib: bsdlib: bsdlib send() workaround

Adjust the length passed on to the modem so only portion
that fits in the send buffer is sent, and the length sent
is returned as usual to the caller.

ext: cjson: Be less greedy with heap when reallocating

Change ensure() in cJSON.c to only request what is needed, not double 
the message size.  This is too wasteful when sending large messages.

Jira: NRF91-601