### PR TITLE
applications: nrf_desktop: Add BLE peer disconnecting state

### DIFF
--- a/applications/nrf_desktop/src/events/ble_event.h
+++ b/applications/nrf_desktop/src/events/ble_event.h
@@ -27,6 +27,7 @@ extern "C" {
 /** @brief Peer connection state list. */
 #define PEER_STATE_LIST		\
 	X(DISCONNECTED)		\
+	X(DISCONNECTING)	\
 	X(CONNECTED)		\
 	X(SECURED)		\
 	X(CONN_FAILED)

--- a/applications/nrf_desktop/src/modules/ble_bond.c
+++ b/applications/nrf_desktop/src/modules/ble_bond.c
@@ -838,10 +838,16 @@ static bool event_handler(const struct event_header *eh)
 
 			if (bt_info.id != get_bt_stack_peer_id(cur_peer_id)) {
 				LOG_INF("Connection for old id - ignored");
-				bt_conn_disconnect(event->id,
-					BT_HCI_ERR_REMOTE_USER_TERM_CONN);
+				int err = bt_conn_disconnect(event->id,
+					      BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 
-				 return false;
+				if (err && (err != -ENOTCONN)) {
+					LOG_ERR("Cannot disconnect peer (err=%d)",
+						err);
+					module_set_state(MODULE_STATE_ERROR);
+				}
+
+				return false;
 			}
 
 			LOG_INF("Erased peer");

--- a/applications/nrf_desktop/src/modules/ble_latency.c
+++ b/applications/nrf_desktop/src/modules/ble_latency.c
@@ -46,11 +46,14 @@ static void security_timeout_fn(struct k_work *w)
 	int err = bt_conn_disconnect(active_conn,
 				     BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 
-	if (err == -ENOTCONN) {
-		err = 0;
+	LOG_WRN("Security establishment failed");
+
+	if (err && (err != -ENOTCONN)) {
+		LOG_ERR("Cannot disconnect peer (err=%d)", err);
+		module_set_state(MODULE_STATE_ERROR);
+	} else {
+		LOG_INF("Peer disconnected");
 	}
-	LOG_WRN("Security establishment failed - device %s",
-		err ? "failed to disconnect" : "disconnected");
 }
 
 static void set_ble_latency(bool low_latency)

--- a/applications/nrf_desktop/src/modules/ble_scan.c
+++ b/applications/nrf_desktop/src/modules/ble_scan.c
@@ -608,6 +608,7 @@ static bool event_handler(const struct event_header *eh)
 		switch (event->state) {
 		case PEER_STATE_CONNECTED:
 		case PEER_STATE_SECURED:
+		case PEER_STATE_DISCONNECTING:
 			/* Ignore */
 			break;
 		case PEER_STATE_CONN_FAILED:

--- a/applications/nrf_desktop/src/modules/ble_state.c
+++ b/applications/nrf_desktop/src/modules/ble_state.c
@@ -54,13 +54,11 @@ static void disconnect_peer(struct bt_conn *conn)
 {
 	int err = bt_conn_disconnect(conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 
-	if (err == -ENOTCONN) {
-		err = 0;
-	}
-	LOG_WRN("Device %s", err ? "failed to disconnect" : "disconnected");
-
-	if (err) {
+	if (err && (err != -ENOTCONN)) {
+		LOG_ERR("Failed to disconnect peer (err=%d)", err);
 		module_set_state(MODULE_STATE_ERROR);
+	} else {
+		LOG_INF("Peer disconnected");
 	}
 }
 
@@ -424,6 +422,7 @@ static bool event_handler(const struct event_header *eh)
 			/* Connection object is no longer in use. */
 			bt_conn_unref(event->id);
 			break;
+
 		default:
 			/* Ignore. */
 			break;

--- a/applications/nrf_desktop/src/modules/hid_state.c
+++ b/applications/nrf_desktop/src/modules/hid_state.c
@@ -1324,6 +1324,7 @@ static bool handle_ble_peer_event(const struct ble_peer_event *event)
 		connect_subscriber(event->id, false);
 		break;
 
+	case PEER_STATE_DISCONNECTING:
 	case PEER_STATE_DISCONNECTED:
 		disconnect_subscriber(event->id);
 		break;

--- a/applications/nrf_desktop/src/modules/hids.c
+++ b/applications/nrf_desktop/src/modules/hids.c
@@ -501,6 +501,7 @@ static void notify_hids(const struct ble_peer_event *event)
 
 		break;
 
+	case PEER_STATE_DISCONNECTING:
 	case PEER_STATE_CONN_FAILED:
 		/* No action */
 		break;

--- a/applications/nrf_desktop/src/modules/led_state.c
+++ b/applications/nrf_desktop/src/modules/led_state.c
@@ -112,6 +112,7 @@ static bool event_handler(const struct event_header *eh)
 			connected--;
 			break;
 		case PEER_STATE_CONN_FAILED:
+		case PEER_STATE_DISCONNECTING:
 			/* Ignore */
 			break;
 		default:

--- a/applications/nrf_desktop/src/modules/power_manager.c
+++ b/applications/nrf_desktop/src/modules/power_manager.c
@@ -204,6 +204,7 @@ static bool event_handler(const struct event_header *eh)
 
 		case PEER_STATE_SECURED:
 		case PEER_STATE_CONN_FAILED:
+		case PEER_STATE_DISCONNECTING:
 			/* No action */
 			break;
 


### PR DESCRIPTION
Change adds a new BLE peer state (disconnecting). This state is used to let application modules prepare for a planned disconnection.