### PR TITLE
samples: lwm2m_client: Sample improvements

### DIFF
--- a/include/modem/modem_info.h
+++ b/include/modem/modem_info.h
@@ -59,6 +59,7 @@ enum modem_info {
 	MODEM_INFO_IMSI,	/**< Mobile subscriber identity. */
 	MODEM_INFO_IMEI,	/**< Modem serial number. */
 	MODEM_INFO_DATE_TIME,	/**< Mobile network time and date */
+	MODEM_INFO_APN,		/**< Access point name. */
 	MODEM_INFO_COUNT,	/**< Number of legal elements in the enum. */
 };
 
@@ -85,6 +86,7 @@ struct network_param {
 	struct lte_param nbiot_mode; /**< NB-IoT support mode. */
 	struct lte_param gps_mode; /**< GPS support mode. */
 	struct lte_param date_time; /**< Mobile network time and date */
+	struct lte_param apn; /**< Access point name (string). */
 
 	double cellid_dec; /**< Cell ID of the device (in decimal format). */
 	char network_mode[MODEM_INFO_NETWORK_MODE_MAX_SIZE];

--- a/lib/modem_info/modem_info.c
+++ b/lib/modem_info/modem_info.c
@@ -65,6 +65,7 @@ LOG_MODULE_REGISTER(modem_info);
 #define IMSI_DATA_NAME		"imsi"
 #define MODEM_IMEI_DATA_NAME	"imei"
 #define DATE_TIME_DATA_NAME	"dateTime"
+#define APN_DATA_NAME		"apn"
 
 #define RSRP_PARAM_INDEX	1
 #define RSRP_PARAM_COUNT	5
@@ -116,6 +117,9 @@ LOG_MODULE_REGISTER(modem_info);
 
 #define DATE_TIME_PARAM_INDEX	1
 #define DATE_TIME_PARAM_COUNT	2
+
+#define APN_PARAM_INDEX		3
+#define APN_PARAM_COUNT		7
 
 struct modem_info_data {
 	const char *cmd;
@@ -293,6 +297,14 @@ static const struct modem_info_data date_time_data = {
 	.data_type	= AT_PARAM_TYPE_STRING,
 };
 
+static const struct modem_info_data apn_data = {
+	.cmd		= AT_CMD_PDP_CONTEXT,
+	.data_name	= APN_DATA_NAME,
+	.param_index	= APN_PARAM_INDEX,
+	.param_count	= APN_PARAM_COUNT,
+	.data_type	= AT_PARAM_TYPE_STRING,
+};
+
 static const struct modem_info_data *const modem_data[] = {
 	[MODEM_INFO_RSRP]	= &rsrp_data,
 	[MODEM_INFO_CUR_BAND]	= &band_data,
@@ -315,6 +327,7 @@ static const struct modem_info_data *const modem_data[] = {
 	[MODEM_INFO_IMSI]	= &imsi_data,
 	[MODEM_INFO_IMEI]	= &imei_data,
 	[MODEM_INFO_DATE_TIME]	= &date_time_data,
+	[MODEM_INFO_APN]	= &apn_data,
 };
 
 static rsrp_cb_t modem_info_rsrp_cb;

--- a/lib/modem_info/modem_info_params.c
+++ b/lib/modem_info/modem_info_params.c
@@ -32,6 +32,7 @@ int modem_info_params_init(struct modem_param_info *modem)
 	modem->network.nbiot_mode.type		= MODEM_INFO_NBIOT_MODE;
 	modem->network.gps_mode.type		= MODEM_INFO_GPS_MODE;
 	modem->network.date_time.type		= MODEM_INFO_DATE_TIME;
+	modem->network.apn.type			= MODEM_INFO_APN;
 
 	modem->sim.uicc.type			= MODEM_INFO_UICC;
 	modem->sim.iccid.type			= MODEM_INFO_ICCID;
@@ -144,6 +145,7 @@ int modem_info_params_get(struct modem_param_info *modem)
 		ret += modem_data_get(&modem->network.lte_mode);
 		ret += modem_data_get(&modem->network.nbiot_mode);
 		ret += modem_data_get(&modem->network.gps_mode);
+		ret += modem_data_get(&modem->network.apn);
 
 		if (IS_ENABLED(CONFIG_MODEM_INFO_ADD_DATE_TIME)) {
 			ret += modem_data_get(&modem->network.date_time);

--- a/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_connmon.c
+++ b/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_connmon.c
@@ -52,6 +52,7 @@ static void modem_data_update(struct k_work *work)
 		sizeof(modem_param.network.current_operator.value_string),
 		LWM2M_RES_DATA_FLAG_RO);
 
+	lwm2m_engine_set_u32("4/0/8", (u32_t)modem_param.network.cellid_dec);
 	lwm2m_engine_set_u16("4/0/9", modem_param.network.mnc.value);
 	lwm2m_engine_set_u16("4/0/10", modem_param.network.mcc.value);
 

--- a/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_connmon.c
+++ b/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_connmon.c
@@ -85,8 +85,9 @@ static void modem_signal_update(struct k_work *work)
 {
 	static u32_t timestamp_prev;
 
-	if (k_uptime_get_32() - timestamp_prev <
-	    K_SECONDS(CONFIG_APP_HOLD_TIME_RSRP)) {
+	if ((timestamp_prev != 0) &&
+	    (k_uptime_get_32() - timestamp_prev <
+	     CONFIG_APP_HOLD_TIME_RSRP * MSEC_PER_SEC)) {
 		return;
 	}
 

--- a/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_connmon.c
+++ b/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_connmon.c
@@ -48,8 +48,8 @@ static void modem_data_update(struct k_work *work)
 	/* APN */
 	lwm2m_engine_create_res_inst("4/0/7/0");
 	lwm2m_engine_set_res_data("4/0/7/0",
-		modem_param.network.current_operator.value_string,
-		sizeof(modem_param.network.current_operator.value_string),
+		modem_param.network.apn.value_string,
+		strlen(modem_param.network.apn.value_string),
 		LWM2M_RES_DATA_FLAG_RO);
 
 	lwm2m_engine_set_u32("4/0/8", (u32_t)modem_param.network.cellid_dec);

--- a/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_device.c
+++ b/samples/nrf9160/lwm2m_client/src/lwm2m/lwm2m_device.c
@@ -20,6 +20,7 @@ LOG_MODULE_REGISTER(app_lwm2m_device, CONFIG_APP_LOG_LEVEL);
 #define CLIENT_DEVICE_TYPE	"OMA-LWM2M Client"
 #define CLIENT_HW_VER		CONFIG_SOC
 #define CLIENT_FLASH_SIZE	PM_MCUBOOT_SECONDARY_SIZE
+#define REBOOT_DELAY		K_SECONDS(1)
 
 static u8_t bat_idx = LWM2M_DEVICE_PWR_SRC_TYPE_BAT_INT;
 static int bat_mv = 3800;
@@ -30,13 +31,20 @@ static int usb_ma = 900;
 static u8_t bat_status = LWM2M_DEVICE_BATTERY_STATUS_CHARGING;
 static int mem_total = (CLIENT_FLASH_SIZE / 1024);
 
+static struct k_delayed_work reboot_work;
+
+static void reboot_work_handler(struct k_work *work)
+{
+	LOG_PANIC();
+	sys_reboot(0);
+}
+
 static int device_reboot_cb(u16_t obj_inst_id)
 {
 	LOG_INF("DEVICE: Reboot in progress");
-	LOG_PANIC();
-	sys_reboot(0);
 
-	/* wont reach this */
+	k_delayed_work_submit(&reboot_work, REBOOT_DELAY);
+
 	return 0;
 }
 
@@ -49,6 +57,8 @@ static int device_factory_default_cb(u16_t obj_inst_id)
 
 int lwm2m_init_device(char *serial_num)
 {
+	k_delayed_work_init(&reboot_work, reboot_work_handler);
+
 	lwm2m_engine_set_res_data("3/0/0", CLIENT_MANUFACTURER,
 				  sizeof(CLIENT_MANUFACTURER),
 				  LWM2M_RES_DATA_FLAG_RO);

--- a/samples/nrf9160/lwm2m_client/src/main.c
+++ b/samples/nrf9160/lwm2m_client/src/main.c
@@ -224,6 +224,10 @@ void main(void)
 
 	/* Setup LwM2M */
 	(void)memset(&client, 0x0, sizeof(client));
+
+	/* Workaround for improperly initialized socket fd in lwm2m engine. */
+	client.sock_fd = -1;
+
 	ret = lwm2m_setup();
 	if (ret < 0) {
 		LOG_ERR("Cannot setup LWM2M fields (%d)", ret);


### PR DESCRIPTION
* Added a delay to the reboot request, to allow the LWM2M engine to send a response,
* Set proper APN string,
* Add Cell ID information

Note, that Cell ID needs a fix from the Zephyr upstream (already merged) to be fully functional, should happen in next upmerge.