### PR TITLE
applications: nrf_desktop: Fix references to device tree

### DIFF
--- a/applications/nrf_desktop/README.rst
+++ b/applications/nrf_desktop/README.rst
@@ -153,7 +153,7 @@ Configuration sources
 
 The nRF Desktop project uses the following files as sources of its configuration:
 
-    * DTS files -- reflect the hardware configuration (see :ref:`device-tree`).
+    * DTS files -- reflect the hardware configuration (see :ref:`devicetree`).
     * ``_def`` files -- contain configuration arrays for the application modules and are specific to the nRF Desktop project.
     * Kconfig files -- reflect the software configuration (see :ref:`kconfig_tips_and_tricks`).
 

--- a/applications/nrf_desktop/doc/board.rst
+++ b/applications/nrf_desktop/doc/board.rst
@@ -30,7 +30,7 @@ The ``port_state_def.h`` file defines the states set to the GPIO ports by the fo
 
 Every :c:type:`struct port_state` refers to a single GPIO port and contains the following information:
 
-* :cpp:member:`name` - GPIO device name (defined by a symbol in :ref:`zephyr:device-tree`, for example :c:macro:`DT_GPIO_P0_DEV_NAME`).
+* :cpp:member:`name` - GPIO device name (defined by a symbol in :ref:`zephyr:devicetree`, for example :c:macro:`DT_GPIO_P0_DEV_NAME`).
 * :cpp:member:`ps` - pointer to the array of :c:type:`struct pin_state`.
 * :cpp:member:`ps_count` - size of the `ps` array.
 

--- a/applications/nrf_desktop/doc/leds.rst
+++ b/applications/nrf_desktop/doc/leds.rst
@@ -49,7 +49,7 @@ You can use the following additional configuration options:
 * number of color channels per diode (``CONFIG_DESKTOP_LED_COLOR_COUNT``),
 * maximum value of LED brightness (``CONFIG_DESKTOP_LED_BRIGHTNESS_MAX``).
 
-Symbols from :ref:`zephyr:device-tree` are used to define the mapping of the PWM channels to pin numbers.
+Symbols from :ref:`zephyr:devicetree` are used to define the mapping of the PWM channels to pin numbers.
 By default, the symbols are defined in the board configuration, but you can redefine them in the ``dts.overlay`` file.
 The configuration for the board is written in the ``leds_def.h`` file.
 Both files are located in the board-specific directory in the application configuration folder.


### PR DESCRIPTION
Fix references to device tree.

Signed-off-by: Pawel Dunaj <pawel.dunaj@nordicsemi.no>