### PR TITLE
partition_manager: allow static configuration to fill region

### DIFF
--- a/scripts/partition_manager.py
+++ b/scripts/partition_manager.py
@@ -568,6 +568,10 @@ def verify_static_conf(size, start, placement_strategy, static_conf):
     ends = {start} | {c['address'] + c['size'] for c in static_conf.values() if 'size' in c}
     gaps = list(zip(sorted(ends - starts), sorted(starts - ends)))
 
+    # The whole region is filled, which is valid.
+    if len(gaps) == 0:
+        return
+
     if placement_strategy == START_TO_END:
         start_end_correct = gaps[0][0] == start + size
     else:


### PR DESCRIPTION
Prior this, an error whas issued if a statically defined partition
used all the area in its region.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>