### PR TITLE
application: asset_tracker: fix cloud_ping() timing

### DIFF
--- a/applications/asset_tracker/Kconfig
+++ b/applications/asset_tracker/Kconfig
@@ -217,8 +217,15 @@ endmenu # Motion
 menu "Cloud"
 
 config MQTT_KEEPALIVE
-	int
+	int "Time after last transmission to send a ping to keep connection on"
 	default 1200
+	help
+	  This should be set to the expected time between messages sent from
+	  this device. Making it larger than the expected data period does not
+	  conserve bandwidth, as the ping is only sent if nothing else
+	  has been within the specified period. Shorter values can prevent hidden
+	  NAT timeouts at the carrier, but also will interrupt GPS fix attempts
+	  and slow down TTFF.
 
 config CLOUD_BUTTON
 	bool "Enable button sensor"

--- a/applications/asset_tracker/prj.conf
+++ b/applications/asset_tracker/prj.conf
@@ -43,6 +43,8 @@ CONFIG_NRF_CLOUD_LOG_LEVEL_DBG=y
 CONFIG_NRF_CLOUD_AGPS=y
 # Needed for the cloud codec
 CONFIG_CJSON_LIB=y
+# Shorter to prevent NAT timeouts
+CONFIG_MQTT_KEEPALIVE=120
 
 # Sensors
 CONFIG_ACCEL_USE_SIM=y

--- a/applications/asset_tracker/prj_nrf9160_pca20035ns.conf
+++ b/applications/asset_tracker/prj_nrf9160_pca20035ns.conf
@@ -47,6 +47,8 @@ CONFIG_NRF_CLOUD_LOG_LEVEL_DBG=y
 CONFIG_NRF_CLOUD_AGPS=y
 # Needed for the cloud codec
 CONFIG_CJSON_LIB=y
+# Shorter to prevent NAT timeouts
+CONFIG_MQTT_KEEPALIVE=120
 
 # Sensors
 CONFIG_SENSOR=y

--- a/applications/asset_tracker/src/main.c
+++ b/applications/asset_tracker/src/main.c
@@ -1437,7 +1437,9 @@ connect:
 			continue;
 		}
 
-		if (ret == 0) {
+		if ((ret == 0) &&
+		    (cloud_keepalive_time_left(cloud_backend) == 0)) {
+			LOG_DBG("cloud_ping()!");
 			cloud_ping(cloud_backend);
 			continue;
 		}


### PR DESCRIPTION
Prevent unnecessary pings due to bug in poll() which causes it to
return 0 sometimes even without a timeout.  Change default keepalive
value back to 120 to prevent NAT timeouts on some carriers.
Does not save bandwidth anyway to have a large value for this if it
is larger than shortest sensor reporting interval.

Jira: NCSDK-4422