### PR TITLE
manifest: update manifest to include nrf security config options

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -94,7 +94,7 @@ manifest:
       path: modules/lib/mcumgr
     - name: nrfxlib
       path: nrfxlib
-      revision: b4a814f8a55f75d74c280ee6da35105e42920b5e
+      revision: d7916f7f758fa81f2536252482c46b08fc99fa5c
     # Other third-party repositories.
     - name: cmock
       path: test/cmock


### PR DESCRIPTION
This commit updates the manifest to include nrf security config options
for HMAC_DRBG and AES_ROM tables includes in nrfxlib#148.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>