### PR TITLE
applications: asset_tracker: Use DBG log level for invalid JSON

### DIFF
--- a/applications/asset_tracker/src/cloud_codec/cloud_codec.c
+++ b/applications/asset_tracker/src/cloud_codec/cloud_codec.c
@@ -852,7 +852,7 @@ int cloud_decode_command(char const *input)
 
 	root_obj = cJSON_Parse(input);
 	if (root_obj == NULL) {
-		LOG_ERR("[%s:%d] Unable to parse input", __func__, __LINE__);
+		LOG_DBG("[%s:%d] Unable to parse input", __func__, __LINE__);
 		return -ENOENT;
 	}
 


### PR DESCRIPTION
Change from log level ERR to DBG when the codec can't parse
an input as JSON.
It's expected and allowed that incoming data can be non-JSON,
and the logging should reflect that.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>