### PR TITLE
ci: use v1.2 fork of CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@
 // express written agreement with Nordic Semiconductor ASA.
 //
 
-@Library("CI_LIB") _
+@Library("CI_LIB@v1.2-branch") _
 
 HashMap CI_STATE = lib_State.getConfig(JOB_NAME)
 def TestExecutionList = [:]


### PR DESCRIPTION
Loads the exact CI when NRF:v1.2 was tagged
v1.2 was released from master, so this wasn't needed until today. 

Signed-off-by: Thomas Stilwell <Thomas.Stilwell@nordicsemi.no>