### PR TITLE
applications: nrf_desktop: Add info module documentation

### DIFF
--- a/applications/nrf_desktop/README.rst
+++ b/applications/nrf_desktop/README.rst
@@ -664,6 +664,7 @@ For more information about each application module and its configuration details
    doc/hid_forward.rst
    doc/hid_state.rst
    doc/hids.rst
+   doc/info.rst
    doc/led_state.rst
    doc/power_manager.rst
    doc/usb_state.rst

--- a/applications/nrf_desktop/doc/info.rst
+++ b/applications/nrf_desktop/doc/info.rst
@@ -1,0 +1,39 @@
+.. _info:
+
+Info module
+###########
+
+The Info module is required by the :ref:`config_channel`.
+The module is the final subscriber for the :ref:`config_channel` events and provides the board name through the :ref:`config_channel`.
+
+Module Events
+*************
+
++------------------+--------------------------------+---------------+------------------------+------------------+
+| Source Module    | Input Event                    | This Module   | Output Event           | Sink Module      |
++==================+================================+===============+========================+==================+
+| :ref:`hids`      | ``config_event``               |  ``info``     |                        |                  |
++------------------+                                |               |                        |                  |
+| :ref:`usb_state` |                                |               |                        |                  |
++------------------+--------------------------------+               |                        |                  |
+| :ref:`hids`      | ``config_fetch_request_event`` |               |                        |                  |
++------------------+                                |               |                        |                  |
+| :ref:`usb_state` |                                |               |                        |                  |
++------------------+--------------------------------+               +------------------------+------------------+
+|                  |                                |               | ``config_fetch_event`` | :ref:`hids`      |
+|                  |                                |               |                        +------------------+
+|                  |                                |               |                        | :ref:`usb_state` |
++------------------+--------------------------------+---------------+------------------------+------------------+
+
+Configuration
+*************
+
+The module is enabled with the same Kconfig option as the :ref:`config_channel`: ``CONFIG_DESKTOP_CONFIG_CHANNEL_ENABLE``.
+
+Implementation details
+**********************
+
+The Info module must be the final subscriber for ``config_event`` and ``config_fetch_request_event``.
+Otherwise some listeners may not be accessible by the :ref:`config_channel_script`.
+
+The board name provided by the module through the :ref:`config_channel` is a part of the Zephyr board name (:option:`CONFIG_BOARD`), beginning with the predefined prefix (:c:macro:`BOARD_PREFIX`).


### PR DESCRIPTION
Change adds Info module documentation. The module is used by the configuration channel.