### PR TITLE
Feature mqtt persistent sessions

### DIFF
--- a/applications/asset_tracker/prj.conf
+++ b/applications/asset_tracker/prj.conf
@@ -45,6 +45,8 @@ CONFIG_NRF_CLOUD_AGPS=y
 CONFIG_CJSON_LIB=y
 # Shorter to prevent NAT timeouts
 CONFIG_MQTT_KEEPALIVE=120
+# Don't resubscribe to topics if broker remembers them
+CONFIG_CLOUD_PERSISTENT_SESSIONS=y
 
 # Sensors
 CONFIG_ACCEL_USE_SIM=y

--- a/applications/asset_tracker/prj_nrf9160_pca20035ns.conf
+++ b/applications/asset_tracker/prj_nrf9160_pca20035ns.conf
@@ -49,6 +49,8 @@ CONFIG_NRF_CLOUD_AGPS=y
 CONFIG_CJSON_LIB=y
 # Shorter to prevent NAT timeouts
 CONFIG_MQTT_KEEPALIVE=120
+# Don't resubscribe to topics if broker remembers them
+CONFIG_CLOUD_PERSISTENT_SESSIONS=y
 
 # Sensors
 CONFIG_SENSOR=y

--- a/applications/asset_tracker/src/main.c
+++ b/applications/asset_tracker/src/main.c
@@ -1086,6 +1086,10 @@ void cloud_event_handler(const struct cloud_backend *const backend,
 		LOG_INF("CLOUD_EVT_CONNECTED");
 		k_delayed_work_cancel(&cloud_reboot_work);
 		ui_led_set_pattern(UI_CLOUD_CONNECTED);
+#if defined(CONFIG_CLOUD_PERSISTENT_SESSIONS)
+		LOG_INF("Persistent Sessions = %u",
+			evt->data.persistent_session);
+#endif
 		break;
 	case CLOUD_EVT_READY: {
 		LOG_INF("CLOUD_EVT_READY");

--- a/include/net/aws_jobs.h
+++ b/include/net/aws_jobs.h
@@ -60,6 +60,21 @@ enum execution_status {
 		AWS_JOBS_TOPIC_STATIC_LEN + AWS_JOBS_JOB_ID_MAX_LEN)
 
 /**
+ * @brief Construct the notify-next topic for receiving AWS IoT
+ *        jobs.
+ *
+ * @param[in]  client Connected MQTT client instance.
+ * @param[out] topic_buf Buffer to store the topic in.
+ *
+ * @retval 0       If successful.
+ * @retval -EINVAL If the provided input parameter is not valid.
+ * @retval -ENOMEM If cannot fit in the buffer, which is assumed
+ *                 to be AWS_JOBS_TOPIC_MAX_LEN in size.
+ */
+int aws_jobs_create_topic_notify_next(struct mqtt_client *const client,
+					 u8_t *topic_buf);
+
+/**
  * @brief Construct the notify-next topic and subscribe to it for receiving
  *        AWS IoT jobs.
  *
@@ -67,7 +82,7 @@ enum execution_status {
  * @param[out] topic_buf Buffer to store the topic in.
  *
  * @retval 0       If successful, otherwise the return code of
- *                 mqtt_unsubscribe or snprintf.
+ *                 mqtt_subscribe or snprintf.
  *
  * @retval -EINVAL If the provided input parameter is not valid.
  */
@@ -88,6 +103,20 @@ int aws_jobs_subscribe_topic_notify_next(struct mqtt_client *const client,
  */
 int aws_jobs_unsubscribe_topic_notify_next(struct mqtt_client *const client,
 					   u8_t *topic_buf);
+
+/**
+ * @brief Construct the notify topic for receiving AWS IoT jobs.
+ *
+ * @param[in]  client Connected MQTT client instance.
+ * @param[out] topic_buf Buffer to store the topic in.
+ *
+ * @retval 0       If successful.
+ * @retval -EINVAL If the provided input parameter is not valid.
+ * @retval -ENOMEM If cannot fit in the buffer, which is assumed
+ *                 to be AWS_JOBS_TOPIC_MAX_LEN in size.
+ */
+int aws_jobs_create_topic_notify(struct mqtt_client *const client,
+				 u8_t *topic_buf);
 
 /**
  * @brief Construct the notify topic and subscribe to it for receiving
@@ -117,6 +146,21 @@ int aws_jobs_subscribe_topic_notify(struct mqtt_client *const client,
  */
 int aws_jobs_unsubscribe_topic_notify(struct mqtt_client *const client,
 				      u8_t *topic_buf);
+
+/**
+ * @brief Construct the get topic for a job ID.
+ *
+ * @param[in]  client Connected MQTT client instance.
+ * @param[in]  job_id Job ID of the currently accepted job.
+ * @param[out] topic_buf Buffer to store the topic in.
+ *
+ * @retval 0       If successful.
+ * @retval -EINVAL If the provided input parameter is not valid.
+ * @retval -ENOMEM If cannot fit in the buffer, which is assumed
+ *                 to be AWS_JOBS_TOPIC_MAX_LEN in size.
+ */
+int aws_jobs_create_topic_get(struct mqtt_client *const client,
+			      const u8_t *job_id, u8_t *topic_buf);
 
 /**
  * @brief Construct the get topic for a job ID and subscribe to it for both

--- a/include/net/cloud.h
+++ b/include/net/cloud.h
@@ -109,6 +109,7 @@ struct cloud_event {
 	union {
 		struct cloud_msg msg;
 		int err;
+		bool persistent_session;
 	} data;
 };
 

--- a/subsys/net/lib/aws_iot/src/aws_iot.c
+++ b/subsys/net/lib/aws_iot/src/aws_iot.c
@@ -417,7 +417,9 @@ static void mqtt_evt_handler(struct mqtt_client *const c,
 	case MQTT_EVT_CONNACK:
 		LOG_DBG("MQTT client connected!");
 
-		topic_subscribe();
+		if (!mqtt_evt->param.connack.session_present_flag) {
+			topic_subscribe();
+		}
 
 #if defined(CONFIG_CLOUD_API)
 		cloud_evt.type = CLOUD_EVT_CONNECTED;

--- a/subsys/net/lib/aws_jobs/src/aws_jobs.c
+++ b/subsys/net/lib/aws_jobs/src/aws_jobs.c
@@ -131,6 +131,17 @@ static int reg_topic(struct mqtt_client *const client, u8_t *topic_buf,
 	return mqtt_unsubscribe(client, &subscription_list);
 }
 
+
+int aws_jobs_create_topic_notify_next(struct mqtt_client *const client,
+					 u8_t *topic_buf)
+{
+	struct mqtt_topic topic;
+
+	return construct_topic(client->client_id.utf8, "",
+			       &TOPIC_NOTIFY_NEXT_CONF, topic_buf, &topic,
+			       false);
+}
+
 int aws_jobs_subscribe_topic_notify_next(struct mqtt_client *const client,
 					 u8_t *topic_buf)
 {
@@ -143,6 +154,15 @@ int aws_jobs_unsubscribe_topic_notify_next(struct mqtt_client *const client,
 	return reg_topic(client, topic_buf, &TOPIC_NOTIFY_NEXT_CONF, "", false);
 }
 
+int aws_jobs_create_topic_notify(struct mqtt_client *const client,
+				 u8_t *topic_buf)
+{
+	struct mqtt_topic topic;
+
+	return construct_topic(client->client_id.utf8, "",
+			       &TOPIC_NOTIFY_CONF, topic_buf, &topic, false);
+}
+
 int aws_jobs_subscribe_topic_notify(struct mqtt_client *const client,
 				    u8_t *topic_buf)
 {
@@ -153,6 +173,15 @@ int aws_jobs_unsubscribe_topic_notify(struct mqtt_client *const client,
 				      u8_t *topic_buf)
 {
 	return reg_topic(client, topic_buf, &TOPIC_NOTIFY_CONF, "", false);
+}
+
+int aws_jobs_create_topic_get(struct mqtt_client *const client,
+				 const u8_t *job_id, u8_t *topic_buf)
+{
+	struct mqtt_topic topic;
+
+	return construct_topic(client->client_id.utf8, job_id,
+			       &TOPIC_GET_CONF, topic_buf, &topic, false);
 }
 
 int aws_jobs_subscribe_topic_get(struct mqtt_client *const client,

--- a/subsys/net/lib/cloud/Kconfig
+++ b/subsys/net/lib/cloud/Kconfig
@@ -5,3 +5,11 @@
 
 config CLOUD_API
 	bool "Cloud API"
+
+config CLOUD_PERSISTENT_SESSIONS
+	bool "Enable reusing previous subscriptions to save bandwidth"
+	default n
+	help
+	  If y, request using the previous session on connect. If allowed by the broker,
+	  the broker will indicate it is or not.  If not, the device must resubscribe. If
+	  it is allowed, then the device does not need to subscribe to its usual topics.

--- a/subsys/net/lib/nrf_cloud/include/nrf_cloud_transport.h
+++ b/subsys/net/lib/nrf_cloud/include/nrf_cloud_transport.h
@@ -51,6 +51,7 @@ struct nct_evt {
 		struct nct_cc_data *cc;
 		struct nct_dc_data *dc;
 		u32_t data_id;
+		u8_t flag;
 	} param;
 	enum nct_evt_type type;
 };

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud.c
@@ -226,7 +226,7 @@ static void event_handler(const struct nrf_cloud_evt *nrf_cloud_evt)
 		LOG_DBG("NRF_CLOUD_EVT_TRANSPORT_CONNECTED");
 
 		evt.type = CLOUD_EVT_CONNECTED;
-
+		evt.data.persistent_session = (nrf_cloud_evt->status != 0);
 		cloud_notify_event(nrf_cloud_backend, &evt, config->user_data);
 		break;
 	case NRF_CLOUD_EVT_USER_ASSOCIATION_REQUEST:

--- a/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
+++ b/subsys/net/lib/nrf_cloud/src/nrf_cloud_transport.c
@@ -609,6 +609,10 @@ int nct_mqtt_connect(void)
 	nct.client.protocol_version = MQTT_VERSION_3_1_1;
 	nct.client.password = NULL;
 	nct.client.user_name = NULL;
+#if defined(CONFIG_CLOUD_PERSISTENT_SESSIONS)
+	nct.client.clean_session = 0U;
+	LOG_DBG("mqtt_connect requesting persistent session");
+#endif
 #if defined(CONFIG_MQTT_LIB_TLS)
 	nct.client.transport.type = MQTT_TRANSPORT_SECURE;
 	nct.client.rx_buf = nct.rx_buf;
@@ -673,9 +677,12 @@ static void nct_mqtt_evt_handler(struct mqtt_client *const mqtt_client,
 
 	switch (_mqtt_evt->type) {
 	case MQTT_EVT_CONNACK: {
+		const struct mqtt_connack_param *p = &_mqtt_evt->param.connack;
+
 		LOG_DBG("MQTT_EVT_CONNACK");
 
 		evt.type = NCT_EVT_CONNECTED;
+		evt.param.flag = (p->session_present_flag != 0);
 		event_notify = true;
 		break;
 	}


### PR DESCRIPTION
Add support for persistent sessions to the generic cloud interface, the aws_iot backend, and the nrf_cloud backend.  Use persistent session information to skip resubscribing to topics in
aws_fota and the backends.  Enable it in asset_tracker prj.*conf and log status in main.c.

Jira: TG91-248