### PR TITLE
bluetooth: hids_c: Fix updating report size

### DIFF
--- a/subsys/bluetooth/services/hids_c.c
+++ b/subsys/bluetooth/services/hids_c.c
@@ -993,7 +993,13 @@ static u8_t rep_notify_process(struct bt_conn *conn,
 		LOG_WRN("Data size too big, truncating");
 		length = UINT8_MAX;
 	}
-	rep->size = (u8_t)length;
+	/* Zephyr uses the callback with data set to NULL to inform about the
+	 * subscription removal. Do not update the report size in that case.
+	 */
+	if (data != NULL) {
+		rep->size = (u8_t)length;
+	}
+
 	return rep->notify_cb(rep->hids_c, rep, 0, data);
 }
 


### PR DESCRIPTION
Do not update the report size if length is set to 0 and data is set to NULL. The callback with these values informs about subscription removal.