### PR TITLE
lib: at_cmd: fix off-by-one and wrong error check

### DIFF
--- a/lib/at_cmd/at_cmd.c
+++ b/lib/at_cmd/at_cmd.c
@@ -172,7 +172,8 @@ static void socket_thread_fn(void *arg1, void *arg2, void *arg3)
 			goto next;
 		}
 
-		LOG_DBG("at_cmd_rx: %s", log_strdup(item->data));
+		LOG_DBG("at_cmd_rx %d bytes, %s",
+			bytes_read, log_strdup(item->data));
 
 		payload_len = get_return_code(item->data, &ret);
 

--- a/lib/at_cmd/at_cmd.c
+++ b/lib/at_cmd/at_cmd.c
@@ -162,10 +162,9 @@ static void socket_thread_fn(void *arg1, void *arg2, void *arg3)
 				"thread killed", errno);
 			close(common_socket_fd);
 			return;
-		} else if (bytes_read == sizeof(item->data) ||
-			   item->data[bytes_read - 1] != '\0') {
+		} else if (item->data[bytes_read - 1] != '\0') {
 
-			LOG_ERR("AT message to large for reception buffer or "
+			LOG_ERR("AT message too large for reception buffer or "
 				"missing termination character");
 
 			ret.code  = -ENOBUFS;

--- a/lib/at_cmd/at_cmd.c
+++ b/lib/at_cmd/at_cmd.c
@@ -180,7 +180,7 @@ static void socket_thread_fn(void *arg1, void *arg2, void *arg3)
 		if (ret.state != AT_CMD_NOTIFICATION) {
 			if ((response_buf_len > 0) &&
 			    (response_buf != NULL)) {
-				if (response_buf_len > payload_len) {
+				if (response_buf_len >= payload_len) {
 					memcpy(response_buf, item->data,
 					       payload_len);
 				} else {


### PR DESCRIPTION
- fix off-by-one error when copying response
- remove incorrect check when checking the notification length
- print number of bytes received in the response

Please have a look, these can be tricky :)