### PR TITLE
manifest: Update nrfxlib with new ble controller

### DIFF
--- a/subsys/bluetooth/controller/hci_driver.c
+++ b/subsys/bluetooth/controller/hci_driver.c
@@ -424,6 +424,20 @@ static int hci_driver_open(void)
 		}
 	}
 
+	if (IS_ENABLED(CONFIG_BT_CTLR_PHY_2M)) {
+		err = ble_controller_support_le_2m_phy();
+		if (err) {
+			return -ENOTSUP;
+		}
+	}
+
+	if (IS_ENABLED(CONFIG_BT_CTLR_PHY_CODED)) {
+		err = ble_controller_support_le_coded_phy();
+		if (err) {
+			return -ENOTSUP;
+		}
+	}
+
 	err = MULTITHREADING_LOCK_ACQUIRE();
 	if (!err) {
 		err = ble_controller_enable(host_signal,

--- a/west.yml
+++ b/west.yml
@@ -96,7 +96,7 @@ manifest:
       path: modules/lib/mcumgr
     - name: nrfxlib
       path: nrfxlib
-      revision: 588bf3474c4b60de5aa51604bf88bd86262b5e4c
+      revision: fdfbd6768fdfd692aaa492cbc440c0481bd53260
     # Other third-party repositories.
     - name: cmock
       path: test/cmock


### PR DESCRIPTION
Includes configurable PHY support.

Signed-off-by: Rubin Gerritsen <rubin.gerritsen@nordicsemi.no>

See https://github.com/NordicPlayground/nrfxlib/pull/170