### PR TITLE
lib: modem_info: add missing include

### DIFF
--- a/include/modem/modem_info.h
+++ b/include/modem/modem_info.h
@@ -11,6 +11,8 @@
 #include <cJSON.h>
 #endif
 
+#include <modem/at_params.h>
+
 /**
  * @file modem_info.h
  *


### PR DESCRIPTION
Add missing include for return enum at_param_type
on function modem_info_type_get(...)

Signed-off-by: Håkon Alseth <haal@nordicsemi.no>