### PR TITLE
lib: modem_key_mgmt: various fixes

### DIFF
--- a/include/modem/modem_key_mgmt.h
+++ b/include/modem/modem_key_mgmt.h
@@ -71,6 +71,25 @@ int modem_key_mgmt_read(nrf_sec_tag_t sec_tag,
 			enum modem_key_mgnt_cred_type cred_type,
 			void *buf, size_t *len);
 
+/**
+ * @brief Compare a credential with a credential in persistent storage.
+ *
+ * @param[in] sec_tag		The security tag of the credential.
+ * @param[in] cred_type		The credential type.
+ * @param[in] buf		Buffer to compare the credential to.
+ * @param[in] len		Length of the buffer.
+
+ * @retval 0		If the credentials match.
+ * @retval 1		If the credentials do not match.
+ * @retval -ENOBUFS	Internal buffer is too small.
+ * @retval -ENOENT	No credential associated with the given
+ *			@p sec_tag and @p cred_type.
+ * @retval -EPERM	Insufficient permissions.
+ */
+int modem_key_mgmt_cmp(nrf_sec_tag_t sec_tag,
+		       enum modem_key_mgnt_cred_type cred_type,
+		       const void *buf, size_t len);
+
 /**@brief Delete a credential from persistent storage.
  *
  * @note If used when the LTE link is active, the function will return

--- a/include/modem/modem_key_mgmt.h
+++ b/include/modem/modem_key_mgmt.h
@@ -49,7 +49,7 @@ enum modem_key_mgnt_cred_type {
  */
 int modem_key_mgmt_write(nrf_sec_tag_t sec_tag,
 			 enum modem_key_mgnt_cred_type cred_type,
-			 const void *buf, u16_t len);
+			 const void *buf, size_t len);
 
 /**@brief Read a credential from persistent storage.
  *

--- a/include/modem/modem_key_mgmt.h
+++ b/include/modem/modem_key_mgmt.h
@@ -26,17 +26,19 @@ enum modem_key_mgnt_cred_type {
 	MODEM_KEY_MGMT_CRED_TYPE_IDENTITY
 };
 
-/**@brief Write or update a credential in persistent storage.
+/**
+ * @brief Write or update a credential in persistent storage.
  *
- * This function will store the credential and associate it with the given
- * security tag, which can later be used to access it.
+ * Store the credential and associate it with the given security tag,
+ * which can later be used to access it.
  *
  * @note If used when the LTE link is active, the function will return
  *	 an error and the key will not be written.
  *
- * @param[in] sec_tag	Security tag to associate with this credential.
- * @param[in] buf	Buffer containing the credential data.
- * @param[in] len	Length of the buffer.
+ * @param[in] sec_tag		Security tag to associate with this credential.
+ * @param[in] cred_type		The credential type.
+ * @param[in] buf		Buffer containing the credential data.
+ * @param[in] len		Length of the buffer.
  *
  * @retval 0		On success.
  * @retval -EINVAL	Invalid parameters.
@@ -45,27 +47,26 @@ enum modem_key_mgnt_cred_type {
  * @retval -EACCES	Th operation failed because the LTE link is active.
  * @retval -ENOENT	The security tag could not be written.
  * @retval -EPERM	Insufficient permissions.
- * @retval -EIO		Internal error.
  */
 int modem_key_mgmt_write(nrf_sec_tag_t sec_tag,
 			 enum modem_key_mgnt_cred_type cred_type,
 			 const void *buf, size_t len);
 
-/**@brief Read a credential from persistent storage.
+/**
+ * @brief Read a credential from persistent storage.
  *
- * @param[in]		sec_tag		The crediantial security tag.
- * @param[in]		cred_type	Type of credential being read.
+ * @param[in]		sec_tag		The security tag of the credential.
+ * @param[in]		cred_type	The credential type.
  * @param[out]		buf		Buffer to read the credential into.
- * @param[in,out]	len		Length of the buffer.
+ * @param[in,out]	len		Length of the buffer,
+ *					length of the credential.
  *
  * @retval 0		On success.
  * @retval -ENOBUFS	Internal buffer is too small.
  * @retval -ENOMEM	If provided buffer is too small for result data.
- *			The required buffer size is written to @param len.
  * @retval -ENOENT	No credential associated with the given
  *			@p sec_tag and @p cred_type.
  * @retval -EPERM	Insufficient permissions.
- * @retval -EIO		Internal error.
  */
 int modem_key_mgmt_read(nrf_sec_tag_t sec_tag,
 			enum modem_key_mgnt_cred_type cred_type,
@@ -90,13 +91,14 @@ int modem_key_mgmt_cmp(nrf_sec_tag_t sec_tag,
 		       enum modem_key_mgnt_cred_type cred_type,
 		       const void *buf, size_t len);
 
-/**@brief Delete a credential from persistent storage.
+/**
+ * @brief Delete a credential from persistent storage.
  *
  * @note If used when the LTE link is active, the function will return
  *	 an error and the key will not be written.
  *
- * @param[in] sec_tag	The credential security tag.
- * @param[in] cred_type	Type of credential being deleted.
+ * @param[in] sec_tag		The security tag of the credential.
+ * @param[in] cred_type		The credential type.
  *
  * @retval 0		On success.
  * @retval -ENOBUFS	Internal buffer is too small.
@@ -104,14 +106,14 @@ int modem_key_mgmt_cmp(nrf_sec_tag_t sec_tag,
  * @retval -ENOENT	No credential associated with the given
  *			@p sec_tag and @p cred_type.
  * @retval -EPERM	Insufficient permissions.
- * @retval -EIO		Internal error.
  */
 int modem_key_mgmt_delete(nrf_sec_tag_t sec_tag,
 			  enum modem_key_mgnt_cred_type cred_type);
 
-/**@brief Set permissions for a credential in persistent storage.
+/**
+ * @brief Set permissions for a credential in persistent storage.
  *
- * @param[in] sec_tag		The credential security tag.
+ * @param[in] sec_tag		The security tag of the credential.
  * @param[in] cred_type		The credential type.
  * @param[in] perm_flags	Permission flags. Not yet implemented.
  *
@@ -120,26 +122,24 @@ int modem_key_mgmt_delete(nrf_sec_tag_t sec_tag,
  * @retval -ENOENT	No credential associated with the given
  *			@p sec_tag and @p cred_type.
  * @retval -EPERM	Insufficient permissions.
- * @retval -EIO		Internal error.
  */
 int modem_key_mgmt_permission_set(nrf_sec_tag_t sec_tag,
 				  enum modem_key_mgnt_cred_type cred_type,
 				  u8_t perm_flags);
 
-/**@brief Check if a credential exists in persistent storage.
+/**
+ * @brief Check if a credential exists in persistent storage.
  *
- * @param[in]  sec_tag		The security tag to search for.
+ * @param[in] sec_tag		The security tag to search for.
+ * @param[in] cred_type		The credential type.
  * @param[out] exists		Whether the credential exists.
  *				Only valid if the operation is successful.
  * @param[out] perm_flags	The permission flags of the credential.
- *				Only valid if the operation is successful
- *				and @param exists is true.
  *				Not yet implemented.
  *
  * @retval 0		On success.
  * @retval -ENOBUFS	Internal buffer is too small.
  * @retval -EPERM	Insufficient permissions.
- * @retval -EIO		Internal error.
  */
 int modem_key_mgmt_exists(nrf_sec_tag_t sec_tag,
 			  enum modem_key_mgnt_cred_type cred_type,

--- a/include/modem/modem_key_mgmt.h
+++ b/include/modem/modem_key_mgmt.h
@@ -68,8 +68,8 @@ int modem_key_mgmt_write(nrf_sec_tag_t sec_tag,
  * @retval -EIO		Internal error.
  */
 int modem_key_mgmt_read(nrf_sec_tag_t sec_tag,
-			enum modem_key_mgnt_cred_type cred_type, void *buf,
-			u16_t *len);
+			enum modem_key_mgnt_cred_type cred_type,
+			void *buf, size_t *len);
 
 /**@brief Delete a credential from persistent storage.
  *

--- a/lib/modem_key_mgmt/Kconfig
+++ b/lib/modem_key_mgmt/Kconfig
@@ -4,7 +4,16 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
-config MODEM_KEY_MGMT
+menuconfig MODEM_KEY_MGMT
 	bool "nRF9160 modem key management library"
 	depends on AT_CMD_PARSER
 	depends on BSD_LIBRARY
+
+if MODEM_KEY_MGMT
+
+module = MODEM_KEY_MGMT
+module-dep = LOG
+module-str = Modem key management
+source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
+
+endif # MODEM_KEY_MGMT

--- a/lib/modem_key_mgmt/modem_key_mgmt.c
+++ b/lib/modem_key_mgmt/modem_key_mgmt.c
@@ -191,15 +191,15 @@ int modem_key_mgmt_delete(nrf_sec_tag_t sec_tag,
 	int written;
 	enum at_cmd_state state;
 
-	written = snprintf(scratch_buf, sizeof(scratch_buf),
-			   "%s,%u,%u\r\n", MODEM_KEY_MGMT_OP_RM,
-			   (u32_t)sec_tag, (u8_t)cred_type);
+	written = snprintf(scratch_buf, sizeof(scratch_buf), "%s,%d,%d",
+			   MODEM_KEY_MGMT_OP_RM, sec_tag, cred_type);
 
-	if ((written < 0) || (written >= sizeof(scratch_buf))) {
+	if (written < 0 || written >= sizeof(scratch_buf)) {
 		return -ENOBUFS;
 	}
 
 	err = write_at_cmd_with_cme_enabled(scratch_buf, NULL, 0, &state);
+
 	return translate_error(err, state);
 }
 

--- a/lib/modem_key_mgmt/modem_key_mgmt.c
+++ b/lib/modem_key_mgmt/modem_key_mgmt.c
@@ -12,6 +12,7 @@
 #include <modem/at_params.h>
 #include <bsd_limits.h>
 #include <modem/modem_key_mgmt.h>
+#include <logging/log.h>
 
 #define MODEM_KEY_MGMT_OP_LS "AT%CMNG=1"
 #define MODEM_KEY_MGMT_OP_RD "AT%CMNG=2"
@@ -20,6 +21,8 @@
 
 #define AT_CMNG_PARAMS_COUNT 5
 #define AT_CMNG_CONTENT_INDEX 4
+
+LOG_MODULE_REGISTER(modem_key_mgmt, CONFIG_MODEM_KEY_MGMT_LOG_LEVEL);
 
 static char scratch_buf[4096];
 static char at_cmee_strings[2][10] = {"AT+CMEE=0", "AT+CMEE=1"};


### PR DESCRIPTION
- added `modem_key_mgmt_cmp()` to avoid having to keep yet another buffer in the application to read the credential into; this was usually a large buffer 2-4 KB.
- fixed two bugs in `modem_key_mgmt_read()` that prevented it from working
- simplified `modem_key_mgmt_write()`, `modem_key_mgmt_exists()` and `modem_key_mgmt_delete()`
- added a couple of log lines
