### PR TITLE
doc: Updated the links in the user guides

### DIFF
--- a/doc/nrf/links.txt
+++ b/doc/nrf/links.txt
@@ -50,7 +50,7 @@
 
 .. _`nRF Connect Programmer`: https://infocenter.nordicsemi.com/topic/ug_nc_programmer/UG/nrf_connect_programmer/ncp_introduction.html
 
-.. _`Updating the nRF9160 DK cellular modem`: https://infocenter.nordicsemi.com/topic/ug_nc_programmer/UG/nrf_connect_programmer/ncp_updating_modem.html
+.. _`Updating the nRF9160 DK cellular modem`: https://infocenter.nordicsemi.com/topic/ug_nc_programmer/UG/nrf_connect_programmer/ncp_updating_modem_nrf9160dk.html
 
 .. _`nRF9160 DK board control section in the nRF9160 DK User Guide`: https://infocenter.nordicsemi.com/topic/ug_nrf91_dk/UG/nrf91_DK/board_controller.html
 
@@ -69,11 +69,10 @@
 .. _`Programming DK boards using nrfjprog`: https://infocenter.nordicsemi.com/topic/ug_nrf5x_cltools/UG/cltools/nrf5x_nrfjprogexe.html
 .. _`Nordic Thingy:91 User Guide`: https://infocenter.nordicsemi.com/topic/ug_thingy91/UG/thingy91/intro/frontpage.html
 
-.. _`Programming the nRF9160 SiP of Thingy:91 through USB`: https://infocenter.nordicsemi.com/topic/ug_thingy91/UG/thingy91/firmware_update/updating_appn_fw_9160_mcu.html
+.. _`Programming applications on Nordic Thingy:91`: https://infocenter.nordicsemi.com/topic/ug_nc_programmer/UG/nrf_connect_programmer/ncp_programming_appln_thingy91.html
 
-.. _`Programming the nRF52840 SoC of Thingy:91 through USB`: https://infocenter.nordicsemi.com/topic/ug_thingy91/UG/thingy91/firmware_update/updatg_appln_fw_nrf52840_mcu.html
 
-.. _`Updating the Thingy:91 modem`: https://infocenter.nordicsemi.com/topic/ug_thingy91/UG/thingy91/firmware_update/updating_modem_fw.html
+.. _`Programming the Thingy:91 modem`: https://infocenter.nordicsemi.com/topic/ug_nc_programmer/UG/nrf_connect_programmer/ncp_updating_modem_thingy91_intro.html
 
 .. _`nRF52 Series`: https://infocenter.nordicsemi.com/topic/struct_nrf52/struct/nrf52.html
 

--- a/doc/nrf/ug_thingy91.rst
+++ b/doc/nrf/ug_thingy91.rst
@@ -116,16 +116,19 @@ In this method, the Thingy:91 is connected directly to your PC through USB.
 This method makes use of the :doc:`mcuboot:index` feature and the inbuilt serial recovery mode of Thingy:91.
 You can program either the nRF9160 SiP or the nRF52840 SoC component on the Thingy:91.
 
-For the detailed procedures for programming a Thingy:91 using nRF Connect Programmer, see the following documentation:
+Alternatively, you can use an external debug probe such as nRF9160 DK or any J-Link device supporting ARM Cortex-M33 to program applications on a Thingy:91.
 
-* `Programming the nRF9160 SiP of Thingy:91 through USB`_
-* `Programming the nRF52840 SoC of Thingy:91 through USB`_
+See `Programming applications on Nordic Thingy:91`_ for the detailed procedures to program a Thingy:91 using nRF Connect Programmer.
 
 Updating the modem firmware
 ===========================
 
-You can update the modem firmware of Thingy:91 by using an external debug probe such as nRF9160 DK or any J-Link device supporting ARM Cortex-M33.
-See `Updating the Thingy:91 modem`_ for the detailed steps to update the modem firmware.
+You can update the modem firmware of Thingy:91 using any of the following methods:
+
+* Using USB (MCUboot)
+* Using an external debug probe such as nRF9160 DK or any J-Link device supporting ARM Cortex-M33
+
+See `Programming the Thingy:91 modem`_ for the detailed steps to update the modem firmware.
 
 .. _building_pgming:
 


### PR DESCRIPTION
Updated the links in the 'Working with Thingy:91' and the
'Working with nRF9160' user guides to point to the latest
documentation in nRF Connect Programmer user guide in infocenter.

Signed-off-by: Uma Praseeda <uma.praseeda@nordicsemi.no>