### PR TITLE
lib: modem_info: do not fail on multi-line parsing

### DIFF
--- a/lib/modem_info/modem_info.c
+++ b/lib/modem_info/modem_info.c
@@ -371,7 +371,11 @@ static int modem_info_parse(const struct modem_info_data *modem_data,
 	err = at_parser_max_params_from_str(buf, NULL, &m_param_list,
 					    modem_data->param_count);
 
-	if (err != 0) {
+	if (err == -EAGAIN) {
+		LOG_DBG("More items exist to parse for: %s",
+			modem_data->data_name);
+		err = 0;
+	} else if (err != 0) {
 		return err;
 	}
 


### PR DESCRIPTION
Do not return failure if `at_parser_max_params_from_str` returns
`-EAGAIN`, as it means there are more items to parse.  For now,
just process the first item and quit.
Relates to TG91-215.

Signed-off-by: Justin Morton <justin.morton@nordicsemi.no>