### PR TITLE
For B0N: Move boot/validation code (boot_from()) into subsys.

### DIFF
--- a/samples/bootloader/src/main.c
+++ b/samples/bootloader/src/main.c
@@ -5,49 +5,17 @@
  */
 
 #include <zephyr/types.h>
-#include <errno.h>
-#include <toolchain.h>
-#include <sys/util.h>
 #include <sys/printk.h>
-#include <nrf.h>
 #include <pm_config.h>
-#include <bl_validation.h>
-#include <bl_crypto.h>
 #include <fw_info.h>
 #include <fprotect.h>
 #include <bl_storage.h>
-#ifdef CONFIG_UART_NRFX
-#ifdef CONFIG_UART_0_NRF_UART
-#include <hal/nrf_uart.h>
-#else
-#include <hal/nrf_uarte.h>
-#endif
-#endif
+#include <bl_boot.h>
+#include <bl_validation.h>
 
-static void uninit_used_peripherals(void)
+
+static void validate_and_boot(const struct fw_info *fw_info)
 {
-#ifdef CONFIG_UART_0_NRF_UART
-	nrf_uart_disable(NRF_UART0);
-#elif defined(CONFIG_UART_0_NRF_UARTE)
-	nrf_uarte_disable(NRF_UARTE0);
-#elif defined(CONFIG_UART_1_NRF_UARTE)
-	nrf_uarte_disable(NRF_UARTE1);
-#elif defined(CONFIG_UART_2_NRF_UARTE)
-	nrf_uarte_disable(NRF_UARTE2);
-#endif
-}
-
-#ifdef CONFIG_SW_VECTOR_RELAY
-extern u32_t _vector_table_pointer;
-#define VTOR _vector_table_pointer
-#else
-#define VTOR SCB->VTOR
-#endif
-
-static void boot_from(const struct fw_info *fw_info)
-{
-	u32_t *vector_table = (u32_t *)fw_info->address;
-
 	printk("Attempting to boot from address 0x%x.\n\r",
 		fw_info->address);
 
@@ -58,74 +26,7 @@ static void boot_from(const struct fw_info *fw_info)
 		return;
 	}
 
-#if !(defined(CONFIG_SOC_NRF9160) || defined(CONFIG_SOC_NRF5340_CPUAPP))
-	/* Protect bootloader storage data after firmware is validated so
-	 * invalidation of public keys can be written into the page if needed.
-	 * Note that for some devices (for example, nRF9160 and the nRF5340
-	 * application core), the bootloader storage data is kept in OTP which
-	 * does not need or support protection.
-	 */
-	int err = fprotect_area(PM_PROVISION_ADDRESS, PM_PROVISION_SIZE);
-
-	if (err) {
-		printk("Failed to protect bootloader storage.\n\r");
-		return;
-	}
-#endif
-
-#if CONFIG_ARCH_HAS_USERSPACE
-	__ASSERT(!(CONTROL_nPRIV_Msk & __get_CONTROL()),
-			"Not in Privileged mode");
-#endif
-
-	/* Allow any pending interrupts to be recognized */
-	__ISB();
-	__disable_irq();
-	NVIC_Type *nvic = NVIC;
-	/* Disable NVIC interrupts */
-	for (u8_t i = 0; i < ARRAY_SIZE(nvic->ICER); i++) {
-		nvic->ICER[i] = 0xFFFFFFFF;
-	}
-	/* Clear pending NVIC interrupts */
-	for (u8_t i = 0; i < ARRAY_SIZE(nvic->ICPR); i++) {
-		nvic->ICPR[i] = 0xFFFFFFFF;
-	}
-
-	printk("Booting (0x%x).\r\n", fw_info->address);
-
-	uninit_used_peripherals();
-
-	SysTick->CTRL = 0;
-
-	/* Disable fault handlers used by the bootloader */
-	SCB->ICSR |= SCB_ICSR_PENDSTCLR_Msk;
-
-#ifndef CONFIG_CPU_CORTEX_M0
-	SCB->SHCSR &= ~(SCB_SHCSR_USGFAULTENA_Msk | SCB_SHCSR_BUSFAULTENA_Msk |
-			SCB_SHCSR_MEMFAULTENA_Msk);
-#endif
-
-	/* Activate the MSP if the core is found to currently run with the PSP */
-	if (CONTROL_SPSEL_Msk & __get_CONTROL()) {
-		__set_CONTROL(__get_CONTROL() & ~CONTROL_SPSEL_Msk);
-	}
-
-	__DSB(); /* Force Memory Write before continuing */
-	__ISB(); /* Flush and refill pipeline with updated permissions */
-
-	VTOR = fw_info->address;
-
-	if (!fw_info_ext_api_provide(fw_info, true)) {
-		return;
-	}
-
-	/* Set MSP to the new address and clear any information from PSP */
-	__set_MSP(vector_table[0]);
-	__set_PSP(0);
-
-	/* Call reset handler. */
-	((void (*)(void))vector_table[1])();
-	CODE_UNREACHABLE;
+	bl_boot(fw_info);
 }
 
 void main(void)
@@ -143,11 +44,11 @@ void main(void)
 	const struct fw_info *s1_info = fw_info_find(s1_addr);
 
 	if (!s1_info || (s0_info->version >= s1_info->version)) {
-		boot_from(s0_info);
-		boot_from(s1_info);
+		validate_and_boot(s0_info);
+		validate_and_boot(s1_info);
 	} else {
-		boot_from(s1_info);
-		boot_from(s0_info);
+		validate_and_boot(s1_info);
+		validate_and_boot(s0_info);
 	}
 
 	printk("No bootable image found. Aborting boot.\n\r");

--- a/subsys/bootloader/CMakeLists.txt
+++ b/subsys/bootloader/CMakeLists.txt
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
+add_subdirectory(bl_boot)
+
 zephyr_include_directories(include)
 
 if (NOT IMAGE_NAME)

--- a/subsys/bootloader/bl_boot/CMakeLists.txt
+++ b/subsys/bootloader/bl_boot/CMakeLists.txt
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+zephyr_library()
+zephyr_library_sources(bl_boot.c)

--- a/subsys/bootloader/bl_boot/bl_boot.c
+++ b/subsys/bootloader/bl_boot/bl_boot.c
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#include <sys/printk.h>
+#include <pm_config.h>
+#include <fw_info.h>
+#include <fprotect.h>
+#ifdef CONFIG_UART_NRFX
+#ifdef CONFIG_UART_0_NRF_UART
+#include <hal/nrf_uart.h>
+#else
+#include <hal/nrf_uarte.h>
+#endif
+#endif
+
+static void uninit_used_peripherals(void)
+{
+#ifdef CONFIG_UART_0_NRF_UART
+	nrf_uart_disable(NRF_UART0);
+#elif defined(CONFIG_UART_0_NRF_UARTE)
+	nrf_uarte_disable(NRF_UARTE0);
+#elif defined(CONFIG_UART_1_NRF_UARTE)
+	nrf_uarte_disable(NRF_UARTE1);
+#elif defined(CONFIG_UART_2_NRF_UARTE)
+	nrf_uarte_disable(NRF_UARTE2);
+#endif
+}
+
+#ifdef CONFIG_SW_VECTOR_RELAY
+extern u32_t _vector_table_pointer;
+#define VTOR _vector_table_pointer
+#else
+#define VTOR SCB->VTOR
+#endif
+
+void bl_boot(const struct fw_info *fw_info)
+{
+#if !(defined(CONFIG_SOC_NRF9160) || defined(CONFIG_SOC_NRF5340_CPUAPP))
+	/* Protect bootloader storage data after firmware is validated so
+	 * invalidation of public keys can be written into the page if needed.
+	 * Note that for some devices (for example, nRF9160 and the nRF5340
+	 * application core), the bootloader storage data is kept in OTP which
+	 * does not need or support protection.
+	 */
+	int err = fprotect_area(PM_PROVISION_ADDRESS, PM_PROVISION_SIZE);
+
+	if (err) {
+		printk("Failed to protect bootloader storage.\n\r");
+		return;
+	}
+#endif
+
+#if CONFIG_ARCH_HAS_USERSPACE
+	__ASSERT(!(CONTROL_nPRIV_Msk & __get_CONTROL()),
+			"Not in Privileged mode");
+#endif
+
+	/* Allow any pending interrupts to be recognized */
+	__ISB();
+	__disable_irq();
+	NVIC_Type *nvic = NVIC;
+	/* Disable NVIC interrupts */
+	for (u8_t i = 0; i < ARRAY_SIZE(nvic->ICER); i++) {
+		nvic->ICER[i] = 0xFFFFFFFF;
+	}
+	/* Clear pending NVIC interrupts */
+	for (u8_t i = 0; i < ARRAY_SIZE(nvic->ICPR); i++) {
+		nvic->ICPR[i] = 0xFFFFFFFF;
+	}
+
+	printk("Booting (0x%x).\r\n", fw_info->address);
+
+	uninit_used_peripherals();
+
+	SysTick->CTRL = 0;
+
+	/* Disable fault handlers used by the bootloader */
+	SCB->ICSR |= SCB_ICSR_PENDSTCLR_Msk;
+
+#ifndef CONFIG_CPU_CORTEX_M0
+	SCB->SHCSR &= ~(SCB_SHCSR_USGFAULTENA_Msk | SCB_SHCSR_BUSFAULTENA_Msk |
+			SCB_SHCSR_MEMFAULTENA_Msk);
+#endif
+
+	/* Activate the MSP if the core is currently running with the PSP */
+	if (CONTROL_SPSEL_Msk & __get_CONTROL()) {
+		__set_CONTROL(__get_CONTROL() & ~CONTROL_SPSEL_Msk);
+	}
+
+	__DSB(); /* Force Memory Write before continuing */
+	__ISB(); /* Flush and refill pipeline with updated permissions */
+
+	VTOR = fw_info->address;
+	u32_t *vector_table = (u32_t *)fw_info->address;
+
+	if (!fw_info_ext_api_provide(fw_info, true)) {
+		return;
+	}
+
+	/* Set MSP to the new address and clear any information from PSP */
+	__set_MSP(vector_table[0]);
+	__set_PSP(0);
+
+	/* Call reset handler. */
+	((void (*)(void))vector_table[1])();
+	CODE_UNREACHABLE;
+}

--- a/subsys/bootloader/include/bl_boot.h
+++ b/subsys/bootloader/include/bl_boot.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#ifndef BL_BOOT_H_
+#define BL_BOOT_H_
+
+#include <fw_info.h>
+
+/** Prepare the device and boot the firmware.
+ *
+ *  Before booting, the function does necessary cleanup and preparation, such
+ *  as uninitializing UART and setting VTOR.
+ *
+ *  @param[in] fw_info  The firmware's fw_info struct. The pointer must point
+ *                      to the actual structure in flash, not a copy.
+ *
+ *  @return  If validation fails this function returns, otherwise it transfers
+ *           control to the firmware and doesn't return.
+ */
+void bl_boot(const struct fw_info *fw_info);
+
+#endif /* BL_BOOT_H_ */


### PR DESCRIPTION
Add to a new file (bl_boot) and rename the function to
bl_validate_and_boot().

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>