### PR TITLE
lib: lte_lc: add dynamically adjustable psm edrx setting

### DIFF
--- a/include/modem/lte_lc.h
+++ b/include/modem/lte_lc.h
@@ -182,9 +182,21 @@ int lte_lc_power_off(void);
  */
 int lte_lc_normal(void);
 
-/** @brief Function for requesting modem to go to or disable
- * power saving mode (PSM) with default settings defined in kconfig.
+/** @brief Function for setting modem PSM parameters:
+ * requested periodic TAU (RPTAU) and requested active time (RAT)
+ * to be used when psm mode is subsequently enabled using `lte_lc_psm_req`.
  * For reference see 3GPP 27.007 Ch. 7.38.
+ *
+ * @param rptau Requested periodic TAU.
+ * @param rat Requested active time
+ *
+ * @return Zero on success or (negative) error code otherwise.
+ */
+int lte_lc_psm_param_set(const char *rptau, const char *rat);
+
+/** @brief Function for requesting modem to enable or disable
+ * power saving mode (PSM) using default Kconfig value or as set using
+ * `lte_lc_psm_param_set`.
  *
  * @return Zero on success or (negative) error code otherwise.
  */
@@ -203,8 +215,19 @@ int lte_lc_psm_req(bool enable);
  */
 int lte_lc_psm_get(int *tau, int *active_time);
 
-/** @brief Function for requesting modem to use eDRX or disable
- * use of values defined in kconfig.
+/** @brief Function for setting modem eDRX value to be used when
+ * eDRX is subsequently enabled using `lte_lc_edrx_req`.
+ * For reference see 3GPP 27.007 Ch. 7.40.
+ *
+ * @param edrx eDRX value
+ *
+ * @return Zero on success or (negative) error code otherwise.
+ */
+int lte_lc_edrx_param_set(const char *edrx);
+
+/** @brief Function for requesting modem to enable or disable
+ * use of eDRX using values set by `lte_lc_edrx_param_set`. The
+ * default values are defined in kconfig.
  * For reference see 3GPP 27.007 Ch. 7.40.
  *
  * @return Zero on success or (negative) error code otherwise.

--- a/lib/lte_link_control/lte_lc.c
+++ b/lib/lte_link_control/lte_lc.c
@@ -108,10 +108,12 @@ static const char unlock_plmn[] = "AT+COPS=0";
 #endif
 /* Request eDRX to be disabled */
 static const char edrx_disable[] = "AT+CEDRXS=3";
-/* Request modem to go to power saving mode */
-static const char psm_req[] = "AT+CPSMS=1,,,\""CONFIG_LTE_PSM_REQ_RPTAU
-			      "\",\""CONFIG_LTE_PSM_REQ_RAT"\"";
-
+/* Default eDRX setting */
+static char edrx_param[5] = CONFIG_LTE_EDRX_REQ_VALUE;
+/* Default PSM RAT setting */
+static char psm_param_rat[9] = CONFIG_LTE_PSM_REQ_RAT;
+/* Default PSM RPATU setting */
+static char psm_param_rptau[9] = CONFIG_LTE_PSM_REQ_RPTAU;
 /* Request PSM to be disabled */
 static const char psm_disable[] = "AT+CPSMS=";
 /* Set the modem to power off mode */
@@ -740,10 +742,35 @@ int lte_lc_normal(void)
 	return 0;
 }
 
+int lte_lc_psm_param_set(const char *rptau, const char *rat)
+{
+	if (rptau == NULL || strlen(rptau) != 8 ||
+		rat == NULL || strlen(rat) != 8) {
+		return -EINVAL;
+	}
+
+	memcpy(psm_param_rptau, rptau, sizeof(psm_param_rptau));
+	memcpy(psm_param_rat, rat, sizeof(psm_param_rat));
+	return 0;
+}
+
 int lte_lc_psm_req(bool enable)
 {
-	if (at_cmd_write(enable ? psm_req : psm_disable,
-			 NULL, 0, NULL) != 0) {
+	int err;
+
+	if (enable) {
+		char psm_req[40];
+
+		snprintf(psm_req, sizeof(psm_req),
+			"AT+CPSMS=1,,,\"%s\",\"%s\"",
+			psm_param_rptau, psm_param_rat);
+
+		err = at_cmd_write(psm_req, NULL, 0, NULL);
+	} else {
+		err = at_cmd_write(psm_disable, NULL, 0, NULL);
+	}
+
+	if (err != 0) {
 		return -EIO;
 	}
 
@@ -807,9 +834,19 @@ parse_psm_clean_exit:
 	return err;
 }
 
+int lte_lc_edrx_param_set(const char *edrx)
+{
+	if (edrx == NULL || strlen(edrx) != 4) {
+		return -EINVAL;
+	}
+
+	memcpy(edrx_param, edrx, sizeof(edrx_param));
+
+	return 0;
+}
+
 int lte_lc_edrx_req(bool enable)
 {
-	char edrx_req[25];
 	int err, actt;
 	enum lte_lc_system_mode mode;
 
@@ -833,15 +870,17 @@ int lte_lc_edrx_req(bool enable)
 		return -EOPNOTSUPP;
 	}
 
-	snprintf(edrx_req, sizeof(edrx_req),
-		 "AT+CEDRXS=2,%d,\""CONFIG_LTE_EDRX_REQ_VALUE"\"", actt);
+	if (enable) {
+		char edrx_req[25];
 
-	err = at_cmd_write(enable ? edrx_req : edrx_disable, NULL, 0, NULL);
-	if (err) {
-		return err;
+		snprintf(edrx_req, sizeof(edrx_req),
+			 "AT+CEDRXS=2,%d,\"%s\"", actt, edrx_param);
+		err = at_cmd_write(edrx_req, NULL, 0, NULL);
+	} else {
+		err = at_cmd_write(edrx_disable, NULL, 0, NULL);
 	}
 
-	return 0;
+	return err;
 }
 
 /**@brief Helper function to check if a response is what was expected


### PR DESCRIPTION
This PR adds two new functions to `lte_lc` that set the parameters for PSM and eDRX using passed in values, instead of `Kconfig` defines. This is useful in dynamically changing PSM and eDRX at runtime depending on application demands.

- `lte_lc_psm_req_param_set` is used to set RPTAU and RAT values that will be used when PSM is enabled in a subsequent `lte_lc_psm_req` call. By default `lte_lc_psm_req` uses Kconfig values.

- `lte_lc_edrx_req_param_set` is used to set eDRX value that will be used when eDRX is enabled in a subsequent `lte_lc_edrx_req` call. By default `lte_lc_edrx_req` uses Kconfig values.