### PR TITLE
bootloader: Boot S0 before S1 if versions match

### DIFF
--- a/samples/bootloader/src/main.c
+++ b/samples/bootloader/src/main.c
@@ -59,7 +59,7 @@ void main(void)
 	const struct fw_info *s0_info = fw_info_find(s0_addr);
 	const struct fw_info *s1_info = fw_info_find(s1_addr);
 
-	if (!s1_info || (s0_info->version > s1_info->version)) {
+	if (!s1_info || (s0_info->version >= s1_info->version)) {
 		validate_and_boot(s0_info, BOOT_SLOT_0);
 		validate_and_boot(s1_info, BOOT_SLOT_1);
 	} else {


### PR DESCRIPTION
This was the behavior until e47babbc, but the reasons for changing it
don't exist anymore, so revert the change.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>