### PR TITLE
subsys: spm: Add I2S to the non-secure area

### DIFF
--- a/subsys/spm/Kconfig
+++ b/subsys/spm/Kconfig
@@ -211,6 +211,10 @@ config SPM_NRF_REGULATORS_NS
 config SPM_NRF_WDT_NS
 	bool "WDT is Non-Secure"
 	default y
+
+config SPM_NRF_I2S_NS
+	bool "I2S is Non-Secure"
+	default y
 endmenu
 
 config SPM_NRF_DPPIC_NS

--- a/subsys/spm/spm.c
+++ b/subsys/spm/spm.c
@@ -351,6 +351,9 @@ static void spm_config_peripherals(void)
 #ifdef NRF_WDT
 		PERIPH("NRF_WDT", NRF_WDT, CONFIG_SPM_NRF_WDT_NS),
 #endif
+#ifdef NRF_I2S
+		PERIPH("NRF_I2S", NRF_I2S, CONFIG_SPM_NRF_I2S_NS),
+#endif
 		/* There is no DTS node for the peripherals below,
 		 * so address them using nrfx macros directly.
 		 */


### PR DESCRIPTION
Make the I2S peripheral available to be used in
the non-secure area as default.

Signed-off-by: Martin Lesund <martin.lesund@nordicsemi.no>