### PR TITLE
scripts: requirements: Add env marker for editdistance

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,5 +1,5 @@
 ecdsa
-editdistance>=0.5.0
+editdistance>=0.5.0;python_version<'3.8'
 imagesize>=1.2.0
 intelhex
 pygit2>=0.26.0


### PR DESCRIPTION
Editdistance has not been ported to Python 3.8. Add an environment
marker so that it is ignored if running Python 3.8.

https://github.com/aflc/editdistance/issues/41
https://www.python.org/dev/peps/pep-0508/#environment-markers

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>