### PR TITLE
scripts: remove NCS internals from requirements.txt

### DIFF
--- a/scripts/requirements-extra.txt
+++ b/scripts/requirements-extra.txt
@@ -1,0 +1,2 @@
+pygit2>=0.26.0
+editdistance>=0.5.0

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,8 +1,6 @@
 ecdsa
-editdistance>=0.5.0
 imagesize>=1.2.0
 intelhex
-pygit2>=0.26.0
 recommonmark==0.4.0
 sphinxcontrib-mscgen
 west>=0.7.2


### PR DESCRIPTION
The editdistance and pygit2 dependencies are only needed by
maintainers for the internal ncs-loot and ncs-compare west extension
commands.

They're also causing installation problems for Windows users, as e.g.
editdistance is a C extension which is not currently available in
wheel form on Windows + Python 3.8.

Let's move them out to their own requirements file to make this
problem go away. This has the side benefit of making the installation
footprint for regular users smaller.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>
Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>