### PR TITLE
samples: nrf9160: lwm2m_carrier: Add printing of all events

### DIFF
--- a/samples/nrf9160/lwm2m_carrier/src/main.c
+++ b/samples/nrf9160/lwm2m_carrier/src/main.c
@@ -51,8 +51,14 @@ int lwm2m_carrier_event_handler(const lwm2m_carrier_event_t *event)
 	case LWM2M_CARRIER_EVENT_DISCONNECTED:
 		printk("LWM2M_CARRIER_EVENT_DISCONNECTED\n");
 		break;
+	case LWM2M_CARRIER_EVENT_BOOTSTRAPPED:
+		printk("LWM2M_CARRIER_EVENT_BOOTSTRAPPED\n");
+		break;
 	case LWM2M_CARRIER_EVENT_READY:
 		printk("LWM2M_CARRIER_EVENT_READY\n");
+		break;
+	case LWM2M_CARRIER_EVENT_DEFERRED:
+		printk("LWM2M_CARRIER_EVENT_DEFERRED\n");
 		break;
 	case LWM2M_CARRIER_EVENT_FOTA_START:
 		printk("LWM2M_CARRIER_EVENT_FOTA_START\n");


### PR DESCRIPTION
Add printing of missing events in LwM2M carrier library.

Signed-off-by: Jan Tore Guggedal <jantore.guggedal@nordicsemi.no>