### PR TITLE
manifest: update zephyr to include upstream USB fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -46,7 +46,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: fw-nrfconnect-zephyr
-      revision: 616c7d5becd4e89870830e586f2626758653b1ea
+      revision: c0e092a07d17820120f72b23a817dc895a5ca34e
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Updates the manifest to include Zephyr PR 286

Ref https://github.com/NordicPlayground/fw-nrfconnect-zephyr/pull/286