### PR TITLE
tests: crypto: Update due to DT changes

### DIFF
--- a/tests/crypto/src/common_test.c
+++ b/tests/crypto/src/common_test.c
@@ -61,11 +61,11 @@ int init_drbg(const unsigned char *p_optional_seed, size_t len)
 		p_seed = p_optional_seed;
 	}
 
-	struct device *p_device = device_get_binding(
-		DT_LABEL(DT_CHOSEN(zephyr_entropy)));
-	if (p_device == NULL) {
+	struct device *p_device =
+	    device_get_binding(DT_LABEL(DT_CHOSEN(zephyr_entropy)));
+
+	if (p_device == NULL)
 		return -ENODEV;
-	}
 
 	mbedtls_ctr_drbg_init(&drbg_ctx);
 	return mbedtls_ctr_drbg_seed(&drbg_ctx, entropy_func, p_device,
@@ -90,7 +90,8 @@ int init_drbg(const unsigned char *p_optional_seed, size_t len)
 
 	mbedtls_hmac_drbg_init(&drbg_ctx);
 
-	struct device *p_device = device_get_binding(CONFIG_ENTROPY_NAME);
+	struct device *p_device =
+	    device_get_binding(DT_LABEL(DT_CHOSEN(zephyr_entropy)));
 
 	if (!p_device)
 		return -ENODEV;


### PR DESCRIPTION
Previously `device_get_binding(CONFIG_ENTROPY_NAME);` was recently changed to use the device tree's _chosen_ node instead.

This was missed in the case of hmac drbg, which is now added.

Also, when using hw backends the default chosen entropy source (RNG peripheral) should be cryptocell.
A small overlay file is added to use this.
Usage is shown in `testcase.yaml`.