### PR TITLE
applications: nrf_desktop: Fix UUID allocating

### DIFF
--- a/applications/nrf_desktop/src/modules/ble_discovery.c
+++ b/applications/nrf_desktop/src/modules/ble_discovery.c
@@ -35,6 +35,7 @@ static u16_t peer_vid;
 static u16_t peer_pid;
 static bool peer_llpm_support;
 static struct bt_conn *discovering_peer_conn;
+static const struct bt_uuid * const pnp_uuid = BT_UUID_DIS_PNP_ID;
 
 static struct k_work next_discovery_step;
 
@@ -173,7 +174,7 @@ static void discovery_completed(struct bt_gatt_dm *dm, void *context)
 		break;
 
 	case DISCOVERY_STATE_DIS:
-		uuid = BT_UUID_DIS_PNP_ID;
+		uuid = pnp_uuid;
 		break;
 
 	default:


### PR DESCRIPTION
Change fixes allocating BT_UUID_DIS_PNP_ID in ble_discovery module. Allocating the data in switch scope may lead to errors (the data is used after it goes out of the scope).