### PR TITLE
sample: Add Minimal Thread Device variant of Thread CoAP Client sample

### DIFF
--- a/doc/nrf/shortcuts.txt
+++ b/doc/nrf/shortcuts.txt
@@ -34,7 +34,7 @@
 .. |fota_upgrades_building| replace:: To create a binary file for an application upgrade, make sure that :option:`CONFIG_BOOTLOADER_MCUBOOT` is enabled and build the application as usual.
    The build will create several binary files (see :ref:`mcuboot:mcuboot_ncs`).
 
-.. |Google_CCLicense| replace:: Portions of this page are reproduced from work created and shared by Google, and used according to terms described in the Creative Commons 3.0 Attribution License.*
+.. |Google_CCLicense| replace:: *Portions of this page are reproduced from work created and shared by Google, and used according to terms described in the Creative Commons 3.0 Attribution License.*
    *Thread is a registered trademark of the Thread Group, Inc.*
 
 .. |enable_thread_before_testing| replace:: Make sure to enable the OpenThread stack before building and testing this sample.

--- a/doc/nrf/ug_thread.rst
+++ b/doc/nrf/ug_thread.rst
@@ -191,6 +191,8 @@ These options enable dumping 802.15.4 or IPv6 frames (or both) in the debug log 
 
 You can disable writing to log with the :option:`CONFIG_OPENTHREAD_L2_LOG_LEVEL_OFF` option.
 
+.. _thread_ug_device_type:
+
 Switching device type
 ---------------------
 

--- a/samples/openthread/coap_client/README.rst
+++ b/samples/openthread/coap_client/README.rst
@@ -17,7 +17,7 @@ It can turn on the LED either on every server node in the network with a multica
 The following CoAP resources are accessed on the server side:
 
 * ``/light`` - Used to control LED 4.
-* ``/provisioning`` - Used to perform provisioning
+* ``/provisioning`` - Used to perform provisioning.
 
 This sample uses :ref:`Zephyr CoAP API<zephyr:coap_sock_interface>` for communication, which is the preferred API to use for new CoAP applications.
 For example usage of the native Thread CoAp API, see the :ref:`coap_server_sample` sample.
@@ -51,6 +51,23 @@ Button 2:
 Button 4:
   Pressing results in sending a multicast pairing request to the ``/provisioning`` resource on other nodes within the network.
 
+Minimal Thread Device assignments
+=================================
+
+When the device is working as Minimal Thread Device (MTD), the following LED and Button assignments are also available:
+
+LED 3:
+    Indicates the mode the device is working in:
+
+    * On when in the Minimal End Device (MED) mode.
+    * Off when in the Sleepy End Device (SED) mode.
+
+Button 3:
+    Pressing results in toggling the power consumption between SED and MED.
+
+For more information, see :ref:`thread_ug_device_type` in the Thread user guide.
+
+
 Building and running
 ********************
 .. |sample path| replace:: :file:`samples/openthread/coap_client`
@@ -58,6 +75,10 @@ Building and running
 |enable_thread_before_testing|
 
 .. include:: /includes/build_and_run.txt
+
+.. note::
+   To activate the Minimal Thread Device variant of this sample, modify :makevar:`CONF_FILE` by applying ``overlay-mtd.conf``.
+   For more information, see :ref:`important-build-vars` in the Zephyr documentation.
 
 Testing
 =======
@@ -80,6 +101,19 @@ After building the sample and programming it to your development kit, test it by
    #. Press Button 4 on a client node to pair it with the server node in the pairing mode.
 
 #. Press Button 1 on the client node to control the LED 4 on the paired server node.
+
+Testing Minimal Thread Device
+-----------------------------
+
+After building the MTD variant of this sample and programming it, the device starts in the SED mode with LED 3 disabled.
+You can switch to the MED mode at any moment during the standard testing procedure.
+
+To toggle MED, press Button 3 on the client node.
+LED 3 turns on to indicate the switch to the MED mode.
+At this point, the radio is enabled and power consumption increases.
+
+Pressing Button 3 again will switch the mode back to SED.
+This does not affect the standard testing procedure.
 
 Running OpenThread CLI commands
 -------------------------------

--- a/samples/openthread/coap_client/overlay-mtd.conf
+++ b/samples/openthread/coap_client/overlay-mtd.conf
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2020 Nordic Semiconductor
+#
+# SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
+#
+
+# enable MTD Sleepy End Device
+CONFIG_OPENTHREAD_MTD=y
+CONFIG_OPENTHREAD_MTD_SED=y

--- a/samples/openthread/coap_client/src/coap_client.c
+++ b/samples/openthread/coap_client/src/coap_client.c
@@ -17,6 +17,9 @@
 LOG_MODULE_REGISTER(coap_client, CONFIG_COAP_CLIENT_LOG_LEVEL);
 
 #define OT_CONNECTION_LED DK_LED1
+#define MTD_SED_LED DK_LED3
+
+#define RESPONSE_POLL_PERIOD 100
 
 /* Options supported by the server */
 static const char *const light_option[] = { LIGHT_URI_PATH, NULL };
@@ -44,11 +47,78 @@ static struct sockaddr_in6 unique_local_addr = {
 static struct k_work unicast_light_work;
 static struct k_work multicast_light_work;
 static struct k_work provisioning_work;
+static struct k_work toggle_MTD_SED_work;
+
+static u32_t poll_period;
+
+static struct otInstance *openthread_get_default_instance(void)
+{
+	struct otInstance *instance = NULL;
+	struct net_if *iface;
+	struct openthread_context *ot_context;
+
+	iface = net_if_get_first_by_type(&NET_L2_GET_NAME(OPENTHREAD));
+	if (!iface) {
+		LOG_ERR("There is no net interface for OpenThread");
+		goto end;
+	}
+
+	ot_context = net_if_l2_data(iface);
+	if (!ot_context) {
+		LOG_ERR("There is no Openthread context in net interface data");
+		goto end;
+	}
+
+	instance = ot_context->instance;
+
+end:
+	return instance;
+}
+
+static bool poll_period_response_set(void)
+{
+	otError error;
+	otInstance *instance = openthread_get_default_instance();
+
+	if (otThreadGetLinkMode(instance).mRxOnWhenIdle) {
+		return false;
+	}
+
+	if (!poll_period) {
+		poll_period = otLinkGetPollPeriod(instance);
+
+		error = otLinkSetPollPeriod(instance, RESPONSE_POLL_PERIOD);
+		__ASSERT_NO_MSG(error == OT_ERROR_NONE);
+
+		LOG_INF("Poll Period: %dms set", RESPONSE_POLL_PERIOD);
+	}
+
+	return true;
+}
+
+static void poll_period_restore(void)
+{
+	otError error;
+	otInstance *instance = openthread_get_default_instance();
+
+	if (otThreadGetLinkMode(instance).mRxOnWhenIdle) {
+		return;
+	}
+
+	if (poll_period) {
+		error = otLinkSetPollPeriod(instance, poll_period);
+		__ASSERT_NO_MSG(error == OT_ERROR_NONE);
+
+		LOG_INF("Poll Period: %dms restored", poll_period);
+		poll_period = 0;
+	}
+}
 
 static int on_provisioning_reply(const struct coap_packet *response,
 				 struct coap_reply *reply,
 				 const struct sockaddr *from)
 {
+	int ret = 0;
 	const u8_t *payload;
 	u16_t payload_size = 0u;
 
@@ -66,12 +136,18 @@ static int on_provisioning_reply(const struct coap_packet *response,
 	if (!inet_ntop(AF_INET6, payload, unique_local_addr_str,
 		       INET6_ADDRSTRLEN)) {
 		LOG_ERR("Received data is not IPv6 address: %d", errno);
-		return -errno;
+		ret = -errno;
+		goto exit;
 	}
 
 	LOG_INF("Received peer address: %s", log_strdup(unique_local_addr_str));
 
-	return 0;
+exit:
+	if (IS_ENABLED(CONFIG_OPENTHREAD_MTD_SED)) {
+		poll_period_restore();
+	}
+
+	return ret;
 }
 
 static void toggle_one_light(struct k_work *item)
@@ -111,9 +187,38 @@ static void send_provisioning_request(struct k_work *item)
 {
 	ARG_UNUSED(item);
 
+	if (IS_ENABLED(CONFIG_OPENTHREAD_MTD_SED)) {
+		/* decrease the polling period for higher responsiveness */
+		if (false == poll_period_response_set()) {
+			LOG_WRN("Failed to set response poll period");
+			return;
+		}
+	}
+
 	LOG_INF("Send 'provisioning' request");
 	coap_send_request(COAP_METHOD_GET, &multicast_local_addr,
 			  provisioning_option, NULL, 0u, on_provisioning_reply);
+}
+
+static void toggle_minimal_sleepy_end_device(struct k_work *item)
+{
+	otError error;
+	struct otInstance *instance = openthread_get_default_instance();
+	otLinkModeConfig mode = otThreadGetLinkMode(instance);
+
+	if (mode.mRxOnWhenIdle) {
+		mode.mRxOnWhenIdle = false;
+	} else {
+		mode.mRxOnWhenIdle = true;
+	}
+
+	error = otThreadSetLinkMode(instance, mode);
+	if (error != OT_ERROR_NONE) {
+		LOG_ERR("Failed to set MLE link mode configuration");
+		return;
+	}
+
+	dk_set_led(MTD_SED_LED, mode.mRxOnWhenIdle);
 }
 
 static void on_button_changed(u32_t button_state, u32_t has_changed)
@@ -126,6 +231,10 @@ static void on_button_changed(u32_t button_state, u32_t has_changed)
 
 	if (buttons & DK_BTN2_MSK) {
 		k_work_submit(&multicast_light_work);
+	}
+
+	if (IS_ENABLED(CONFIG_OPENTHREAD_MTD_SED) && (buttons & DK_BTN3_MSK)) {
+		k_work_submit(&toggle_MTD_SED_work);
 	}
 
 	if (buttons & DK_BTN4_MSK) {
@@ -155,30 +264,6 @@ static void on_thread_state_changed(u32_t flags, void *p_context)
 		otThreadGetDeviceRole(p_context));
 }
 
-static struct otInstance *openthread_get_default_instance(void)
-{
-	struct otInstance *instance = NULL;
-	struct net_if *iface;
-	struct openthread_context *ot_context;
-
-	iface = net_if_get_first_by_type(&NET_L2_GET_NAME(OPENTHREAD));
-	if (!iface) {
-		LOG_ERR("There is no net interface for OpenThread");
-		goto end;
-	}
-
-	ot_context = net_if_l2_data(iface);
-	if (!ot_context) {
-		LOG_ERR("There is no Openthread context in net interface data");
-		goto end;
-	}
-
-	instance = ot_context->instance;
-
-end:
-	return instance;
-}
-
 void main(void)
 {
 	int ret;
@@ -189,6 +274,11 @@ void main(void)
 	k_work_init(&unicast_light_work, toggle_one_light);
 	k_work_init(&multicast_light_work, toggle_mesh_lights);
 	k_work_init(&provisioning_work, send_provisioning_request);
+
+	if (IS_ENABLED(CONFIG_OPENTHREAD_MTD_SED)) {
+		k_work_init(&toggle_MTD_SED_work,
+			    toggle_minimal_sleepy_end_device);
+	}
 
 	ret = dk_buttons_init(on_button_changed);
 	if (ret) {

--- a/samples/openthread/coap_server/src/coap_server.c
+++ b/samples/openthread/coap_server/src/coap_server.c
@@ -23,7 +23,7 @@ static struct k_timer provisioning_timer;
 
 static void on_light_request(u8_t command)
 {
-	static u8_t val = 1;
+	static u8_t val;
 
 	switch (command) {
 	case THREAD_COAP_UTILS_LIGHT_CMD_ON:


### PR DESCRIPTION
When the device is working as MTD you can toggle between Sleepy End Device
mode and Minimal End Device mode what causes different device behaviour
in the Thread network and the difrent power consumption.