### PR TITLE
cmake: Using Zephyr CMake package for locating Zephyr installation

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -17,14 +17,15 @@
 cmake_minimum_required(VERSION 3.13.1)
 project(nrf-connect-sdk-doc LANGUAGES)
 
+set(NO_BOILERPLATE TRUE)
+find_package(Zephyr HINTS $ENV{ZEPHYR_BASE} ..)
+
 #
 # Set various *_BASE variables pointing to the nrf/, zephyr/, etc.,
 # directories. Derive them automatically if they're not set in the environment,
 # by assuming that e.g. nrfxlib can be found at ../../nrfxlib/. Also add them
 # to the environment if they're not there.
 #
-
-set(ZEPHYR_BASE $ENV{ZEPHYR_BASE})
 
 get_filename_component(NRF_BASE ${CMAKE_CURRENT_LIST_DIR}../ DIRECTORY)
 set(ENV{NRF_BASE} ${NRF_BASE})
@@ -184,6 +185,7 @@ endif()
 
 set(NRF_SPHINX_BUILD_HTML_COMMAND
   ${CMAKE_COMMAND} -E env
+  ZEPHYR_BASE=${ZEPHYR_BASE}
   ZEPHYR_BUILD=${ZEPHYR_BINARY_DIR}
   ZEPHYR_OUTPUT=${HTML_DIR}/zephyr
   NRF_BASE=${NRF_BASE}

--- a/doc/nrf/doc_build.rst
+++ b/doc/nrf/doc_build.rst
@@ -43,13 +43,12 @@ Building documentation output
 
 Complete the following steps to build the documentation output:
 
-1. Create the build folder ``ncs/nrf/doc/_build``.
+1. Open a shell and enter the doc folder ``ncs/nrf/doc``.
 
    * On Windows:
 
-     a. Navigate to ``ncs/nrf/doc``.
-     #. Right-click to create a folder and name it ``_build``.
-     #. Hold shift and right-click on the new folder.
+     a. Navigate to ``ncs/nrf``.
+     #. Hold shift and right-click on the ``doc`` folder.
         Select **Open command window here**.
 
    * On Linux or macOS:
@@ -62,30 +61,17 @@ Complete the following steps to build the documentation output:
 
            cd ~/ncs/nrf/doc
 
-     #. Create a folder named ``_build`` and enter it:
-
-        .. code-block:: console
-
-           mkdir -p _build && cd _build
-
-#. Load the environment setting for Zephyr builds.
-
-   * On Windows:
-
-        .. code-block:: console
-
-           ..\..\..\zephyr\zephyr-env.cmd
-   * On Linux or macOS:
-
-        .. code-block:: console
-
-           source ../../../zephyr/zephyr-env.sh
-
 #. Generate the Ninja build files:
 
         .. code-block:: console
 
-           cmake -GNinja ..
+           cmake -GNinja -B_build .
+
+#. Enter the generated build folder:
+
+        .. code-block:: console
+
+           cd _build
 
 #. Run ninja to build the Kconfig documentation:
 


### PR DESCRIPTION
This commit fixes an issue in building NCS docs on windows where the
Zephyr base could contain backslashes.

This is fixed by using the new Zephyr CMake package.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>