### PR TITLE
cmake: add sub-image build step to ninja console pool

### DIFF
--- a/cmake/multi_image.cmake
+++ b/cmake/multi_image.cmake
@@ -208,6 +208,7 @@ function(add_child_image_from_source)
     BUILD_COMMAND ${CMAKE_COMMAND} --build . -- ${multi_image_build_args}
     INSTALL_COMMAND ""
     BUILD_ALWAYS True
+    USES_TERMINAL_BUILD True
     )
 
   foreach(kconfig_target


### PR DESCRIPTION
This allows the sub-ninja direct access to the console, which in turn
allows it to print quieter output as its users generally expect.

This avoids a long scrolling output when the user is building
interactively at the console.

