### PR TITLE
cmake: change how path to subsys pm.yml is set

### DIFF
--- a/subsys/partition_manager/CMakeLists.txt
+++ b/subsys/partition_manager/CMakeLists.txt
@@ -47,20 +47,25 @@ if((EXISTS ${CMAKE_SOURCE_DIR}/pm.yml) AND IMAGE_NAME)
     )
 endif()
 
-get_property(img_pm_subsys GLOBAL PROPERTY PM_SUBSYS)
-if (img_pm_subsys)
-  foreach (subsys_pm_yml ${img_pm_subsys})
-    file(RELATIVE_PATH rel_path_to_yml ${ZEPHYR_BASE} ${subsys_pm_yml})
-    set(subsys_pm_preprocessed
-      ${PROJECT_BINARY_DIR}/${rel_path_to_yml})
+# Check for partition manager configurations defined by subsystems
+# This is a list of absolute paths to these pm.yml files.
+get_property(pm_yml_paths GLOBAL PROPERTY PM_SUBSYS_PATH)
+if (pm_yml_paths)
+  # Each entry in the list has a corresponding entry with the output
+  # path in the build directory for the pm.yml file.
+  get_property(output_pm_yml_paths GLOBAL PROPERTY PM_SUBSYS_OUTPUT_PATH)
+  foreach (pm_yml_path ${pm_yml_paths})
+    list(GET output_pm_yml_paths 0 output_pm_yml_path)
+    list(REMOVE_AT output_pm_yml_paths 0)
+
     preprocess_pm_yml(
-      ${subsys_pm_yml}
-      ${subsys_pm_preprocessed}
+      ${pm_yml_path}
+      ${output_pm_yml_path}/pm.yml
       )
-  set_property(
-    GLOBAL APPEND PROPERTY
-    PM_SUBSYS_PREPROCESSED
-      ${subsys_pm_preprocessed}
-    )
+    set_property(
+      GLOBAL APPEND PROPERTY
+      PM_SUBSYS_PREPROCESSED
+      ${output_pm_yml_path}/pm.yml
+      )
   endforeach()
 endif()

--- a/west.yml
+++ b/west.yml
@@ -46,7 +46,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: fw-nrfconnect-zephyr
-      revision: c0e092a07d17820120f72b23a817dc895a5ca34e
+      revision: 79f1bb595339a6ba0f281c4beb3fec79da817f0d
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
The relative path from the build dir to the binary dir of a subsys
folder is not static. In a zephyr subsys it is

build/zephyr/subsys/path

whereas in a nrf subsys it is

build/modules/nrf/subsys/path

The previous way of setting the path to preprocessed pm.yml files
for subsystems only worked with the first of these.

This commit introduces the use of a cmake variable for the binary dir,
and a mechanism for setting the build dir path for each pm.yml
explicitly.

This PR depends on https://github.com/NordicPlayground/fw-nrfconnect-zephyr/pull/292