### PR TITLE
applications: nrf_desktop: Allow empty BT name scan filter

### DIFF
--- a/applications/nrf_desktop/src/modules/ble_scan.c
+++ b/applications/nrf_desktop/src/modules/ble_scan.c
@@ -211,7 +211,8 @@ static int configure_name_filters(u8_t *filter_mode)
 
 	/* Bluetooth scan filters are defined in separate header. */
 	for (size_t i = 0; i < ARRAY_SIZE(peer_name); i++) {
-		if (!(BIT(i) & (~peers_mask))) {
+		if ((BIT(i) & peers_mask) ||
+		    (peer_name[i] == NULL)) {
 			continue;
 		}
 


### PR DESCRIPTION
Change allows defining empty Bluetooth name scan filters in` ble_scan_def.h`. This could be useful if the dongle is not connecting with given peripheral type.