### PR TITLE
drivers: net: eth_rtt: pass PM function to device macro

### DIFF
--- a/drivers/net/eth_rtt.c
+++ b/drivers/net/eth_rtt.c
@@ -544,5 +544,6 @@ static const struct ethernet_api if_api = {
 
 /** Initialization of network device driver. */
 ETH_NET_DEVICE_INIT(eth_rtt, CONFIG_ETH_RTT_DRV_NAME, eth_rtt_init,
-		    &context_data, NULL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
-		    &if_api, CONFIG_ETH_RTT_MTU);
+		    device_pm_control_nop, &context_data, NULL,
+		    CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &if_api,
+		    CONFIG_ETH_RTT_MTU);


### PR DESCRIPTION
Pass power management function to ETH_NET_DEVICE_INIT.

There isn't a sample in CI which compiles this file, and it was broken in the last upmerge.
@torsteingrindvik could confirm that the compilation of his test application is fixed with this change.