### PR TITLE
samples: bluetooth: peripheral_hids_mouse: force rpa for directed adv

### DIFF
--- a/samples/bluetooth/peripheral_hids_mouse/src/main.c
+++ b/samples/bluetooth/peripheral_hids_mouse/src/main.c
@@ -164,6 +164,7 @@ static void advertising_continue(void)
 		struct bt_conn *conn;
 
 		adv_param = *BT_LE_ADV_CONN_DIR;
+		adv_param.options |= BT_LE_ADV_OPT_DIR_ADDR_RPA;
 		conn = bt_conn_create_slave_le(&addr, &adv_param);
 		if (!conn) {
 			printk("Directed advertising failed to start\n");


### PR DESCRIPTION
This change adds an additional flag to the directed advertising
parameters. This flag instructs BLE stack to use RPA in initiator
address field of directed advertising packets even when privacy
feature is disabled. This is necessary to make directed advertising
packets visible to the central devices that are using Zephyr BLE stack.

Ref: NCSDK-4647

Signed-off-by: Kamil Piszczek <Kamil.Piszczek@nordicsemi.no>