### PR TITLE
applications: asset_tracker: set sensors started flag.

### DIFF
--- a/applications/asset_tracker/src/main.c
+++ b/applications/asset_tracker/src/main.c
@@ -1182,6 +1182,7 @@ void sensors_start(void)
 			break;
 		}
 		set_gps_enable(start_gps);
+		started = true;
 	}
 }
 


### PR DESCRIPTION
Set the started flag to true.
Lost in a previous merge.

Signed-off-by: Justin Morton <justin.morton@nordicsemi.no>