### PR TITLE
tests: debug: cpu_load: Fix test for PPI case

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,6 +39,7 @@ pipeline {
                                       --board-root zephyr/boards \
                                       --testcase-root nrf/samples \
                                       --testcase-root nrf/applications \
+                                      --testcase-root nrf/tests \
                                       --inline-logs --disable-unrecognized-section-test \
                                       --tag ci_build \
                                       --retry-failed 7 \

--- a/tests/drivers/clock_control/clock_control_mpsl/src/test_clock_control.c
+++ b/tests/drivers/clock_control/clock_control_mpsl/src/test_clock_control.c
@@ -216,7 +216,9 @@ static bool async_capable(const char *dev_name, clock_control_subsys_t subsys)
 /*
  * Test checks that callbacks are called after clock is started.
  */
-static void clock_on_callback(struct device *dev, void *user_data)
+static void clock_on_callback(struct device *dev,
+			      clock_control_subsys_t subsys,
+			      void *user_data)
 {
 	bool *executed = (bool *)user_data;
 
@@ -291,7 +293,9 @@ static void test_async_on_off(void)
 /*
  * Test callback used to count the number of executed async_on requests.
  */
-static void clock_on_counting_callback(struct device *dev, void *user_data)
+static void clock_on_counting_callback(struct device *dev,
+				       clock_control_subsys_t subsys,
+				       void *user_data)
 {
 	int *count = (int *)user_data;
 

--- a/tests/subsys/debug/cpu_load/src/test_cpu_load.c
+++ b/tests/subsys/debug/cpu_load/src/test_cpu_load.c
@@ -10,59 +10,60 @@
 #include <debug/cpu_load.h>
 #include <helpers/nrfx_gppi.h>
 #include <nrfx_timer.h>
-#include <nrfx_dppi.h>
 #include <hal/nrf_power.h>
 
-#define FULL_LOAD 100000
-#define SMALL_LOAD 3000
+#ifdef DPPI_PRESENT
+#include <nrfx_dppi.h>
 
 static void timer_handler(nrf_timer_event_t event_type, void *context)
 {
 	/*empty*/
 }
+#endif
+
+#define FULL_LOAD 100000
+#define SMALL_LOAD 3000
 
 void test_cpu_load(void)
 {
 	int err;
 	u32_t load;
-	static nrfx_timer_t timer = NRFX_TIMER_INSTANCE(1);
 
 	if (IS_ENABLED(CONFIG_SOC_NRF9160)) {
 		/* Wait for LF clock stabilization. */
 		k_busy_wait(500000);
 	}
 
-	if (IS_ENABLED(CONFIG_HAS_HW_NRF_DPPIC)) {
-		nrfx_timer_config_t config = NRFX_TIMER_DEFAULT_CONFIG;
-		u8_t ch;
-		u32_t evt =
-			nrf_power_event_address_get(NRF_POWER,
-						    NRF_POWER_EVENT_SLEEPENTER);
-		u32_t tsk =
-		     nrfx_timer_task_address_get(&timer, NRF_TIMER_TASK_COUNT);
+#ifdef DPPI_PRESENT
+	static nrfx_timer_t timer = NRFX_TIMER_INSTANCE(1);
+	nrfx_timer_config_t config = NRFX_TIMER_DEFAULT_CONFIG;
+	u8_t ch;
+	u32_t evt = nrf_power_event_address_get(NRF_POWER,
+						NRF_POWER_EVENT_SLEEPENTER);
+	u32_t tsk = nrfx_timer_task_address_get(&timer, NRF_TIMER_TASK_COUNT);
 
-		config.frequency = NRF_TIMER_FREQ_1MHz;
-		config.bit_width = NRF_TIMER_BIT_WIDTH_32;
+	config.frequency = NRF_TIMER_FREQ_1MHz;
+	config.bit_width = NRF_TIMER_BIT_WIDTH_32;
 
-		err = nrfx_timer_init(&timer, &config, timer_handler);
-		zassert_equal(err, NRFX_SUCCESS, "Unexpected error:%d", err);
+	err = nrfx_timer_init(&timer, &config, timer_handler);
+	zassert_equal(err, NRFX_SUCCESS, "Unexpected error:%d", err);
 
-		err = nrfx_dppi_channel_alloc(&ch);
-		zassert_equal(err, NRFX_SUCCESS, "Unexpected error:%d", err);
+	err = nrfx_dppi_channel_alloc(&ch);
+	zassert_equal(err, NRFX_SUCCESS, "Unexpected error:%d", err);
 
-		nrfx_gppi_channel_endpoints_setup(ch, evt, tsk);
-		nrfx_gppi_channels_enable(BIT(ch));
+	nrfx_gppi_channel_endpoints_setup(ch, evt, tsk);
+	nrfx_gppi_channels_enable(BIT(ch));
 
-		if (!IS_ENABLED(CONFIG_CPU_LOAD_USE_SHARED_DPPI_CHANNELS)) {
-			err = cpu_load_init();
-			zassert_equal(err, -ENODEV, "Unexpected err:%d", err);
+	if (!IS_ENABLED(CONFIG_CPU_LOAD_USE_SHARED_DPPI_CHANNELS)) {
+		err = cpu_load_init();
+		zassert_equal(err, -ENODEV, "Unexpected err:%d", err);
 
-			nrfx_gppi_channels_disable(BIT(ch));
-			nrfx_gppi_event_endpoint_clear(ch, evt);
-			nrfx_gppi_task_endpoint_clear(ch, tsk);
-			err = nrfx_dppi_channel_free(ch);
-		}
+		nrfx_gppi_channels_disable(BIT(ch));
+		nrfx_gppi_event_endpoint_clear(ch, evt);
+		nrfx_gppi_task_endpoint_clear(ch, tsk);
+		err = nrfx_dppi_channel_free(ch);
 	}
+#endif
 
 	err = cpu_load_init();
 	zassert_equal(err, 0, "Unexpected err:%d", err);

--- a/tests/subsys/debug/cpu_load/testcase.yaml
+++ b/tests/subsys/debug/cpu_load/testcase.yaml
@@ -2,10 +2,10 @@ tests:
   testing.cpu_load:
     platform_whitelist: nrf52840_pca10056 nrf9160_pca10090
     build_only: true
-    tags: debug
+    tags: ci_build debug
   testing.cpu_load.shared_dppi:
     platform_whitelist: nrf9160_pca10090
     build_only: true
-    tags: debug
+    tags: ci_build debug
     extra_configs:
       - CONFIG_CPU_LOAD_USE_SHARED_DPPI_CHANNELS=y


### PR DESCRIPTION
Test was including DPPI headers for all cases, including case
when DPPI was not available. That lead to compilation error.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>