### PR TITLE
manifest: update manifest to include zephyr fix for python detection

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -46,7 +46,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: fw-nrfconnect-zephyr
-      revision: 479376885055ead099592d0bc0c0d939971d904a
+      revision: pull/299/head
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
This manifest update includes a python3 detection issue on windows
that has been merged from Zephyr upstream.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>

This manifest update refers to: https://github.com/NordicPlayground/fw-nrfconnect-zephyr/pull/299