### PR TITLE
cmake: partition_manager: move pm patches from zephyr to nrf

### DIFF
--- a/subsys/partition_manager/CMakeLists.txt
+++ b/subsys/partition_manager/CMakeLists.txt
@@ -4,6 +4,13 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
+macro(add_partition_manager_config config_file)
+  get_filename_component(pm_path ${config_file} REALPATH)
+  get_filename_component(pm_filename ${config_file} NAME)
+  list(APPEND PM_SUBSYS_PATHS ${pm_path})
+  list(APPEND PM_SUBSYS_OUTPUT_PATHS ${CMAKE_CURRENT_BINARY_DIR}/${pm_filename})
+endmacro()
+
 function(preprocess_pm_yml in_file out_file)
   execute_process(
     COMMAND ${CMAKE_C_COMPILER}
@@ -22,6 +29,19 @@ function(preprocess_pm_yml in_file out_file)
   endif()
 
 endfunction()
+
+
+# Add all pm.yml files for subsystems
+# Store the preprocessed output in the binary dir of the subsystems
+# to avoid overwriting pm.yml files.
+if (CONFIG_SETTINGS_FCB OR CONFIG_SETTINGS_NVS)
+  add_partition_manager_config(pm.yml.settings)
+endif()
+
+if (CONFIG_FILE_SYSTEM)
+  add_partition_manager_config(pm.yml.file_system)
+endif()
+
 
 # We are using partition manager if we are a child image or if we are
 # the root image and the 'partition_manager' target exists.
@@ -49,23 +69,21 @@ endif()
 
 # Check for partition manager configurations defined by subsystems
 # This is a list of absolute paths to these pm.yml files.
-get_property(pm_yml_paths GLOBAL PROPERTY PM_SUBSYS_PATH)
-if (pm_yml_paths)
+if (PM_SUBSYS_PATHS)
   # Each entry in the list has a corresponding entry with the output
   # path in the build directory for the pm.yml file.
-  get_property(output_pm_yml_paths GLOBAL PROPERTY PM_SUBSYS_OUTPUT_PATH)
-  foreach (pm_yml_path ${pm_yml_paths})
-    list(GET output_pm_yml_paths 0 output_pm_yml_path)
-    list(REMOVE_AT output_pm_yml_paths 0)
+  foreach (pm_yml_path ${PM_SUBSYS_PATHS})
+    list(GET PM_SUBSYS_OUTPUT_PATHS 0 output_pm_yml_path)
+    list(REMOVE_AT PM_SUBSYS_OUTPUT_PATHS 0)
 
     preprocess_pm_yml(
       ${pm_yml_path}
-      ${output_pm_yml_path}/pm.yml
+      ${output_pm_yml_path}
       )
     set_property(
       GLOBAL APPEND PROPERTY
       PM_SUBSYS_PREPROCESSED
-      ${output_pm_yml_path}/pm.yml
+      ${output_pm_yml_path}
       )
   endforeach()
 endif()

--- a/subsys/partition_manager/Kconfig
+++ b/subsys/partition_manager/Kconfig
@@ -4,6 +4,25 @@
 # SPDX-License-Identifier: LicenseRef-BSD-5-Clause-Nordic
 #
 
+menu "Partition Manager"
+
+menu "Zephyr subsystem configurations"
+
+if FILE_SYSTEM_LITTLEFS
+partition=LITTLEFS
+partition-size=0x6000
+rsource "Kconfig.template.partition_size"
+endif
+
+
+if SETTINGS
+partition=SETTINGS_STORAGE
+partition-size=0x2000
+rsource "Kconfig.template.partition_size"
+endif
+
+endmenu
+
 menuconfig PM_EXTERNAL_FLASH
 	bool "Support external flash in Partition Manager"
 
@@ -24,3 +43,5 @@ config PM_EXTERNAL_FLASH_BASE
 	default 0
 
 endif
+
+endmenu # Partition Manager

--- a/subsys/partition_manager/pm.yml.file_system
+++ b/subsys/partition_manager/pm.yml.file_system
@@ -1,0 +1,7 @@
+#include <autoconf.h>
+
+#ifdef CONFIG_FILE_SYSTEM_LITTLEFS
+littlefs_storage:
+  placement: {after: [mcuboot_storage, app]}
+  size: CONFIG_PM_PARTITION_SIZE_LITTLEFS
+#endif

--- a/subsys/partition_manager/pm.yml.settings
+++ b/subsys/partition_manager/pm.yml.settings
@@ -1,0 +1,5 @@
+#include <autoconf.h>
+
+settings_storage:
+  placement: {after: [mcuboot_storage, app]}
+  size: CONFIG_PM_PARTITION_SIZE_SETTINGS_STORAGE

--- a/west.yml
+++ b/west.yml
@@ -46,7 +46,7 @@ manifest:
     # https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/zephyr/guides/modules.html
     - name: zephyr
       repo-path: fw-nrfconnect-zephyr
-      revision: e34f48a24ac4614fefb7073aa64b8ce94f1f78c7
+      revision: 9bab3a84b6427662a1d3df45db365d23f2eeaa3a
       import:
         # In addition to the zephyr repository itself, NCS also
         # imports the contents of zephyr/west.yml at the above


### PR DESCRIPTION
Reduce size of downstream patches by moving as much as possible
of the partition manager (pm) functionality to the nrf repo.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>