### PR TITLE
subsys: remove leftover `enhanced_shockburst` folder

### DIFF
--- a/subsys/enhanced_shockburst/CMakeLists.txt
+++ b/subsys/enhanced_shockburst/CMakeLists.txt
@@ -1,7 +1,0 @@
-#
-# Copyright (c) 2019 Nordic Semiconductor ASA
-#
-# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
-#
-zephyr_library()
-zephyr_library_sources_ifdef(CONFIG_ESB nrf_esb.c)


### PR DESCRIPTION
Remove leftover file, only one keeping the folder.
Should have been removed with commit: c78c82d80d15251