### PR TITLE
doc: update board names

### DIFF
--- a/applications/nrf_desktop/README.rst
+++ b/applications/nrf_desktop/README.rst
@@ -203,7 +203,7 @@ Desktop mouse (nrf52_pca20044 and nrf52810_pca20045)
       * There is no configuration with bootloader available.
 
 
-Sample mouse or keyboard (nrf52840_pca10056)
+Sample mouse or keyboard (nrf52840dk_nrf52840)
       * The configuration uses the nRF52840 Development Kit.
       * The build types allow to build the application both as mouse or as keyboard.
       * Inputs are simulated based on the hardware button presses.
@@ -215,7 +215,7 @@ Keyboard (nrf52_pca20037)
       * Bluetooth is configured to use Nordic's proprietary link layer.
       * |preconfigured_build_types|
 
-Dongle (nrf52840_pca10059)
+Dongle (nrf52840dongle_nrf52840)
       * This configuration uses Nordic's nRF52840 dongle defined in Zephyr.
       * Since the board is generic, project-specific changes are applied in the DTS overlay file.
       * The application is configured to act as both mouse and keyboard.

--- a/applications/nrf_desktop/doc/ble_discovery.rst
+++ b/applications/nrf_desktop/doc/ble_discovery.rst
@@ -44,7 +44,7 @@ Complete the following steps to configure the module:
             * Product ID (PID)
             * Peer type (:cpp:enum:`PEER_TYPE_MOUSE` or :cpp:enum:`PEER_TYPE_KEYBOARD`)
 
-   For an example of the module configuration, see :file:`configuration/nrf52840_pca10059/ble_discovery_def.h`.
+   For an example of the module configuration, see :file:`configuration/nrf52840dongle_nrf52840/ble_discovery_def.h`.
 
    .. note::
         The module configuration example uses ``0x1915`` as Nordic Semiconductor's VID.

--- a/doc/nrf/gs_programming.rst
+++ b/doc/nrf/gs_programming.rst
@@ -42,7 +42,7 @@ Complete the following steps to build |NCS| projects with SES after :ref:`instal
 
 .. build_SES_projimport_open_end
 
-   The following figure shows an example configuration for the Asset Tracker application built for the ``nrf9160_pca10090ns`` board target:
+   The following figure shows an example configuration for the Asset Tracker application built for the ``nrf9160dk_nrf9160ns`` build target:
 
    .. figure:: images/ses_config.png
       :alt: Opening the Asset Tracker project
@@ -178,25 +178,31 @@ For more information on building and programming using the command line, see the
 Board names
 ***********
 
-You can find the board names for the different development boards in the :ref:`zephyr:boards` section in the Zephyr documentation.
-For your convenience, the following table lists the board names for Nordic Semiconductor's development kits.
+You can find the board names for the different hardware platforms in the :ref:`zephyr:boards` section in the Zephyr documentation.
+For your convenience, the following table lists some of the boards and build targets for Nordic Semiconductor's hardware platforms.
 
 .. _table:
 
-+--------------------------------------------------------+-------------------------------------------------------+
-| Development kits                                       | Board names                                           |
-+========================================================+=======================================================+
-| :ref:`nRF51 DK board (PCA10028)<nrf51_pca10028>`       | nrf51_pca10028                                        |
-+--------------------------------------------------------+-------------------------------------------------------+
-| :ref:`nRF52 DK board (PCA10040)<nrf52_pca10040>`       | nrf52_pca10040                                        |
-+--------------------------------------------------------+-------------------------------------------------------+
-| :ref:`nRF52840 DK board (PCA10056)<nrf52840_pca10056>` | nrf52840_pca10056                                     |
-+--------------------------------------------------------+-------------------------------------------------------+
-| :ref:`nRF5340 PDK board (PCA10095)<nrf5340_dk_nrf5340>`| nrf5340_dk_nrf5340_cpunet (for the network sample)    |
-+                                                        +                                                       +
-|                                                        | nrf5340_dk_nrf5340_cpuapp (for the application sample)|
-+--------------------------------------------------------+-------------------------------------------------------+
-| :ref:`nRF9160 DK board (PCA10090)<nrf9160_pca10090>`   | nrf9160_pca10090 (for the secure version)             |
-+                                                        +                                                       +
-|                                                        | nrf9160_pca10090ns (for the non-secure version)       |
-+--------------------------------------------------------+-------------------------------------------------------+
++-------------------+------------+----------------------------------------------------------+---------------------------------------+
+| Hardware platform | PCA number | Board name                                               | Build target                          |
++===================+============+==========================================================+=======================================+
+| nRF51 DK          | PCA10028   | :ref:`nrf51dk_nrf51422 <zephyr:nrf51dk_nrf51422>`        | ``nrf51dk_nrf51422``                  |
++-------------------+------------+----------------------------------------------------------+---------------------------------------+
+| nRF52 DK          | PCA10040   | :ref:`nrf52dk_nrf52832 <zephyr:nrf52dk_nrf52832>`        | ``nrf51dk_nrf51422``                  |
++-------------------+------------+----------------------------------------------------------+---------------------------------------+
+| nRF52833 DK       | PCA10100   | :ref:`nrf52833dk_nrf52833 <zephyr:nrf52833dk_nrf52833>`  | ``nrf52833dk_nrf52833``               |
++-------------------+------------+----------------------------------------------------------+---------------------------------------+
+| nRF52840 DK       | PCA10056   | :ref:`nrf52840dk_nrf52840 <zephyr:nrf52840dk_nrf52840>`  | ``nrf52840dk_nrf52840``               |
++-------------------+------------+----------------------------------------------------------+---------------------------------------+
+| nRF5340 PDK       | PCA10095   | :ref:`nrf5340pdk_nrf5340 <zephyr:nrf5340pdk_nrf5340>`    | ``nrf5340pdk_nrf5340_cpunet``         |
+|                   |            |                                                          |                                       |
+|                   |            |                                                          | ``nrf5340pdk_nrf5340_cpunetns``       |
+|                   |            |                                                          |                                       |
+|                   |            |                                                          | ``nrf5340pdk_nrf5340_cpuapp``         |
++-------------------+------------+----------------------------------------------------------+---------------------------------------+
+| nRF9160 DK        | PCA10090   | :ref:`nrf9160dk_nrf9160 <zephyr:nrf9160dk_nrf9160>`      | ``nrf9160dk_nrf9160``                 |
+|                   |            |                                                          |                                       |
+|                   |            |                                                          | ``nrf9160dk_nrf9160ns``               |
+|                   |            +----------------------------------------------------------+---------------------------------------+
+|                   |            | :ref:`nrf9160dk_nrf52840 <zephyr:nrf9160dk_nrf52840>`    | ``nrf9160dk_nrf52840``                |
++-------------------+------------+----------------------------------------------------------+---------------------------------------+

--- a/doc/nrf/includes/build_and_run_nrf9160.txt
+++ b/doc/nrf/includes/build_and_run_nrf9160.txt
@@ -1,6 +1,6 @@
 This sample can be found under |sample path| in the |NCS| folder structure.
 
-The sample is built as a non-secure firmware image for the nrf9160_pca10090ns board.
+The sample is built as a non-secure firmware image for the nrf9160dk_nrf9160ns build target.
 Because of this, it automatically includes the :ref:`secure_partition_manager`.
 
 See :ref:`gs_programming` for information about how to build and program the application.

--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -241,7 +241,7 @@
 
 .. ### Links to specific files on GitHub
 
-.. _`nrf9160_pca10090_partition_conf.dts`: https://github.com/NordicPlayground/fw-nrfconnect-zephyr/blob/master/boards/arm/nrf9160_pca10090/nrf9160_pca10090_partition_conf.dts
+.. _`nrf9160dk_nrf9160_partition_conf.dts`: https://github.com/NordicPlayground/fw-nrfconnect-zephyr/blob/master/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_partition_conf.dts
 
 .. _`west manifest file`: https://github.com/NordicPlayground/fw-nrfconnect-nrf/blob/master/west.yml
 

--- a/doc/nrf/ug_multi_image.rst
+++ b/doc/nrf/ug_multi_image.rst
@@ -31,7 +31,7 @@ nRF9160 SPU configuration
    The code in the secure domain can configure the System Protection Unit (SPU) to allow non-secure access to the CPU resources that are required by the application, and then jump to the code in the non-secure domain.
    Therefore, the nRF9160 samples (the parent image) require the :ref:`secure_partition_manager` (the child image) to be programmed in addition to the actual application.
 
-   See :ref:`zephyr:nrf9160_pca10090` and :ref:`ug_nrf9160` for more information.
+   See :ref:`zephyr:nrf9160dk_nrf9160` and :ref:`ug_nrf9160` for more information.
 
 MCUboot bootloader
    The MCUboot bootloader establishes a root of trust by verifying the next step in the boot sequence.

--- a/doc/nrf/ug_nrf52.rst
+++ b/doc/nrf/ug_nrf52.rst
@@ -16,12 +16,8 @@ See `nRF52 Series`_ for the technical documentation on the nRF52 Series chips an
 Supported boards
 ================
 
-All supported boards have a PCA number, which is used to uniquely identify each board.
-The build system uses a combination of device part code and PCA number to identify a build target in the format ``nrf52xxx_pcaxxxxx``.
-For example, for the :ref:`nRF52840 Development Kit (PCA10056) <zephyr:nrf52840_pca10056>`, use ``nrf52840_pca10056`` as target when building.
-
 Devices in the nRF52 Series are supported by these boards in the Zephyr open source project and in |NCS|.
-Refer to the PCA number for building projects for these boards and find a link to their descriptions.
+
 
 .. list-table::
    :header-rows: 1
@@ -29,21 +25,21 @@ Refer to the PCA number for building projects for these boards and find a link t
    * - DK
      - PCA number
      - Build target
-   * - nRF52840 DK
+   * - :ref:`zephyr:nrf52840dk_nrf52840`
      - PCA10056
-     - :ref:`nrf52840_pca10056<zephyr:nrf52840_pca10056>`
-   * - nRF52840 DK (emulating the nRF52811)
+     - ``nrf52840dk_nrf52840``
+   * - :ref:`zephyr:nrf52840dk_nrf52811`
      - PCA10056
-     - :ref:`nrf52811_pca10056<zephyr:nrf52811_pca10056>`
-   * - nRF52833 DK
+     - ``nrf52840dk_nrf52811``
+   * - :ref:`zephyr:nrf52833dk_nrf52833`
      - PCA10100
-     - :ref:`nrf52833_pca10100<zephyr:nrf52833_pca10100>`
-   * - nRF52 DK
+     - ``nrf52833dk_nrf52833``
+   * - :ref:`zephyr:nrf52dk_nrf52832`
      - PCA10040
-     - :ref:`nrf52_pca10040<zephyr:nrf52_pca10040>`
-   * - nRF52 DK (emulating the nRF52810)
+     - ``nrf52dk_nrf52832``
+   * - :ref:`zephyr:nrf52dk_nrf52810`
      - PCA10040
-     - :ref:`nrf52810_pca10040<zephyr:nrf52810_pca10040>`
+     - ``nrf52dk_nrf52810``
 
 nRF Desktop
 ===========

--- a/doc/nrf/ug_nrf5340.rst
+++ b/doc/nrf/ug_nrf5340.rst
@@ -12,7 +12,7 @@ nRF5340 is a wireless ultra-low power multicore System on Chip (SoC) with two fu
 The |NCS| supports Bluetooth Low Energy communication on the nRF5340 SoC.
 
 See the `nRF5340 Product Specification`_ for more information about the nRF5340 SoC.
-:ref:`zephyr:nrf5340_dk_nrf5340` gives an overview of the nRF5340 PDK support in Zephyr.
+:ref:`zephyr:nrf5340pdk_nrf5340` gives an overview of the nRF5340 PDK support in Zephyr.
 
 Network core
 ============
@@ -31,7 +31,7 @@ Currently, the following solutions are available for the network core:
 
 In general, this core should be used for real-time processing tasks involving low-level protocols and layers.
 
-The board name for the network core in Zephyr is ``nrf5340_dk_nrf5340_cpunet``.
+The board name for the network core in Zephyr is ``nrf5340pdk_nrf5340_cpunet``.
 
 Application core
 ================
@@ -45,15 +45,15 @@ Currently, the |NCS| provides the following solutions for the application core:
 
 In general, this core should be used for tasks that require high performance and application-level logic.
 
-The board name for the application core in Zephyr is ``nrf5340_dk_nrf5340_cpuapp``.
+The board name for the application core in Zephyr is ``nrf5340pdk_nrf5340_cpuapp``.
 
 The user application can run in the secure or non-secure domain.
 Therefore, it can be built for two different board targets:
 
-* ``nrf5340_dk_nrf5340_cpuapp`` for the secure domain,
-* ``nrf5340_dk_nrf5340_cpuappns`` for the non-secure domain.
+* ``nrf5340pdk_nrf5340_cpuapp`` for the secure domain,
+* ``nrf5340pdk_nrf5340_cpuappns`` for the non-secure domain.
 
-When built for the ``nrf5340_dk_nrf5340_cpuappns`` board, the :ref:`nrf9160_ug_secure_partition_manager` is automatically included in the build.
+When built for the ``nrf5340pdk_nrf5340_cpuappns`` board, the :ref:`nrf9160_ug_secure_partition_manager` is automatically included in the build.
 
 Inter-core communication
 ========================
@@ -127,10 +127,10 @@ Depending on the sample, you must program only the application core (for example
    On nRF53, the application core is responsible for starting the network core and connecting its GPIO pins.
    Therefore, to run any sample on nRF53, the application core must be programmed, even if the firmware is supposed to run only on the network core.
    You can use the :ref:`zephyr:hello_world` sample for this purpose.
-   For details, see the code in :file:`zephyr/boards/arm/nrf5340_dk_nrf5340/nrf5340_cpunet_reset.c`.
+   For details, see the code in :file:`zephyr/boards/arm/nrf5340pdk_nrf5340/nrf5340_cpunet_reset.c`.
 
 Build and program both samples separately by following the instructions in :ref:`gs_programming_ses`.
-Make sure to use ``nrf5340_dk_nrf5340_cpunet`` as board name when building the network sample, and ``nrf5340_dk_nrf5340_cpuapp`` when building the application sample.
+Make sure to use ``nrf5340pdk_nrf5340_cpunet`` as board name when building the network sample, and ``nrf5340pdk_nrf5340_cpuapp`` when building the application sample.
 
 
 Programming from the command line

--- a/doc/nrf/ug_nrf9160.rst
+++ b/doc/nrf/ug_nrf9160.rst
@@ -32,12 +32,12 @@ The M33 TrustZone divides the application MCU into secure and non-secure domains
 When the MCU boots, it always starts executing from the secure area.
 The secure bootloader chain starts the :ref:`nrf9160_ug_secure_partition_manager`, which configures a part of memory and peripherals to be non-secure and then jumps to the main application located in the non-secure area.
 
-In Zephyr, :ref:`nrf9160_pca10090` is divided into two different boards:
+In Zephyr, :ref:`zephyr:nrf9160dk_nrf9160` is divided into two different build targets:
 
-* ``nrf9160_pca10090`` for firmware in the secure domain
-* ``nrf9160_pca10090ns`` for firmware in the non-secure domain
+* ``nrf9160dk_nrf9160`` for firmware in the secure domain
+* ``nrf9160dk_nrf9160ns`` for firmware in the non-secure domain
 
-Make sure to select the suitable board name when building your application.
+Make sure to select the suitable build target when building your application.
 
 
 Secure bootloader chain
@@ -58,7 +58,7 @@ All nRF9160 samples require the :ref:`secure_partition_manager` sample.
 It provides a reference implementation of a Secure Partition Manager firmware.
 This firmware is required to set up the nRF9160 DK so that it can run user applications in the non-secure domain.
 
-The Secure Partition Manager sample is automatically included in the build for the ``nrf9160_pca10090ns`` board.
+The Secure Partition Manager sample is automatically included in the build for the ``nrf9160dk_nrf9160ns`` build target.
 To disable the automatic inclusion of the Secure Partition Manager sample, set the option :option:`CONFIG_SPM` to "n" in the project configuration.
 
 
@@ -66,7 +66,7 @@ Application
 -----------
 
 The user application runs in the non-secure domain.
-Therefore, it must be built for the ``nrf9160_pca10090ns`` board.
+Therefore, it must be built for the ``nrf9160dk_nrf9160ns`` build target.
 
 The application image might require other images to be present.
 Depending on the configuration, all these images can be built at the same time in a :ref:`multi-image build <ug_multi_image>`.
@@ -227,9 +227,9 @@ To program the HEX file, use nrfjprog (which is part of the `nRF Command Line To
 
 If you want to route some pins differently from what is done in the
 preprogrammed firmware, program the :ref:`zephyr:hello_world` sample instead of the preprogrammed firmware.
-Configure the sample (located under ``samples/hello_world``) for the nrf52840_pca10090 board.
+Configure the sample (located under ``samples/hello_world``) for the nrf9160dk_nrf52840 board.
 All configuration options can be found under **Board configuration** in menuconfig.
-See :ref:`zephyr:nrf52840_pca10090` for detailed information about the board.
+See :ref:`zephyr:nrf9160dk_nrf52840` for detailed information about the board.
 
 Available drivers, libraries, and samples
 *****************************************

--- a/doc/release-notes-1.2.0.rst
+++ b/doc/release-notes-1.2.0.rst
@@ -215,7 +215,7 @@ The application core (nrf5340_dk_nrf5340_cpuapp) can run Bluetooth LE samples fr
   * :ref:`radio_test` - runs on the network core and demonstrates how to configure the radio in a specific mode and then test its performance.
     This sample was ported from the nRF5 SDK.
 
-* Added support for the :ref:`nRF5340 PDK board (PCA10095)<nrf5340_dk_nrf5340>` with board targets nrf5340_dk_nrf5340_cpunet and nrf5340_dk_nrf5340_cpuapp.
+* Added support for the nRF5340 PDK board (PCA10095) with board targets nrf5340_dk_nrf5340_cpunet and nrf5340_dk_nrf5340_cpuapp.
 * Updated nrfx to support nRF5340.
 * Added NFC support.
 

--- a/samples/nrf9160/http_application_update/README.rst
+++ b/samples/nrf9160/http_application_update/README.rst
@@ -38,7 +38,7 @@ Building and running
 
 .. include:: /includes/build_and_run.txt
 
-The sample is built as a non-secure firmware image for the nrf9160_pca10090ns board.
+The sample is built as a non-secure firmware image for the nrf9160dk_nrf9160ns build target.
 Because of this, it automatically includes the :ref:`secure_partition_manager`.
 The sample also uses MCUboot, which is automatically built and merged into the final HEX file when building the sample.
 

--- a/samples/nrf9160/lte_ble_gateway/README.rst
+++ b/samples/nrf9160/lte_ble_gateway/README.rst
@@ -56,14 +56,14 @@ The first port is connected to the main controller (nRF9160) on the board, while
 Before you program the sample application onto the main controller, you must program the :ref:`zephyr:bluetooth-hci-uart-sample` sample onto the board controller:
 
 1. Put the **SW5** switch (marked debug/prog) in the **NRF52** position to program the board controller.
-#. Build the :ref:`zephyr:bluetooth-hci-uart-sample` sample for the nrf52840_pca10090 board and program it.
+#. Build the :ref:`zephyr:bluetooth-hci-uart-sample` sample for the nrf9160dk_nrf52840 build target and program it.
 #. Verify that the sample was programmed successfully by connecting to the second serial port with a terminal emulator (for example, PuTTY) and checking the output.
    See :ref:`putty` for the required settings.
 
 After programming the board controller, you must program the LTE Sensor Gateway sample (which includes the :ref:`secure_partition_manager` sample) to the main controller:
 
 1. Put the **SW5** switch (marked debug/prog) in the **NRF91** position to program the main controller.
-#. Build the LTE Sensor Gateway sample (this sample) for the nrf9160_pca10090ns board and program it.
+#. Build the LTE Sensor Gateway sample (this sample) for the nrf9160dk_nrf9160ns build target and program it.
 #. Verify that the sample was programmed successfully by connecting to the first serial port with a terminal emulator (for example, PuTTY) and checking the output.
    See :ref:`putty` for the required settings.
 

--- a/samples/nrf9160/spm/README.rst
+++ b/samples/nrf9160/spm/README.rst
@@ -32,15 +32,15 @@ Requirements for the application firmware
 =========================================
 
 * The application firmware must be located in the slot_ns flash partition.
-  For more details, see the `nrf9160_pca10090_partition_conf.dts`_ file in the nrf9160_pca10090 board definition.
+  For more details, see the `nrf9160dk_nrf9160_partition_conf.dts`_ file in the nrf9160dk_nrf9160 board definition.
   Note that if you build your application firmware with the |NCS|, this requirement is automatically fulfilled.
 
-* The application firmware must be built as a non-secure firmware for the nrf9160_pca10090ns board.
+* The application firmware must be built as a non-secure firmware for the nrf9160dk_nrf9160ns build target.
 
 Automatic building of SPM
 =========================
 
-The sample is automatically built by the non-secure applications when the nrf9160_pca10090ns board is used.
+The sample is automatically built by the non-secure applications when the nrf9160dk_nrf9160ns build target is used.
 However, it is not a part of the non-secure application.
 
 Instead of programming SPM and the non-secure application at the same time, you might want to program them individually.
@@ -63,7 +63,7 @@ Building and running
 
 .. include:: /includes/build_and_run.txt
 
-The sample is built as a secure firmware image for the nrf9160_pca10090 board.
+The sample is built as a secure firmware image for the nrf9160dk_nrf9160 board.
 See `Automatic building of SPM`_ if you want to program it independently from the non-secure application firmware.
 
 


### PR DESCRIPTION
Update the documentation with the new board names and build
targets.

Ref: NCSDK-4887

Signed-off-by: Ruth Fuchss <ruth.fuchss@nordicsemi.no>