### PR TITLE
[Manual backport] lib: lwm2m_carrier: Make bootstrap PSK independent of URI

### DIFF
--- a/lib/bin/lwm2m_carrier/Kconfig
+++ b/lib/bin/lwm2m_carrier/Kconfig
@@ -43,13 +43,6 @@ config LWM2M_CARRIER_USE_CUSTOM_BOOTSTRAP_URI
 	help
 	  Use a custom bootstrap URI.
 
-	  Enabling this option requires that a file "bootstrap_psk.h" is
-	  made available in an include folder.
-
-	  This file must define the LWM2M bootstrap pre-shared key e.g.:
-
-	  static const char bootstrap_psk[] = {'m', 'y', 'k', 'e', 'y'};
-
 if LWM2M_CARRIER_USE_CUSTOM_BOOTSTRAP_URI
 
 config LWM2M_CARRIER_CUSTOM_BOOTSTRAP_URI
@@ -59,6 +52,18 @@ config LWM2M_CARRIER_CUSTOM_BOOTSTRAP_URI
 	  URI of the custom bootstrap server.
 
 endif # LWM2M_CARRIER_USE_CUSTOM_BOOTSTRAP_URI
+
+config LWM2M_CARRIER_USE_CUSTOM_BOOTSTRAP_PSK
+	bool "Use custom bootstrap PSK"
+	help
+	  Use a custom bootstrap PSK.
+
+	  Enabling this option requires that a file "bootstrap_psk.h" is
+	  made available in an include folder.
+
+	  This file must define the LWM2M bootstrap pre-shared-key e.g.:
+
+	  static const char bootstrap_psk[] = { 0xd6, 0x16, ... };
 
 module=LWM2M_CARRIER
 module-dep=LOG

--- a/lib/bin/lwm2m_carrier/os/lwm2m_carrier.c
+++ b/lib/bin/lwm2m_carrier/os/lwm2m_carrier.c
@@ -8,7 +8,7 @@
 #include <zephyr.h>
 #include <lwm2m_carrier.h>
 
-#ifdef CONFIG_LWM2M_CARRIER_USE_CUSTOM_BOOTSTRAP_URI
+#ifdef CONFIG_LWM2M_CARRIER_USE_CUSTOM_BOOTSTRAP_PSK
 #include <bootstrap_psk.h>
 #endif
 
@@ -30,6 +30,8 @@ void lwm2m_carrier_thread_run(void)
 
 #ifdef CONFIG_LWM2M_CARRIER_USE_CUSTOM_BOOTSTRAP_URI
 	config.bootstrap_uri = CONFIG_LWM2M_CARRIER_CUSTOM_BOOTSTRAP_URI;
+#endif
+#ifdef CONFIG_LWM2M_CARRIER_USE_CUSTOM_BOOTSTRAP_PSK
 	config.psk = (char *)bootstrap_psk;
 	config.psk_length = sizeof(bootstrap_psk);
 #endif


### PR DESCRIPTION
Configuring bootstrap URI and bootstrap PSK is independent of each
other when using the library in a certification process.

Signed-off-by: Stig Bjørlykke <stig.bjorlykke@nordicsemi.no>