### PR TITLE
net: nrf_cloud: Let NRF_CLOUD_AGPS depend on MODEM_INFO

### DIFF
--- a/subsys/net/lib/nrf_cloud/Kconfig
+++ b/subsys/net/lib/nrf_cloud/Kconfig
@@ -70,6 +70,8 @@ menu "nRF Cloud A-GPS"
 config NRF_CLOUD_AGPS
 	bool "Enable nRF Cloud A-GPS"
 	depends on NRF9160_GPS
+	depends on MODEM_INFO
+	depends on MODEM_INFO_ADD_NETWORK
 
 if NRF_CLOUD_AGPS
 config NRF_CLOUD_AGPS_AUTO


### PR DESCRIPTION
The MODE_INFO needs to be enabled, and it has to fetch and
process network information that's used in the nRF Cloud A-GPS
request.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>