### PR TITLE
samples: remove prompt for log level redefinition

### DIFF
--- a/samples/Kconfig
+++ b/samples/Kconfig
@@ -17,21 +17,12 @@ config NCS_SAMPLES_DEFAULTS
 
 if LOG
 
-# LOG_DEFAULT_LEVEL is declared in Zephyr and also here for a second time,
-# for set the valid default size value
-config LOG_DEFAULT_LEVEL
-	int "Default log level"
-	default 1 if NCS_SAMPLES_DEFAULTS
-	range 0 4
-	help
-	  Sets log level for modules which don't specify it explicitly. When
-	  set to 0 it means log will not be activated for those modules.
-	  Levels are:
+# LOG_DEFAULT_LEVEL is declared in Zephyr,
+# we declare it here for a second time, to set a different default.
+# Omit the `prompt` to prevent it from appearing twice in two diffent places.
 
-	  - 0 OFF, do not write by default
-	  - 1 ERROR, default to only write LOG_LEVEL_ERR
-	  - 2 WARNING, default to write LOG_LEVEL_WRN
-	  - 3 INFO, default to write LOG_LEVEL_INFO
-	  - 4 DEBUG, default to write LOG_LEVEL_DBG
+config LOG_DEFAULT_LEVEL
+	default 1 if NCS_SAMPLES_DEFAULTS
+
 
 endif # LOG


### PR DESCRIPTION
Remove `prompt` from the re-define of  LOG_DEFAULT_LEVEL
to prevent it from appearing in two different places in the menu.

Signed-off-by: Emanuele Di Santo <emdi@nordicsemi.no>