### PR TITLE
requirements: Add imagesize 1.2.0

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,4 +1,5 @@
 recommonmark==0.4.0
 sphinxcontrib-mscgen>=0.5
+imagesize>=1.2.0
 ecdsa
 intelhex


### PR DESCRIPTION
In order to be able to support the :scale: directive on .svg files,
imagesize 1.2.0 is required in order to avoid getting the following
warnings:

warning: could not obtain image size. :scale: option is ignored

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>