### PR TITLE
partition_manager: fix issue with static partitions

### DIFF
--- a/scripts/partition_manager.py
+++ b/scripts/partition_manager.py
@@ -540,7 +540,10 @@ def solve_simple_region(pm_config, start, size, placement_strategy, region_name,
         address = start + size - reserved
     else:
         address = start + reserved
-    for partition_name in pm_config:
+
+    # Static partitions are now added to the pm_config dict. These partitions
+    # already have their 'address' set, so skip these partitions in this loop.
+    for partition_name in [k for k in pm_config if 'address' not in pm_config[k]]:
         if placement_strategy == END_TO_START:
             address -= pm_config[partition_name]['size']
 


### PR DESCRIPTION
If static partitions were configured in a region with END_TO_START
or START_TO_END placement strategy, they would handled correctly.

This commit fixes this issue by skipping these partitions when
calculating the address of the partitions.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>