### PR TITLE
manifest: Update nrfxlib with new BLE controller and MPSL

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -94,7 +94,7 @@ manifest:
       path: modules/lib/mcumgr
     - name: nrfxlib
       path: nrfxlib
-      revision: 0d4d6e0be424c90660684c755758f0a1b97c32ed
+      revision: f8a91464f38df43ab2ba894add939c16a1fc9046
     # Other third-party repositories.
     - name: cmock
       path: test/cmock


### PR DESCRIPTION
The BLE controller now supports the HCI command LE Read Supported States.

Signed-off-by: Rubin Gerritsen <rubin.gerritsen@nordicsemi.no>

See https://github.com/NordicPlayground/nrfxlib/pull/162