### PR TITLE
[backport] lib: bsdlib: Add interpretation for EALREADY

### DIFF
--- a/lib/bsdlib/bsd_os.c
+++ b/lib/bsdlib/bsd_os.c
@@ -298,6 +298,9 @@ void bsd_os_errno_set(int err_code)
 	case NRF_EINPROGRESS:
 		errno = EINPROGRESS;
 		break;
+	case NRF_EALREADY:
+		errno = EALREADY;
+		break;
 	case NRF_ECANCELED:
 		errno = ECANCELED;
 		break;


### PR DESCRIPTION
Missing interpretation for NRF_EALREADY added

Backporting to `v1.2-branch`.