### PR TITLE
lib: modem_info: fix error in reading MODEM_INFO_RSRP

### DIFF
--- a/lib/modem_info/modem_info.c
+++ b/lib/modem_info/modem_info.c
@@ -66,8 +66,8 @@ LOG_MODULE_REGISTER(modem_info);
 #define MODEM_IMEI_DATA_NAME	"imei"
 #define DATE_TIME_DATA_NAME	"dateTime"
 
-#define RSRP_PARAM_INDEX	1
-#define RSRP_PARAM_COUNT	5
+#define RSRP_PARAM_INDEX	6
+#define RSRP_PARAM_COUNT	7
 #define RSRP_OFFSET_VAL		141
 
 #define BAND_PARAM_INDEX	1 /* Index of desired parameter */

--- a/lib/modem_info/modem_info.c
+++ b/lib/modem_info/modem_info.c
@@ -66,8 +66,12 @@ LOG_MODULE_REGISTER(modem_info);
 #define MODEM_IMEI_DATA_NAME	"imei"
 #define DATE_TIME_DATA_NAME	"dateTime"
 
+#define RSRP_NOTIFY_PARAM_INDEX	1
+#define RSRP_NOTIFY_PARAM_COUNT	5
+
 #define RSRP_PARAM_INDEX	6
 #define RSRP_PARAM_COUNT	7
+
 #define RSRP_OFFSET_VAL		141
 
 #define BAND_PARAM_INDEX	1 /* Index of desired parameter */
@@ -503,7 +507,15 @@ static void modem_info_rsrp_subscribe_handler(void *context, const char *respons
 		return;
 	}
 
-	err = modem_info_parse(modem_data[MODEM_INFO_RSRP],
+	const struct modem_info_data rsrp_data = {
+		.cmd			= AT_CMD_CESQ,
+		.data_name		= RSRP_DATA_NAME,
+		.param_index	= RSRP_NOTIFY_PARAM_INDEX,
+		.param_count	= RSRP_NOTIFY_PARAM_COUNT,
+		.data_type		= AT_PARAM_TYPE_NUM_SHORT,
+	};
+
+	err = modem_info_parse(&rsrp_data,
 			       response);
 	if (err != 0) {
 		LOG_ERR("modem_info_parse failed to parse "


### PR DESCRIPTION
Calling `modem_info_short_get` with `MODEM_INFO_RSRP` fails without this patch. It appears that `RRSP_PARAM_INDEX` and `RRSP_PARAM_COUNT` were incorrect. Changing them to the values in this patch, results in `modem_info_short_get` call succeeding and reading the LTE signal quality.

I've tested this on nRF9160DK with modem `mfw_nrf9160_1.1.1`