### PR TITLE
samples: serial_lte_modem add TCP/IP proxy service

### DIFF
--- a/samples/nrf9160/serial_lte_modem/CMakeLists.txt
+++ b/samples/nrf9160/serial_lte_modem/CMakeLists.txt
@@ -27,4 +27,6 @@ target_sources(app PRIVATE src/slm_at_tcpip.c)
 target_sources(app PRIVATE src/slm_at_icmp.c)
 target_sources(app PRIVATE src/slm_at_gps.c)
 
+add_subdirectory(src/tcpip_proxy)
+
 zephyr_include_directories(src)

--- a/samples/nrf9160/serial_lte_modem/Kconfig
+++ b/samples/nrf9160/serial_lte_modem/Kconfig
@@ -16,11 +16,6 @@ config SLM_AT_MODE
 	select AT_CMD_PARSER
 	select MODEM_INFO
 
-config SLM_TEST_MODE
-	bool "SLM test mode"
-	help
-	  Enable test logic in source
-
 config SLM_AT_MAX_PARAM
 	int "Max number of parameters in AT command"
 	default 8
@@ -84,6 +79,8 @@ config SLM_INTERFACE_PIN
 	int "Interface GPIO to wake up or exit idle"
 	default 6 if SLM_CONNECT_UART_0
 	default 31 if SLM_CONNECT_UART_2
+
+rsource "src/tcpip_proxy/Kconfig"
 
 module = SLM
 module-str = serial modem

--- a/samples/nrf9160/serial_lte_modem/README.rst
+++ b/samples/nrf9160/serial_lte_modem/README.rst
@@ -109,12 +109,23 @@ The following proprietary BSD socket AT commands are used in this sample:
 * AT#XLISTEN
 * AT#XACCEPT
 * AT#XCONNECT=<url>,<port>
-* AT#XSEND=<data>
+* AT#XSEND=<datatype>,<data>
 * AT#XRECV[=<length>]
-* AT#XSENDTO=<url>,<port>,<data>
+* AT#XSENDTO=<url>,<port>,<datatype>,<data>
 * AT#XRECVFROM=<url>,<port>[,<length>]
 * AT#XGETADDRINFO=<url>
-* AT#XDATATYPE=<type>
+
+If the configuration option ``CONFIG_SLM_TCP_PROXY`` is defined, the following AT commands are available to use the TCP proxy service:
+
+* AT#XTCPSVR=<op>[,<port>[,[sec_tag]]
+* AT#XTCPCLI=<op>[,<url>,<port>[,[sec_tag]]
+* AT#XTCPSEND=<datatype>,<data>
+
+If the configuration option ``CONFIG_SLM_UDP_PROXY`` is defined, the following AT commands are available to use the UDP proxy service:
+
+* AT#XUDPSVR=<op>[,<port>[,[sec_tag]]
+* AT#XUDPCLI=<op>[,<url>,<port>[,[sec_tag]]
+* AT#XUDPSEND=<datatype>,<data>
 
 ICMP AT commands
 ****************

--- a/samples/nrf9160/serial_lte_modem/src/slm_util.c
+++ b/samples/nrf9160/serial_lte_modem/src/slm_util.c
@@ -124,3 +124,22 @@ int slm_util_atoh(const char *ascii, u16_t ascii_len,
 
 	return (ascii_len / 2);
 }
+
+/**@brief Check whether a string has valid IPv4 address or not
+ */
+bool check_for_ipv4(const char *address, u8_t length)
+{
+	int index;
+
+	for (index = 0; index < length; index++) {
+		char ch = *(address + index);
+
+		if ((ch == '.') || (ch >= '0' && ch <= '9')) {
+			continue;
+		} else {
+			return false;
+		}
+	}
+
+	return true;
+}

--- a/samples/nrf9160/serial_lte_modem/src/slm_util.h
+++ b/samples/nrf9160/serial_lte_modem/src/slm_util.h
@@ -17,6 +17,13 @@
 #include <ctype.h>
 #include <stdbool.h>
 
+#define INVALID_SOCKET	-1
+#define INVALID_PORT	-1
+#define INVALID_SEC_TAG	-1
+#define INVALID_ROLE	-1
+
+#define TCPIP_MAX_URL	128
+
 /**
  * @brief Compare string ignoring case
  *
@@ -74,6 +81,16 @@ int slm_util_htoa(const u8_t *hex, u16_t hex_len,
  */
 int slm_util_atoh(const char *ascii, u16_t ascii_len,
 		u8_t *hex, u16_t hex_len);
+
+
+/**@brief Check whether a string has valid IPv4 address or not
+ *
+ * @param address URL text string
+ * @param length size of URL string
+ *
+ * @return true if text string is IPv4 address, false otherwise
+ */
+bool check_for_ipv4(const char *address, u8_t length);
 
 /** @} */
 

--- a/samples/nrf9160/serial_lte_modem/src/tcpip_proxy/CMakeLists.txt
+++ b/samples/nrf9160/serial_lte_modem/src/tcpip_proxy/CMakeLists.txt
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+zephyr_include_directories(.)
+target_sources_ifdef(CONFIG_SLM_TCP_PROXY app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/slm_at_tcp_proxy.c)
+target_sources_ifdef(CONFIG_SLM_UDP_PROXY app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/slm_at_udp_proxy.c)

--- a/samples/nrf9160/serial_lte_modem/src/tcpip_proxy/Kconfig
+++ b/samples/nrf9160/serial_lte_modem/src/tcpip_proxy/Kconfig
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+config SLM_TCP_PROXY
+	bool "Stateful connection-oriented TCP client/server"
+
+config SLM_TCP_POLL_TIME
+	int "Poll timeout in seconds for TCP connection"
+	default 10
+
+config SLM_TCP_CONN_TIME
+	int "Connection timeout in seconds for TCP server"
+	default 60
+
+config SLM_UDP_PROXY
+	bool "Stateful connection-oriented UDP client/server"

--- a/samples/nrf9160/serial_lte_modem/src/tcpip_proxy/slm_at_tcp_proxy.c
+++ b/samples/nrf9160/serial_lte_modem/src/tcpip_proxy/slm_at_tcp_proxy.c
@@ -1,0 +1,671 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+#include <logging/log.h>
+#include <zephyr.h>
+#include <stdio.h>
+#include <string.h>
+#include <net/socket.h>
+#include <modem/modem_info.h>
+#include <net/tls_credentials.h>
+#include "slm_util.h"
+#include "slm_at_host.h"
+#include "slm_at_tcp_proxy.h"
+
+LOG_MODULE_REGISTER(tcp_proxy, CONFIG_SLM_LOG_LEVEL);
+
+#define THREAD_STACK_SIZE	(KB(1) + NET_IPV4_MTU)
+#define THREAD_PRIORITY		K_LOWEST_APPLICATION_THREAD_PRIO
+
+/**@brief Proxy operations. */
+enum slm_tcp_proxy_operation {
+	AT_SERVER_STOP,
+	AT_CLIENT_DISCONNECT = AT_SERVER_STOP,
+	AT_SERVER_START,
+	AT_CLIENT_CONNECT = AT_SERVER_START
+};
+
+/**@brief Proxy roles. */
+enum slm_tcp_proxy_role {
+	AT_TCP_ROLE_CLIENT,
+	AT_TCP_ROLE_SERVER
+};
+
+/**@brief List of supported AT commands. */
+enum slm_tcp_proxy_at_cmd_type {
+	AT_TCP_SERVER,
+	AT_TCP_CLIENT,
+	AT_TCP_SEND,
+	AT_TCP_PROXY_MAX
+};
+
+/** forward declaration of cmd handlers **/
+static int handle_at_tcp_server(enum at_cmd_type cmd_type);
+static int handle_at_tcp_client(enum at_cmd_type cmd_type);
+static int handle_at_tcp_send(enum at_cmd_type cmd_type);
+
+/**@brief SLM AT Command list type. */
+static slm_at_cmd_list_t m_tcp_proxy_at_list[AT_TCP_PROXY_MAX] = {
+	{AT_TCP_SERVER, "AT#XTCPSVR", handle_at_tcp_server},
+	{AT_TCP_CLIENT, "AT#XTCPCLI", handle_at_tcp_client},
+	{AT_TCP_SEND, "AT#XTCPSEND", handle_at_tcp_send},
+};
+
+static struct k_thread tcp_thread;
+static K_THREAD_STACK_DEFINE(tcp_thread_stack, THREAD_STACK_SIZE);
+static k_tid_t tcp_thread_id;
+K_TIMER_DEFINE(conn_timer, NULL, NULL);
+
+static struct sockaddr_in remote;
+static struct tcp_proxy_t {
+	int sock; /* Socket descriptor. */
+	int sock_peer; /* Socket descriptor for peer. */
+	int role; /* Client or Server proxy */
+} proxy;
+
+/* global functions defined in different files */
+void rsp_send(const u8_t *str, size_t len);
+
+/* global variable defined in different files */
+extern struct at_param_list at_param_list;
+extern struct modem_param_info modem_param;
+extern char rsp_buf[CONFIG_AT_CMD_RESPONSE_MAX_LEN];
+
+/** forward declaration of thread function **/
+static void tcp_thread_func(void *p1, void *p2, void *p3);
+
+static int do_tcp_server_start(u16_t port, int sec_tag)
+{
+	int ret = 0;
+	struct sockaddr_in local;
+	int addr_len;
+
+	/* Open socket */
+	if (sec_tag == INVALID_SEC_TAG) {
+		proxy.sock = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+	} else {
+		sprintf(rsp_buf,
+			"#XTCPSVR: TLS Server not supported\r\n");
+		rsp_send(rsp_buf, strlen(rsp_buf));
+		return -ENOTSUP;
+	}
+	if (proxy.sock < 0) {
+		LOG_ERR("socket() failed: %d", -errno);
+		sprintf(rsp_buf, "#XTCPSVR: %d\r\n", -errno);
+		rsp_send(rsp_buf, strlen(rsp_buf));
+		return -errno;
+	}
+
+	/* Bind to local port */
+	local.sin_family = AF_INET;
+	local.sin_port = htons(port);
+	ret = modem_info_params_get(&modem_param);
+	if (ret) {
+		LOG_ERR("Unable to obtain modem parameters (%d)", ret);
+		close(proxy.sock);
+		return ret;
+	}
+	addr_len = strlen(modem_param.network.ip_address.value_string);
+	if (addr_len == 0) {
+		LOG_ERR("LTE not connected yet");
+		close(proxy.sock);
+		return -EINVAL;
+	}
+	if (!check_for_ipv4(modem_param.network.ip_address.value_string,
+			addr_len)) {
+		LOG_ERR("Invalid local address");
+		close(proxy.sock);
+		return -EINVAL;
+	}
+	if (inet_pton(AF_INET, modem_param.network.ip_address.value_string,
+		&local.sin_addr) != 1) {
+		LOG_ERR("Parse local IP address failed: %d", -errno);
+		close(proxy.sock);
+		return -EINVAL;
+	}
+
+	ret = bind(proxy.sock, (struct sockaddr *)&local,
+		 sizeof(struct sockaddr_in));
+	if (ret) {
+		LOG_ERR("bind() failed: %d", -errno);
+		sprintf(rsp_buf, "#XTCPSVR: %d\r\n", -errno);
+		rsp_send(rsp_buf, strlen(rsp_buf));
+		close(proxy.sock);
+		return -errno;
+	}
+
+	/* Enable listen */
+	ret = listen(proxy.sock, 1);
+	if (ret < 0) {
+		LOG_ERR("listen() failed: %d", -errno);
+		sprintf(rsp_buf, "#XTCPSVR: %d\r\n", -errno);
+		rsp_send(rsp_buf, strlen(rsp_buf));
+		close(proxy.sock);
+		return -errno;
+	}
+
+	tcp_thread_id = k_thread_create(&tcp_thread, tcp_thread_stack,
+			K_THREAD_STACK_SIZEOF(tcp_thread_stack),
+			tcp_thread_func, NULL, NULL, NULL,
+			THREAD_PRIORITY, K_USER, K_NO_WAIT);
+
+	proxy.role = AT_TCP_ROLE_SERVER;
+	sprintf(rsp_buf, "#XTCPSVR: %d started\r\n", proxy.sock);
+	rsp_send(rsp_buf, strlen(rsp_buf));
+
+	return ret;
+}
+
+static int do_tcp_server_stop(int error)
+{
+	int ret = 0;
+
+	if (proxy.sock > 0) {
+		k_timer_stop(&conn_timer);
+		k_thread_abort(tcp_thread_id);
+		if (proxy.sock_peer != INVALID_SOCKET) {
+			close(proxy.sock_peer);
+		}
+		ret = close(proxy.sock);
+		if (ret < 0) {
+			LOG_WRN("close() failed: %d", -errno);
+			ret = -errno;
+		}
+		proxy.sock = INVALID_SOCKET;
+		proxy.sock_peer = INVALID_SOCKET;
+		proxy.role = INVALID_ROLE;
+		if (error) {
+			sprintf(rsp_buf, "#XTCPSVR: %d stopped\r\n", error);
+			rsp_send(rsp_buf, strlen(rsp_buf));
+		}
+	}
+
+	return ret;
+}
+
+static int do_tcp_client_connect(const char *url, u16_t port, int sec_tag)
+{
+	int ret;
+
+	/* Open socket */
+	if (sec_tag == INVALID_SEC_TAG) {
+		proxy.sock = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+	} else {
+		proxy.sock = socket(AF_INET, SOCK_STREAM, IPPROTO_TLS_1_2);
+
+	}
+	if (proxy.sock < 0) {
+		LOG_ERR("socket() failed: %d", -errno);
+		sprintf(rsp_buf, "#XTCPCLI: %d\r\n", -errno);
+		rsp_send(rsp_buf, strlen(rsp_buf));
+		return -errno;
+	}
+	if (sec_tag != INVALID_SEC_TAG) {
+		sec_tag_t sec_tag_list[1] = { sec_tag };
+
+		ret = setsockopt(proxy.sock, SOL_TLS, TLS_SEC_TAG_LIST,
+				sec_tag_list, sizeof(sec_tag_t));
+		if (ret) {
+			LOG_ERR("set tag list failed: %d", -errno);
+			sprintf(rsp_buf, "#XTCPCLI: %d\r\n", -errno);
+			rsp_send(rsp_buf, strlen(rsp_buf));
+			close(proxy.sock);
+			return -errno;
+		}
+	}
+
+	/* Connect to remote host */
+	if (check_for_ipv4(url, strlen(url))) {
+		remote.sin_family = AF_INET;
+		remote.sin_port = htons(port);
+		LOG_DBG("IPv4 Address %s", log_strdup(url));
+		/* NOTE inet_pton() returns 1 as success */
+		ret = inet_pton(AF_INET, url, &remote.sin_addr);
+		if (ret != 1) {
+			LOG_ERR("inet_pton() failed: %d", ret);
+			close(proxy.sock);
+			return -EINVAL;
+		}
+	} else {
+		struct addrinfo *result;
+		struct addrinfo hints = {
+			.ai_family = AF_INET,
+			.ai_socktype = SOCK_STREAM
+		};
+
+		ret = getaddrinfo(url, NULL, &hints, &result);
+		if (ret || result == NULL) {
+			LOG_ERR("getaddrinfo() failed: %d", ret);
+			close(proxy.sock);
+			return -EINVAL;
+		}
+
+		remote.sin_family = AF_INET;
+		remote.sin_port = htons(port);
+		remote.sin_addr.s_addr =
+		((struct sockaddr_in *)result->ai_addr)->sin_addr.s_addr;
+		/* Free the address. */
+		freeaddrinfo(result);
+	}
+
+	ret = connect(proxy.sock, (struct sockaddr *)&remote,
+		sizeof(struct sockaddr_in));
+	if (ret < 0) {
+		LOG_ERR("connect() failed: %d", -errno);
+		sprintf(rsp_buf, "#XTCPCLI: %d\r\n", -errno);
+		rsp_send(rsp_buf, strlen(rsp_buf));
+		close(proxy.sock);
+		return -errno;
+	}
+
+	tcp_thread_id = k_thread_create(&tcp_thread, tcp_thread_stack,
+			K_THREAD_STACK_SIZEOF(tcp_thread_stack),
+			tcp_thread_func, NULL, NULL, NULL,
+			THREAD_PRIORITY, K_USER, K_NO_WAIT);
+
+	proxy.role = AT_TCP_ROLE_CLIENT;
+	sprintf(rsp_buf, "#XTCPCLI: %d connected\r\n", proxy.sock);
+	rsp_send(rsp_buf, strlen(rsp_buf));
+
+	return ret;
+}
+
+static int do_tcp_client_disconnect(int error)
+{
+	int ret = 0;
+
+	if (proxy.sock > 0) {
+		k_thread_abort(tcp_thread_id);
+		ret = close(proxy.sock);
+		if (ret < 0) {
+			LOG_WRN("close() failed: %d", -errno);
+			ret = -errno;
+		}
+		proxy.sock = INVALID_SOCKET;
+		proxy.role = INVALID_ROLE;
+
+		if (error) {
+			sprintf(rsp_buf, "#XTCPCLI: %d disconnected\r\n",
+				error);
+			rsp_send(rsp_buf, strlen(rsp_buf));
+		}
+	}
+
+	return ret;
+}
+
+static int do_tcp_send(const u8_t *data, int datalen)
+{
+	int ret = 0;
+	u32_t offset = 0;
+	int sock;
+
+	if (proxy.role == AT_TCP_ROLE_CLIENT &&
+		proxy.sock != INVALID_SOCKET) {
+		sock = proxy.sock;
+	} else if (proxy.role == AT_TCP_ROLE_SERVER &&
+		proxy.sock_peer != INVALID_SOCKET) {
+		sock = proxy.sock_peer;
+	} else {
+		LOG_ERR("Not connected yet");
+		return -EINVAL;
+	}
+
+	while (offset < datalen) {
+		ret = send(sock, data + offset, datalen - offset, 0);
+		if (ret < 0) {
+			LOG_ERR("send() failed: %d", -errno);
+			if (errno != EAGAIN && errno != ETIMEDOUT) {
+				if (proxy.role == AT_TCP_ROLE_CLIENT) {
+					do_tcp_client_disconnect(-errno);
+				} else {
+					do_tcp_server_stop(-errno);
+				}
+			} else {
+				sprintf(rsp_buf, "#XTCPSEND: %d\r\n", -errno);
+				rsp_send(rsp_buf, strlen(rsp_buf));
+			}
+			ret = -errno;
+			break;
+		}
+		offset += ret;
+	}
+
+	sprintf(rsp_buf, "#XTCPSEND: %d\r\n", offset);
+	rsp_send(rsp_buf, strlen(rsp_buf));
+	if (ret >= 0) {
+		return 0;
+	} else {
+		return ret;
+	}
+}
+
+static void tcp_thread_func(void *p1, void *p2, void *p3)
+{
+	int ret;
+	struct pollfd fds;
+	int sock;
+
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+thread_entry:
+	if (proxy.role == AT_TCP_ROLE_SERVER) {
+		socklen_t len = sizeof(struct sockaddr_in);
+		char peer_addr[INET_ADDRSTRLEN];
+
+		/* Accept incoming connection */;
+		LOG_DBG("Accept connection...");
+		proxy.sock_peer = INVALID_SOCKET;
+		ret = accept(proxy.sock, (struct sockaddr *)&remote, &len);
+		if (ret < 0) {
+			LOG_ERR("accept() failed: %d", -errno);
+			do_tcp_server_stop(-errno);
+			return;
+		}
+		if (inet_ntop(AF_INET, &remote.sin_addr, peer_addr,
+			INET_ADDRSTRLEN) != NULL) {
+			sprintf(rsp_buf, "#XTCPSVR: %s connected\r\n",
+				peer_addr);
+			rsp_send(rsp_buf, strlen(rsp_buf));
+		}
+		proxy.sock_peer = ret;
+		/* Start a one-shot timer to close the connection */
+		k_timer_start(&conn_timer, K_SECONDS(CONFIG_SLM_TCP_CONN_TIME),
+			0);
+	}
+
+	if (proxy.role == AT_TCP_ROLE_SERVER) {
+		sock = proxy.sock_peer;
+	} else {
+		sock = proxy.sock;
+	}
+	fds.fd = sock;
+	fds.events = POLLIN;
+	while (true) {
+		if (proxy.role == AT_TCP_ROLE_SERVER &&
+			k_timer_status_get(&conn_timer) > 0) {
+			k_timer_stop(&conn_timer);
+			LOG_INF("Connecion timeout");
+			close(proxy.sock_peer);
+			goto thread_entry;
+		}
+		ret = poll(&fds, 1, MSEC_PER_SEC * CONFIG_SLM_TCP_POLL_TIME);
+		if (ret < 0) {  /* IO error */
+			LOG_WRN("poll() error: %d", ret);
+			continue;
+		}
+		if (ret == 0) {  /* timeout */
+			continue;
+		}
+		LOG_DBG("Poll events 0x%08x", fds.revents);
+		if ((fds.revents & POLLIN) == POLLIN) {
+			char data[NET_IPV4_MTU];
+
+			ret = recv(sock, data, NET_IPV4_MTU, 0);
+			if (ret < 0) {
+				LOG_WRN("recv() error: %d", -errno);
+				continue;
+			}
+			if (ret == 0) {
+				continue;
+			}
+			if (slm_util_hex_check(data, ret)) {
+				char *data_hex = k_malloc(ret * 2);
+				int size = ret * 2;
+
+				if (data_hex == NULL) {
+					LOG_WRN("No memory");
+					continue;
+				}
+				ret = slm_util_htoa(data, ret, data_hex, size);
+				if (ret > 0) {
+					sprintf(rsp_buf,
+						"#XTCPRECV: %d, %d\r\n",
+						DATATYPE_HEXADECIMAL, ret);
+					rsp_send(rsp_buf, strlen(rsp_buf));
+					rsp_send(data_hex, ret);
+					rsp_send("\r\n", 2);
+				}
+				k_free(data_hex);
+			} else {
+				sprintf(rsp_buf, "#XTCPRECV: %d, %d\r\n",
+					DATATYPE_PLAINTEXT, ret);
+				rsp_send(rsp_buf, strlen(rsp_buf));
+				rsp_send(data, ret);
+				rsp_send("\r\n", 2);
+			}
+		}
+	}
+}
+
+/**@brief handle AT#XTCPSVR commands
+ *  AT#XTCPSVR=<op>[,<port>[,[sec_tag]]
+ *  AT#XTCPSVR? READ command not supported
+ *  AT#XTCPSVR=?
+ */
+static int handle_at_tcp_server(enum at_cmd_type cmd_type)
+{
+	int err = -EINVAL;
+	u16_t op;
+	int param_count = at_params_valid_count_get(&at_param_list);
+
+	switch (cmd_type) {
+	case AT_CMD_TYPE_SET_COMMAND:
+		if (param_count < 2) {
+			return -EINVAL;
+		}
+		err = at_params_short_get(&at_param_list, 1, &op);
+		if (err) {
+			return err;
+		}
+		if (op == AT_SERVER_START) {
+			u16_t port;
+			sec_tag_t sec_tag = INVALID_SEC_TAG;
+
+			if (param_count < 3) {
+				return -EINVAL;
+			}
+			err = at_params_short_get(&at_param_list, 2, &port);
+			if (err) {
+				return err;
+			}
+			if (param_count > 3) {
+				at_params_int_get(&at_param_list, 3, &sec_tag);
+			}
+			err = do_tcp_server_start(port, sec_tag);
+		} else if (op == AT_SERVER_STOP) {
+			if (proxy.sock < 0) {
+				LOG_WRN("Server is not running");
+				return -EINVAL;
+			}
+			err = do_tcp_server_stop(0);
+		} break;
+
+	case AT_CMD_TYPE_TEST_COMMAND:
+		sprintf(rsp_buf, "#XTCPSVR: (%d, %d),<port>,<sec_tag>\r\n",
+			AT_SERVER_STOP, AT_SERVER_START);
+		rsp_send(rsp_buf, strlen(rsp_buf));
+		err = 0;
+		break;
+
+	default:
+		break;
+	}
+
+	return err;
+}
+
+/**@brief handle AT#XTCPCLI commands
+ *  AT#XTCPCLI=<op>[,<url>,<port>[,[sec_tag]]
+ *  AT#XTCPCLI? READ command not supported
+ *  AT#XTCPCLI=?
+ */
+static int handle_at_tcp_client(enum at_cmd_type cmd_type)
+{
+	int err = -EINVAL;
+	u16_t op;
+	int param_count = at_params_valid_count_get(&at_param_list);
+
+	switch (cmd_type) {
+	case AT_CMD_TYPE_SET_COMMAND:
+		if (param_count < 2) {
+			return -EINVAL;
+		}
+		err = at_params_short_get(&at_param_list, 1, &op);
+		if (err) {
+			return err;
+		}
+		if (op == AT_CLIENT_CONNECT) {
+			u16_t port;
+			char url[TCPIP_MAX_URL];
+			int size = TCPIP_MAX_URL;
+			sec_tag_t sec_tag = INVALID_SEC_TAG;
+
+			if (param_count < 4) {
+				return -EINVAL;
+			}
+			err = at_params_string_get(&at_param_list,
+						2, url, &size);
+			if (err) {
+				return err;
+			}
+			url[size] = '\0';
+			err = at_params_short_get(&at_param_list, 3, &port);
+			if (err) {
+				return err;
+			}
+			if (param_count > 4) {
+				at_params_int_get(&at_param_list, 4, &sec_tag);
+			}
+			err = do_tcp_client_connect(url, port, sec_tag);
+		} else if (op == AT_CLIENT_DISCONNECT) {
+			if (proxy.sock < 0) {
+				LOG_WRN("Client is not connected");
+				return -EINVAL;
+			}
+			err = do_tcp_client_disconnect(0);
+		} break;
+
+	case AT_CMD_TYPE_TEST_COMMAND:
+		sprintf(rsp_buf,
+			"#XTCPCLI: (%d, %d),<url>,<port>,<sec_tag>\r\n",
+			AT_CLIENT_DISCONNECT, AT_CLIENT_CONNECT);
+		rsp_send(rsp_buf, strlen(rsp_buf));
+		err = 0;
+		break;
+
+	default:
+		break;
+	}
+
+	return err;
+}
+
+/**@brief handle AT#XTCPSEND commands
+ *  AT#XTCPSEND=<datatype>,<data>
+ *  AT#XTCPSEND? READ command not supported
+ *  AT#XTCPSEND=? TEST command not supported
+ */
+static int handle_at_tcp_send(enum at_cmd_type cmd_type)
+{
+	int err = -EINVAL;
+	u16_t datatype;
+	char data[NET_IPV4_MTU];
+	int size = NET_IPV4_MTU;
+
+	switch (cmd_type) {
+	case AT_CMD_TYPE_SET_COMMAND:
+		if (at_params_valid_count_get(&at_param_list) < 3) {
+			return -EINVAL;
+		}
+		err = at_params_short_get(&at_param_list, 1, &datatype);
+		if (err) {
+			return err;
+		}
+		err = at_params_string_get(&at_param_list, 2, data, &size);
+		if (err) {
+			return err;
+		}
+		if (datatype == DATATYPE_HEXADECIMAL) {
+			u8_t *data_hex = k_malloc(size / 2);
+
+			err = slm_util_atoh(data, size, data_hex, size / 2);
+			if (err > 0) {
+				err = do_tcp_send(data_hex, err);
+			}
+			k_free(data_hex);
+		} else {
+			err = do_tcp_send(data, size);
+		}
+		break;
+
+	default:
+		break;
+	}
+
+	return err;
+}
+
+/**@brief API to handle TCP proxy AT commands
+ */
+int slm_at_tcp_proxy_parse(const char *at_cmd)
+{
+	int ret = -ENOTSUP;
+	enum at_cmd_type type;
+
+	for (int i = 0; i < AT_TCP_PROXY_MAX; i++) {
+		if (slm_util_cmd_casecmp(at_cmd,
+			m_tcp_proxy_at_list[i].string)) {
+			ret = at_parser_params_from_str(at_cmd, NULL,
+						&at_param_list);
+			if (ret) {
+				LOG_ERR("Failed to parse AT command %d", ret);
+				return -EINVAL;
+			}
+			type = at_parser_cmd_type_get(at_cmd);
+			ret = m_tcp_proxy_at_list[i].handler(type);
+			break;
+		}
+	}
+
+	return ret;
+}
+
+/**@brief API to list TCP proxy AT commands
+ */
+void slm_at_tcp_proxy_clac(void)
+{
+	for (int i = 0; i < AT_TCP_PROXY_MAX; i++) {
+		sprintf(rsp_buf, "%s\r\n", m_tcp_proxy_at_list[i].string);
+		rsp_send(rsp_buf, strlen(rsp_buf));
+	}
+}
+
+/**@brief API to initialize TCP proxy AT commands handler
+ */
+int slm_at_tcp_proxy_init(void)
+{
+	proxy.sock = INVALID_SOCKET;
+	proxy.sock_peer = INVALID_SOCKET;
+	proxy.role = INVALID_ROLE;
+
+	return 0;
+}
+
+/**@brief API to uninitialize TCP proxy AT commands handler
+ */
+int slm_at_tcp_proxy_uninit(void)
+{
+	if (proxy.role == AT_TCP_ROLE_CLIENT) {
+		return do_tcp_client_disconnect(0);
+	}
+	if (proxy.role == AT_TCP_ROLE_SERVER) {
+		return do_tcp_server_stop(0);
+	}
+
+	return 0;
+}

--- a/samples/nrf9160/serial_lte_modem/src/tcpip_proxy/slm_at_tcp_proxy.h
+++ b/samples/nrf9160/serial_lte_modem/src/tcpip_proxy/slm_at_tcp_proxy.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#ifndef SLM_AT_TCP_PROXY_
+#define SLM_AT_TCP_PROXY_
+
+/**@file slm_at_tcp_proxy.h
+ *
+ * @brief Vendor-specific AT command for TCP proxy service.
+ * @{
+ */
+
+#include <zephyr/types.h>
+#include <modem/at_cmd.h>
+
+/**
+ * @brief TCP proxy AT command parser.
+ *
+ * @param at_cmd AT command string.
+ *
+ * @retval 0 If the operation was successful.
+ *           Otherwise, a (negative) error code is returned.
+ */
+int slm_at_tcp_proxy_parse(const char *at_cmd);
+
+/**
+ * @brief List TCP proxy AT commands.
+ *
+ */
+void slm_at_tcp_proxy_clac(void);
+
+/**
+ * @brief Initialize TCP proxy AT command parser.
+ *
+ * @retval 0 If the operation was successful.
+ *           Otherwise, a (negative) error code is returned.
+ */
+int slm_at_tcp_proxy_init(void);
+
+/**
+ * @brief Uninitialize TCP proxy AT command parser.
+ *
+ * @retval 0 If the operation was successful.
+ *           Otherwise, a (negative) error code is returned.
+ */
+int slm_at_tcp_proxy_uninit(void);
+/** @} */
+
+#endif /* SLM_AT_TCP_PROXY_ */

--- a/samples/nrf9160/serial_lte_modem/src/tcpip_proxy/slm_at_udp_proxy.c
+++ b/samples/nrf9160/serial_lte_modem/src/tcpip_proxy/slm_at_udp_proxy.c
@@ -1,0 +1,607 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+#include <logging/log.h>
+#include <zephyr.h>
+#include <stdio.h>
+#include <string.h>
+#include <net/socket.h>
+#include <modem/modem_info.h>
+#include <net/tls_credentials.h>
+#include "slm_util.h"
+#include "slm_at_host.h"
+#include "slm_at_udp_proxy.h"
+
+LOG_MODULE_REGISTER(udp_proxy, CONFIG_SLM_LOG_LEVEL);
+
+#define THREAD_STACK_SIZE	(KB(1) + NET_IPV4_MTU)
+#define THREAD_PRIORITY		K_LOWEST_APPLICATION_THREAD_PRIO
+
+/*
+ * Known limitation in this version
+ * - Multiple concurrent
+ * - Receive more than IPv4 MTU one-time
+ * - IPv6 support
+ * - does not support proxy
+ */
+
+/**@brief Proxy operations. */
+enum slm_udp_proxy_operation {
+	AT_SERVER_STOP,
+	AT_CLIENT_DISCONNECT = AT_SERVER_STOP,
+	AT_SERVER_START,
+	AT_CLIENT_CONNECT = AT_SERVER_START
+};
+
+/**@brief Proxy roles. */
+enum slm_udp_proxy_role {
+	AT_UDP_ROLE_CLIENT,
+	AT_UDP_ROLE_SERVER
+};
+
+/**@brief List of supported AT commands. */
+enum slm_udp_proxy_at_cmd_type {
+	AT_UDP_SERVER,
+	AT_UDP_CLIENT,
+	AT_UDP_SEND,
+	AT_UDP_PROXY_MAX
+};
+
+/** forward declaration of cmd handlers **/
+static int handle_at_udp_server(enum at_cmd_type cmd_type);
+static int handle_at_udp_client(enum at_cmd_type cmd_type);
+static int handle_at_udp_send(enum at_cmd_type cmd_type);
+
+/**@brief SLM AT Command list type. */
+static slm_at_cmd_list_t m_udp_proxy_at_list[AT_UDP_PROXY_MAX] = {
+	{AT_UDP_SERVER, "AT#XUDPSVR", handle_at_udp_server},
+	{AT_UDP_CLIENT, "AT#XUDPCLI", handle_at_udp_client},
+	{AT_UDP_SEND, "AT#XUDPSEND", handle_at_udp_send},
+};
+
+static struct k_thread udp_thread;
+static K_THREAD_STACK_DEFINE(udp_thread_stack, THREAD_STACK_SIZE);
+static k_tid_t udp_thread_id;
+
+static struct sockaddr_in remote;
+static int udp_sock;
+
+/* global functions defined in different files */
+void rsp_send(const u8_t *str, size_t len);
+
+/* global variable defined in different files */
+extern struct at_param_list at_param_list;
+extern struct modem_param_info modem_param;
+extern char rsp_buf[CONFIG_AT_CMD_RESPONSE_MAX_LEN];
+
+/** forward declaration of thread function **/
+static void udp_thread_func(void *p1, void *p2, void *p3);
+
+static int do_udp_server_start(u16_t port, int sec_tag)
+{
+	int ret = 0;
+	struct sockaddr_in local;
+	int addr_len;
+
+	/* Open socket */
+	if (sec_tag == INVALID_SEC_TAG) {
+		udp_sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+	} else {
+		sprintf(rsp_buf,
+			"#XUDPSVR: DTLS Server not supported\r\n");
+		rsp_send(rsp_buf, strlen(rsp_buf));
+		return -ENOTSUP;
+	}
+	if (udp_sock < 0) {
+		LOG_ERR("socket() failed: %d", -errno);
+		sprintf(rsp_buf, "#XUDPSVR: %d\r\n", -errno);
+		rsp_send(rsp_buf, strlen(rsp_buf));
+		return -errno;
+	}
+
+	/* Bind to local port */
+	local.sin_family = AF_INET;
+	local.sin_port = htons(port);
+	ret = modem_info_params_get(&modem_param);
+	if (ret) {
+		LOG_ERR("Unable to obtain modem parameters (%d)", ret);
+		close(udp_sock);
+		return ret;
+	}
+	addr_len = strlen(modem_param.network.ip_address.value_string);
+	if (addr_len == 0) {
+		LOG_ERR("LTE not connected yet");
+		close(udp_sock);
+		return -EINVAL;
+	}
+	if (!check_for_ipv4(modem_param.network.ip_address.value_string,
+			addr_len)) {
+		LOG_ERR("Invalid local address");
+		close(udp_sock);
+		return -EINVAL;
+	}
+	if (inet_pton(AF_INET, modem_param.network.ip_address.value_string,
+		&local.sin_addr) != 1) {
+		LOG_ERR("Parse local IP address failed: %d", -errno);
+		close(udp_sock);
+		return -EINVAL;
+	}
+
+	ret = bind(udp_sock, (struct sockaddr *)&local,
+		 sizeof(struct sockaddr_in));
+	if (ret) {
+		LOG_ERR("bind() failed: %d", -errno);
+		sprintf(rsp_buf, "#XUDPSVR: %d\r\n", -errno);
+		rsp_send(rsp_buf, strlen(rsp_buf));
+		close(udp_sock);
+		return -errno;
+	}
+
+	udp_thread_id = k_thread_create(&udp_thread, udp_thread_stack,
+			K_THREAD_STACK_SIZEOF(udp_thread_stack),
+			udp_thread_func, NULL, NULL, NULL,
+			THREAD_PRIORITY, K_USER, K_NO_WAIT);
+
+	sprintf(rsp_buf, "#XUDPSVR: %d started\r\n", udp_sock);
+	rsp_send(rsp_buf, strlen(rsp_buf));
+	LOG_DBG("UDP server started");
+
+	return ret;
+}
+
+static int do_udp_server_stop(int error)
+{
+	int ret = 0;
+
+	if (udp_sock > 0) {
+		k_thread_abort(udp_thread_id);
+		ret = close(udp_sock);
+		if (ret < 0) {
+			LOG_WRN("close() failed: %d", -errno);
+			ret = -errno;
+		}
+		udp_sock = INVALID_SOCKET;
+
+		sprintf(rsp_buf, "#XUDPSVR: %d stopped\r\n", error);
+		rsp_send(rsp_buf, strlen(rsp_buf));
+		LOG_DBG("UDP server stopped");
+	}
+
+	return ret;
+}
+
+static int do_udp_client_connect(const char *url, u16_t port, int sec_tag)
+{
+	int ret;
+
+	/* Open socket */
+	if (sec_tag == INVALID_SEC_TAG) {
+		udp_sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+	} else {
+		udp_sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_DTLS_1_2);
+
+	}
+	if (udp_sock < 0) {
+		LOG_ERR("socket() failed: %d", -errno);
+		sprintf(rsp_buf, "#XUDPCLI: %d\r\n", -errno);
+		rsp_send(rsp_buf, strlen(rsp_buf));
+		return -errno;
+	}
+	if (sec_tag != INVALID_SEC_TAG) {
+		sec_tag_t sec_tag_list[1] = { sec_tag };
+
+		ret = setsockopt(udp_sock, SOL_TLS, TLS_SEC_TAG_LIST,
+				sec_tag_list, sizeof(sec_tag_t));
+		if (ret) {
+			LOG_ERR("set tag list failed: %d", -errno);
+			sprintf(rsp_buf, "#XUDPCLI: %d\r\n", -errno);
+			rsp_send(rsp_buf, strlen(rsp_buf));
+			close(udp_sock);
+			return -errno;
+		}
+	}
+
+	/* Connect to remote host */
+	if (check_for_ipv4(url, strlen(url))) {
+		remote.sin_family = AF_INET;
+		remote.sin_port = htons(port);
+		LOG_DBG("IPv4 Address %s", log_strdup(url));
+		/* NOTE inet_pton() returns 1 as success */
+		ret = inet_pton(AF_INET, url, &remote.sin_addr);
+		if (ret != 1) {
+			LOG_ERR("inet_pton() failed: %d", ret);
+			close(udp_sock);
+			return -EINVAL;
+		}
+	} else {
+		struct addrinfo *result;
+		struct addrinfo hints = {
+			.ai_family = AF_INET,
+			.ai_socktype = SOCK_DGRAM
+		};
+
+		ret = getaddrinfo(url, NULL, &hints, &result);
+		if (ret || result == NULL) {
+			LOG_ERR("getaddrinfo() failed: %d", ret);
+			close(udp_sock);
+			return -EINVAL;
+		}
+
+		remote.sin_family = AF_INET;
+		remote.sin_port = htons(port);
+		remote.sin_addr.s_addr =
+		((struct sockaddr_in *)result->ai_addr)->sin_addr.s_addr;
+		/* Free the address. */
+		freeaddrinfo(result);
+	}
+
+	ret = connect(udp_sock, (struct sockaddr *)&remote,
+		sizeof(struct sockaddr_in));
+	if (ret < 0) {
+		LOG_ERR("connect() failed: %d", -errno);
+		sprintf(rsp_buf, "#XUDPCLI: %d\r\n", -errno);
+		rsp_send(rsp_buf, strlen(rsp_buf));
+		close(udp_sock);
+		return -errno;
+	}
+
+	udp_thread_id = k_thread_create(&udp_thread, udp_thread_stack,
+			K_THREAD_STACK_SIZEOF(udp_thread_stack),
+			udp_thread_func, NULL, NULL, NULL,
+			THREAD_PRIORITY, K_USER, K_NO_WAIT);
+
+	sprintf(rsp_buf, "#XUDPCLI: %d connected\r\n", udp_sock);
+	rsp_send(rsp_buf, strlen(rsp_buf));
+
+	return ret;
+}
+
+static int do_udp_client_disconnect(int error)
+{
+	int ret = 0;
+
+	if (udp_sock > 0) {
+		k_thread_abort(udp_thread_id);
+		ret = close(udp_sock);
+		if (ret < 0) {
+			LOG_WRN("close() failed: %d", -errno);
+			ret = -errno;
+		}
+		udp_sock = INVALID_SOCKET;
+		if (error) {
+			sprintf(rsp_buf, "#XUDPCLI: %d disconnected\r\n",
+				error);
+			rsp_send(rsp_buf, strlen(rsp_buf));
+		}
+	}
+
+	return ret;
+}
+
+static int do_udp_send(const u8_t *data, int datalen)
+{
+	int ret = 0;
+	u32_t offset = 0;
+
+	if (udp_sock == INVALID_SOCKET) {
+		LOG_ERR("Not connected yet");
+		return -EINVAL;
+	}
+
+	while (offset < datalen) {
+		ret = sendto(udp_sock, data + offset, datalen - offset, 0,
+			(struct sockaddr *)&remote, sizeof(remote));
+		if (ret < 0) {
+			LOG_ERR("send() failed: %d", -errno);
+			if (errno != EAGAIN && errno != ETIMEDOUT) {
+				do_udp_server_stop(-errno);
+			} else {
+				sprintf(rsp_buf, "#XUDPSEND: %d\r\n", -errno);
+				rsp_send(rsp_buf, strlen(rsp_buf));
+			}
+			ret = -errno;
+			break;
+		}
+		offset += ret;
+	}
+
+	sprintf(rsp_buf, "#XUDPSEND: %d\r\n", offset);
+	rsp_send(rsp_buf, strlen(rsp_buf));
+	if (ret >= 0) {
+		return 0;
+	} else {
+		return ret;
+	}
+}
+
+static void udp_thread_func(void *p1, void *p2, void *p3)
+{
+	int ret;
+	int size = sizeof(struct sockaddr_in);
+	char data[NET_IPV4_MTU];
+
+	ARG_UNUSED(p1);
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
+	do {
+		ret = recvfrom(udp_sock, data, NET_IPV4_MTU, 0,
+			(struct sockaddr *)&remote, &size);
+		if (ret < 0) {
+			LOG_WRN("recv() error: %d", -errno);
+			continue;
+		}
+		if (ret == 0) {
+			continue;
+		}
+		if (slm_util_hex_check(data, ret)) {
+			char *data_hex = k_malloc(ret * 2);
+			int size = ret * 2;
+
+			if (data_hex == NULL) {
+				LOG_WRN("No memory");
+				continue;
+			}
+			ret = slm_util_htoa(data, ret, data_hex, size);
+			if (ret > 0) {
+				sprintf(rsp_buf, "#XUDPRECV: %d, %d\r\n",
+					DATATYPE_HEXADECIMAL, ret);
+				rsp_send(rsp_buf, strlen(rsp_buf));
+				rsp_send(data_hex, ret);
+				rsp_send("\r\n", 2);
+			}
+			k_free(data_hex);
+		} else {
+			sprintf(rsp_buf, "#XUDPRECV: %d, %d\r\n",
+				DATATYPE_PLAINTEXT, ret);
+			rsp_send(rsp_buf, strlen(rsp_buf));
+			rsp_send(data, ret);
+			rsp_send("\r\n", 2);
+		}
+	} while (true);
+
+	LOG_DBG("Quit receive thread");
+}
+
+/**@brief handle AT#XUDPSVR commands
+ *  AT#XUDPSVR=<op>[,<port>[,[sec_tag]]
+ *  AT#XUDPSVR? READ command not supported
+ *  AT#XUDPSVR=?
+ */
+static int handle_at_udp_server(enum at_cmd_type cmd_type)
+{
+	int err = -EINVAL;
+	u16_t op;
+	int param_count = at_params_valid_count_get(&at_param_list);
+
+	switch (cmd_type) {
+	case AT_CMD_TYPE_SET_COMMAND:
+		if (param_count < 2) {
+			return -EINVAL;
+		}
+		err = at_params_short_get(&at_param_list, 1, &op);
+		if (err) {
+			return err;
+		}
+		if (op == AT_SERVER_START) {
+			u16_t port;
+			sec_tag_t sec_tag = INVALID_SEC_TAG;
+
+			if (param_count < 3) {
+				return -EINVAL;
+			}
+			err = at_params_short_get(&at_param_list, 2, &port);
+			if (err) {
+				return err;
+			}
+			if (param_count > 3) {
+				at_params_int_get(&at_param_list, 3, &sec_tag);
+			}
+			if (udp_sock > 0) {
+				LOG_WRN("Server is running");
+				return -EINVAL;
+			}
+			err = do_udp_server_start(port, sec_tag);
+		} else if (op == AT_SERVER_STOP) {
+			if (udp_sock < 0) {
+				LOG_WRN("Server is not running");
+				return -EINVAL;
+			}
+			err = do_udp_server_stop(0);
+		} break;
+
+	case AT_CMD_TYPE_TEST_COMMAND:
+		sprintf(rsp_buf, "#XUDPSVR: (%d, %d),<port>,<sec_tag>\r\n",
+			AT_SERVER_STOP, AT_SERVER_START);
+		rsp_send(rsp_buf, strlen(rsp_buf));
+		err = 0;
+		break;
+
+	default:
+		break;
+	}
+
+	return err;
+}
+
+/**@brief handle AT#XUDPCLI commands
+ *  AT#XUDPCLI=<op>[,<url>,<port>[,[sec_tag]]
+ *  AT#XUDPCLI? READ command not supported
+ *  AT#XUDPCLI=?
+ */
+static int handle_at_udp_client(enum at_cmd_type cmd_type)
+{
+	int err = -EINVAL;
+	u16_t op;
+	int param_count = at_params_valid_count_get(&at_param_list);
+
+	switch (cmd_type) {
+	case AT_CMD_TYPE_SET_COMMAND:
+		if (param_count < 2) {
+			return -EINVAL;
+		}
+		err = at_params_short_get(&at_param_list, 1, &op);
+		if (err) {
+			return err;
+		}
+		if (op == AT_CLIENT_CONNECT) {
+			u16_t port;
+			char url[TCPIP_MAX_URL];
+			int size = TCPIP_MAX_URL;
+			sec_tag_t sec_tag = INVALID_SEC_TAG;
+
+			if (param_count < 4) {
+				return -EINVAL;
+			}
+			err = at_params_string_get(&at_param_list,
+						2, url, &size);
+			if (err) {
+				return err;
+			}
+			url[size] = '\0';
+			err = at_params_short_get(&at_param_list, 3, &port);
+			if (err) {
+				return err;
+			}
+			if (param_count > 4) {
+				at_params_int_get(&at_param_list, 4, &sec_tag);
+			}
+			err = do_udp_client_connect(url, port, sec_tag);
+		} else if (op == AT_CLIENT_DISCONNECT) {
+			if (udp_sock < 0) {
+				LOG_WRN("Client is not connected");
+				return -EINVAL;
+			}
+			err = do_udp_client_disconnect(0);
+		} break;
+
+	case AT_CMD_TYPE_TEST_COMMAND:
+		sprintf(rsp_buf,
+			"#XUDPCLI: (%d, %d),<url>,<port>,<sec_tag>\r\n",
+			AT_CLIENT_DISCONNECT, AT_CLIENT_CONNECT);
+		rsp_send(rsp_buf, strlen(rsp_buf));
+		err = 0;
+		break;
+
+	default:
+		break;
+	}
+
+	return err;
+}
+
+/**@brief handle AT#XUDPSEND commands
+ *  AT#XUDPSEND=<datatype>,<data>
+ *  AT#XUDPSEND? READ command not supported
+ *  AT#XUDPSEND=? TEST command not supported
+ */
+static int handle_at_udp_send(enum at_cmd_type cmd_type)
+{
+	int err = -EINVAL;
+	u16_t datatype;
+	char data[NET_IPV4_MTU];
+	int size = NET_IPV4_MTU;
+
+	if (remote.sin_family == AF_UNSPEC || remote.sin_port == INVALID_PORT) {
+		return err;
+	}
+
+	switch (cmd_type) {
+	case AT_CMD_TYPE_SET_COMMAND:
+		if (at_params_valid_count_get(&at_param_list) < 3) {
+			return -EINVAL;
+		}
+		err = at_params_short_get(&at_param_list, 1, &datatype);
+		if (err) {
+			return err;
+		}
+		err = at_params_string_get(&at_param_list, 2, data, &size);
+		if (err) {
+			return err;
+		}
+		if (datatype == DATATYPE_HEXADECIMAL) {
+			u8_t *data_hex = k_malloc(size / 2);
+
+			err = slm_util_atoh(data, size, data_hex, size / 2);
+			if (err > 0) {
+				err = do_udp_send(data_hex, err);
+			}
+			k_free(data_hex);
+		} else {
+			err = do_udp_send(data, size);
+		}
+		break;
+
+	default:
+		break;
+	}
+
+	return err;
+}
+
+/**@brief API to handle UDP Proxy AT commands
+ */
+int slm_at_udp_proxy_parse(const char *at_cmd)
+{
+	int ret = -ENOTSUP;
+	enum at_cmd_type type;
+
+	for (int i = 0; i < AT_UDP_PROXY_MAX; i++) {
+		if (slm_util_cmd_casecmp(at_cmd,
+					m_udp_proxy_at_list[i].string)) {
+			ret = at_parser_params_from_str(at_cmd, NULL,
+						&at_param_list);
+			if (ret) {
+				LOG_ERR("Failed to parse AT command %d", ret);
+				return -EINVAL;
+			}
+			type = at_parser_cmd_type_get(at_cmd);
+			ret = m_udp_proxy_at_list[i].handler(type);
+			break;
+		}
+	}
+
+	return ret;
+}
+
+/**@brief API to list UDP Proxy AT commands
+ */
+void slm_at_udp_proxy_clac(void)
+{
+	for (int i = 0; i < AT_UDP_PROXY_MAX; i++) {
+		sprintf(rsp_buf, "%s\r\n", m_udp_proxy_at_list[i].string);
+		rsp_send(rsp_buf, strlen(rsp_buf));
+	}
+}
+
+/**@brief API to initialize UDP Proxy AT commands handler
+ */
+int slm_at_udp_proxy_init(void)
+{
+	udp_sock = INVALID_SOCKET;
+	remote.sin_family = AF_UNSPEC;
+	remote.sin_port = INVALID_PORT;
+
+	return 0;
+}
+
+/**@brief API to uninitialize UDP Proxy AT commands handler
+ */
+int slm_at_udp_proxy_uninit(void)
+{
+	int ret;
+
+	if (udp_sock > 0) {
+		k_thread_abort(udp_thread_id);
+		ret = close(udp_sock);
+		if (ret < 0) {
+			LOG_WRN("close() failed: %d", -errno);
+			ret = -errno;
+		}
+		udp_sock = INVALID_SOCKET;
+	}
+
+	return 0;
+}

--- a/samples/nrf9160/serial_lte_modem/src/tcpip_proxy/slm_at_udp_proxy.h
+++ b/samples/nrf9160/serial_lte_modem/src/tcpip_proxy/slm_at_udp_proxy.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2020 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+ */
+
+#ifndef SLM_AT_UDP_PROXY_
+#define SLM_AT_UDP_PROXY_
+
+/**@file slm_at_udp_proxy.h
+ *
+ * @brief Vendor-specific AT command for UDP proxy service.
+ * @{
+ */
+
+#include <zephyr/types.h>
+#include <modem/at_cmd.h>
+
+/**
+ * @brief UDP proxy AT command parser.
+ *
+ * @param at_cmd AT command string.
+ *
+ * @retval 0 If the operation was successful.
+ *           Otherwise, a (negative) error code is returned.
+ */
+int slm_at_udp_proxy_parse(const char *at_cmd);
+
+/**
+ * @brief List UDP/IP AT commands.
+ *
+ */
+void slm_at_udp_proxy_clac(void);
+
+/**
+ * @brief Initialize UDP proxy AT command parser.
+ *
+ * @retval 0 If the operation was successful.
+ *           Otherwise, a (negative) error code is returned.
+ */
+int slm_at_udp_proxy_init(void);
+
+/**
+ * @brief Uninitialize UDP proxy AT command parser.
+ *
+ * @retval 0 If the operation was successful.
+ *           Otherwise, a (negative) error code is returned.
+ */
+int slm_at_udp_proxy_uninit(void);
+/** @} */
+
+#endif /* SLM_AT_UDP_PROXY_ */


### PR DESCRIPTION
Customer engineering, add optional TCP/UDP proxy service of below
.TCP/TLS UDP/DTLS client proxy
.TCP/UDP server proxy

New AT commands
.AT#XTCPSVR=<op>[,<port>[,[sec_tag]]
.AT#XTCPCLI=<op>[,<url>,<port>[,[sec_tag]]
.AT#XTCPSEND=<datatype>,<data>
.AT#XUDPSVR=<op>[,<port>[,[sec_tag]]
.AT#XUDPCLI=<op>[,<url>,<port>[,[sec_tag]]
.AT#XUDPSEND=<datatype>,<data>

Clean up existing BSD-style TCP/IP implementation
.Remove AT#XDATATYPE, now all Send requires specifying data type
.Remove SLM_TEST_MODE, as same could be achieved by proxy services

Signed-off-by: Jun Qing Zou <jun.qing.zou@nordicsemi.no>