### PR TITLE
tests: unity: Fix compilation of example_test

### DIFF
--- a/tests/unity/CMakeLists.txt
+++ b/tests/unity/CMakeLists.txt
@@ -41,6 +41,7 @@ function(test_runner_generate test_file_path)
   add_custom_command(
     COMMAND ${RUBY_EXECUTABLE}
     ${CMOCK_DIR}/vendor/unity/auto/generate_test_runner.rb
+    --main_name=unity_main
     ${test_file_path} ${output_file}
     DEPENDS ${test_file_path}
     OUTPUT ${output_file}

--- a/tests/unity/example_test/src/example_test.c
+++ b/tests/unity/example_test/src/example_test.c
@@ -37,3 +37,14 @@ void test_uut_init_with_param_check(void)
 	err = uut_init(NULL);
 	TEST_ASSERT_EQUAL(-1, err);
 }
+
+/* It is required to be added to each test. That is because unity is using
+ * different main signature (returns int) and zephyr expects main which does
+ * not return value.
+ */
+extern int unity_main(void);
+
+void main(void)
+{
+	(void)unity_main();
+}


### PR DESCRIPTION
Example did not compile because of difference between main() signature.
In zephyr it is expected to be 'void main(void)' but unity generates
'int main(void)'. It could be solved by sending upstream patch to unity
but that is external dependancy.

Solution is using main_name option of unity to give main custom name and
implement actual main function (aligned with zephyr prototype) in test
file.

It started to fail once https://github.com/zephyrproject-rtos/zephyr/commit/66bdb76e7c20753c34747a4cc2d0d17f2084971c got introduced to zephyr.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>